### PR TITLE
Use absolute imports for cli_run and cli_analyze.

### DIFF
--- a/src/quantcore/glm_benchmarks/cli_analyze.py
+++ b/src/quantcore/glm_benchmarks/cli_analyze.py
@@ -5,9 +5,8 @@ from typing import Any, Dict, List, Optional
 import click
 import numpy as np
 import pandas as pd
-
-from .problems import get_all_problems
-from .util import (
+from quantcore.glm_benchmarks.problems import get_all_problems
+from quantcore.glm_benchmarks.util import (
     BenchmarkParams,
     benchmark_params_cli,
     clear_cache,

--- a/src/quantcore/glm_benchmarks/cli_run.py
+++ b/src/quantcore/glm_benchmarks/cli_run.py
@@ -3,18 +3,17 @@ import pickle
 from typing import Any, Dict, List, Optional, Tuple
 
 import click
-
-from .bench_orig_sklearn_fork import orig_sklearn_fork_bench
-from .bench_quantcore_glm import quantcore_glm_bench
-from .problems import Problem, get_all_problems
-from .util import (
+from quantcore.glm_benchmarks.bench_orig_sklearn_fork import orig_sklearn_fork_bench
+from quantcore.glm_benchmarks.bench_quantcore_glm import quantcore_glm_bench
+from quantcore.glm_benchmarks.problems import Problem, get_all_problems
+from quantcore.glm_benchmarks.util import (
     BenchmarkParams,
     benchmark_params_cli,
     clear_cache,
     defaults,
     get_obj_val,
 )
-from .zeros_benchmark import zeros_bench
+from quantcore.glm_benchmarks.zeros_benchmark import zeros_bench
 
 try:
     from .bench_glmnet_python import glmnet_python_bench  # isort:skip


### PR DESCRIPTION
The relative imports work when we call the scripts using `glm_benchmarks_run` or `glm_benchmarks_analyze` but fail when we run the scripts directly. Running the scripts directly is useful for profiling. e.g. `kernprof -lbv src/quantcore/glm_benchmarks/cli_run.py ...`