### PR TITLE
Less builds on MacOS for non-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.6', '3.7', '3.8']
+        PYTHON_VERSION: ['3.7']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2.1.0
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.6', '3.7', '3.8']
+        PYTHON_VERSION: ['3.8']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2.1.0


### PR DESCRIPTION
We've been hammering on resources quite a bit, let's trim down the matrix for PRs.