### PR TITLE
Issue #286 fixed.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - pytest-xdist
   - scikit-learn
   - setuptools_scm
-  - sparse_dot_mkl>=0.4.0
+  - sparse_dot_mkl>=0.5.3
   - xsimd
   - dask-ml
   - tqdm

--- a/tests/glm/test_performance.py
+++ b/tests/glm/test_performance.py
@@ -6,7 +6,11 @@ from threading import Thread
 import pandas as pd
 import psutil
 import pytest
+import quantcore.matrix as mx
 import scipy.sparse as sps
+from quantcore.glm_benchmarks.cli_run import get_all_problems
+
+from quantcore.glm import GeneralizedLinearRegressor
 
 
 def get_memory_usage():
@@ -45,13 +49,6 @@ class MemoryPoller:
 
 
 def runner(storage):
-    # Once issue #286 is solved, these imports can be moved outside the runner
-    # function. For now, there will be an indefinite hang if the imports are
-    # moved outside.
-    from quantcore.glm_benchmarks.cli_run import get_all_problems
-    from quantcore.glm import GeneralizedLinearRegressor
-    import quantcore.matrix as mx
-
     gc.collect()
     P = get_all_problems()["wide-insurance-no-weights-lasso-poisson"]
     dat = P.data_loader(num_rows=100000, storage=storage)


### PR DESCRIPTION
Fixes #286. This was fixed upstream. This PR updates to make sure we're using the latest sparse_dot_mkl version. And then it removes some of the old hacks that were necessary to get things working.