### PR TITLE
Make sure data is always dense

### DIFF
--- a/src/glm_benchmarks/data/create.py
+++ b/src/glm_benchmarks/data/create.py
@@ -227,6 +227,7 @@ def gen_col_trans(drop=True, standardize=False) -> Tuple[Any, List[str]]:
             ),
         ],
         remainder="drop",
+        sparse_threshold=0.0,
     )
     column_trans_names = [
         "VehPower_4",
@@ -434,6 +435,7 @@ def generate_wide_insurance_dataset(
             ),
         ],
         remainder="drop",
+        sparse_threshold=0.0,
     )
     y, exposure = compute_y_exposure(df, distribution)
 


### PR DESCRIPTION
Follow up to #72 to ensure that the data that we load is always dense. Data will only be sparse if `--storage sparse` is asking for it.