### PR TITLE
Cli library fix

### DIFF
--- a/src/glm_benchmarks/main.py
+++ b/src/glm_benchmarks/main.py
@@ -31,12 +31,7 @@ from glm_benchmarks.problems import get_all_problems
     help="The directory to store benchmarking output.",
 )
 def cli_run(problem_names, library_names, num_rows, output_dir):
-    print("library names")
-    print(library_names)
     problems, libraries = get_limited_problems_libraries(problem_names, library_names)
-    print("libraries")
-    print(libraries)
-    assert False
 
     for Pn, P in problems.items():
         for Ln, L in libraries.items():


### PR DESCRIPTION
Fixed a bug in the CLI where "problem_names" was referred to as "library_names"