### PR TITLE
Add print_diagnostics

### DIFF
--- a/src/glm_benchmarks/bench_glmnet_python.py
+++ b/src/glm_benchmarks/bench_glmnet_python.py
@@ -14,6 +14,7 @@ def glmnet_python_bench(
     alpha: float,
     l1_ratio: float,
     iterations: int,
+    print_diagnostics: bool = True,  # ineffective here
 ) -> Dict[str, Any]:
     result: Dict = dict()
 

--- a/src/glm_benchmarks/bench_h2o.py
+++ b/src/glm_benchmarks/bench_h2o.py
@@ -28,6 +28,7 @@ def h2o_bench(
     alpha: float,
     l1_ratio: float,
     iterations: int,
+    print_diagnostics: bool = True,  # ineffective here
 ):
 
     h2o.init(nthreads=int(os.environ.get("OMP_NUM_THREADS", os.cpu_count())))  # type: ignore


### PR DESCRIPTION
This adds the (ineffective) `print_diagnostics` argument to the glmnet and h2o benchmark problems so that they match the signature of the sklearn_fork problem. 

Otherwise we run into problems here:
https://github.com/Quantco/glm_benchmarks/blob/e9d8c4c9fe20f221c8acf3dbface729078ed2005/src/glm_benchmarks/main.py#L147-L154