### PR TITLE
Standardize features in glmnet_python

### DIFF
--- a/src/glm_benchmarks/bench_glmnet_python.py
+++ b/src/glm_benchmarks/bench_glmnet_python.py
@@ -36,7 +36,7 @@ def glmnet_python_bench(
         family=distribution,
         alpha=l1_ratio,
         lambdau=np.array([alpha]),
-        standardize=False,
+        standardize=True,
         thresh=1e-7,
     )
     if "weights" in dat.keys():


### PR DESCRIPTION
Currently, we're standardizing features for `h2o` and `sklearn_fork`. Seems only fair to also standardize features in `glmnet_python` -- unless there was a good reason not to.