### PR TITLE
Fix real data set

### DIFF
--- a/src/glm_benchmarks/data/create.py
+++ b/src/glm_benchmarks/data/create.py
@@ -376,16 +376,16 @@ def generate_real_insurance_dataset(
     if distribution != "poisson":
         raise NotImplementedError("distibution must be poisson")
 
+    # restrict X and df to train set
+    train_set = df["sample"] == "train"
+    X = X.loc[train_set].reset_index(drop=True)
+    df = df.loc[train_set].reset_index(drop=True)
+
     # subsample
     if num_rows is not None:
         idx = df.sample(n=num_rows).index
         df = df.loc[idx].reset_index(drop=True)
         X = X.loc[idx].reset_index(drop=True)
-
-    # restrict X and df to train set
-    train_set = df["sample"] == "train"
-    X = X.loc[train_set]
-    df = df.loc[train_set]
 
     # account for exposure and offsets
     y, weights = exposure_correction(


### PR DESCRIPTION
First restrict to train sample, then sample. Not the other way around. Otherwise it's difficult to generate data sets with a specific number of rows.

Not quite sure why this hasn't bothered us before. Working hypothesis: I was always running the "real" benchmarks on about 70% of the data. It's just that the analyze function never bothered to actually count the number of rows until [recently](https://github.com/Quantco/glm_benchmarks/blame/master/src/glm_benchmarks/cli_run.py#L124).