### PR TITLE
Print full table when summarizing results

### DIFF
--- a/src/glm_benchmarks/main.py
+++ b/src/glm_benchmarks/main.py
@@ -143,19 +143,20 @@ def cli_analyze(problem_names: str, library_names: str, num_rows: str, output_di
     # keeps = ["sparse" not in x and "no_weights" in x for x in problems]
     keeps = [x in x for x in problems]
     # res_df.loc[keeps, :].reset_index().to_csv("results.csv")
-    print(
-        res_df.loc[
-            keeps,
-            [
-                "n_iter",
-                "runtime",
-                "intercept",
-                "obj_val",
-                "rel_obj_val",
-                "rel_obj_val_2",
-            ],
-        ]
-    )
+    with pd.option_context("display.expand_frame_repr", False, "max_columns", 10):
+        print(
+            res_df.loc[
+                keeps,
+                [
+                    "n_iter",
+                    "runtime",
+                    "intercept",
+                    "obj_val",
+                    "rel_obj_val",
+                    "rel_obj_val_2",
+                ],
+            ]
+        )
 
 
 def extract_dict_results_to_pd_series(


### PR DESCRIPTION
No more truncation.

Before:

```
$ glm_benchmarks_analyze --problem_names "real_sparse_insurance_net_poisson" --library_names "sklearn_fork" --output_dir results
                                                       n_iter  runtime  ...  rel_obj_val rel_obj_val_2   
problem                           n_rows library                        ...                              
real_sparse_insurance_net_poisson 1000   sklearn_fork       9   0.2456  ...            0             0   
                                                                                                         
[1 rows x 6 columns]           
```

With this PR:

```
$ glm_benchmarks_analyze --problem_names "real_sparse_insurance_net_poisson" --library_names "sklearn_fork" --output_dir results

                                                       n_iter  runtime  intercept obj_val rel_obj_val rel_obj_val_2                                                                                               
problem                           n_rows library                                                         
                                                                                                         
real_sparse_insurance_net_poisson 1000   sklearn_fork       9   0.2456     -5.825   305.6           0             0                                                                                               
```

This gets especially annoying when it takes a while to summarize results.