### PR TITLE
glmnet-python can work with sparse csc matrices

### DIFF
--- a/src/glm_benchmarks/bench_glmnet_python.py
+++ b/src/glm_benchmarks/bench_glmnet_python.py
@@ -18,10 +18,9 @@ def glmnet_python_bench(
 
     X = dat["X"]
     if isinstance(X, sps.spmatrix):
-        warnings.warn(
-            "glmnet_python does not support sparse matrices. Converting to a dense matrix."
-        )
-        X = X.toarray()
+        if not isinstance(X, sps.csc.csc_matrix):
+            warnings.warn("sparse matrix will be converted to csc format")
+            X = X.tocsc()
 
     if len(dat["y"]) <= 650:
         warnings.warn("glmnet_python does not work with too few rows")

--- a/src/glm_benchmarks/data/create.py
+++ b/src/glm_benchmarks/data/create.py
@@ -403,4 +403,4 @@ def generate_sparse_insurance_dataset(
     )
     y, exposure = compute_y_exposure(df, distribution)
 
-    return transformer.fit_transform(df), y, exposure
+    return transformer.fit_transform(df).tocsc(), y, exposure


### PR DESCRIPTION
Related #21 

@tbenthompson you added the line "glmnet_python does not support sparse matrices. Converting to a dense matrix." Any deeper reason for this that I missed? 

glmnet seems to be fine sparse csc matrices: https://github.com/johnlees/glmnet_python/blob/master/glmnet_python/glmnet.py#L251-L253