### PR TITLE
Add option to control number of threads

### DIFF
--- a/src/glm_benchmarks/bench_h2o.py
+++ b/src/glm_benchmarks/bench_h2o.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, Union
 
 import h2o
@@ -27,7 +28,8 @@ def h2o_bench(
     alpha: float,
     l1_ratio: float,
 ):
-    h2o.init()
+
+    h2o.init(nthreads=int(os.environ.get("OMP_NUM_THREADS", os.cpu_count())))  # type: ignore
 
     train_mat = hstack_sparse_or_dense((dat["X"], dat["y"][:, np.newaxis]))
 


### PR DESCRIPTION
I added a `--threads` option to our run and analyze scripts. It sets `OMP_NUM_THREADS` and it passes `nthreads` to `h2o.init()`.

The behavior of `--threads` imitates that of `--num_rows` and `--storage`: it doesn't accept lists.

If you don't pass in anything for `--threads` it will default to `OMP_NUM_THREADS`. If that's also empty, it will use `os.cpu_count()`.

### Example

Running 
```bash
PROBLEM_NAMES="narrow_insurance_net_poisson"
LIBRARY_NAMES="sklearn_fork, h2o"
glm_benchmarks_run --problem_names "${PROBLEM_NAMES}" --library_names "${LIBRARY_NAMES}" --num_rows 100000 --threads 1 --storage dense
glm_benchmarks_run --problem_names "${PROBLEM_NAMES}" --library_names "${LIBRARY_NAMES}" --num_rows 100000 --threads 2 --storage dense
glm_benchmarks_run --problem_names "${PROBLEM_NAMES}" --library_names "${LIBRARY_NAMES}" --num_rows 100000 --threads 4 --storage dense
glm_benchmarks_run --problem_names "${PROBLEM_NAMES}" --library_names "${LIBRARY_NAMES}" --num_rows 100000 --threads 8 --storage dense
glm_benchmarks_run --problem_names "${PROBLEM_NAMES}" --library_names "${LIBRARY_NAMES}" --num_rows 100000 --threads 16 --storage dense
glm_benchmarks_analyze --problem_names "${PROBLEM_NAMES}" --library_names "${LIBRARY_NAMES}"
```

produces

```
                                                                    n_iter  runtime  intercept    obj_val rel_obj_val rel_obj_val_2
problem                      num_rows storage threads library
narrow_insurance_net_poisson 100000   dense   1       h2o                6   2.2530    -3.9852  5.262e+04           0         68.91
                                                      sklearn_fork       7   0.4945    -3.9680  5.276e+04       131.9             0
                                              2       h2o                6   1.6088    -3.9852  5.262e+04           0         68.91
                                                      sklearn_fork       7   0.3402    -3.9680  5.276e+04       131.9             0
                                              4       h2o                6   1.1275    -3.9852  5.262e+04           0         68.91
                                                      sklearn_fork       7   0.2924    -3.9680  5.276e+04       131.9             0
                                              8       h2o                6   1.1296    -3.9852  5.262e+04           0         68.91
                                                      sklearn_fork       7   0.2700    -3.9680  5.276e+04       131.9             0
                                              16      h2o                6   1.1729    -3.9852  5.262e+04           0         68.91
                                                      sklearn_fork       7   0.2673    -3.9680  5.276e+04       131.9             0
```

