### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
    rev: 19.10b0
    hooks:
      - id: black-conda
-       additional_dependencies: [flake8-docstrings, flake8-rst-docstrings]
        args:
          - --safe
          - --target-version=py36
@@ -11,15 +10,27 @@ repos:
    rev: v3.7.9
    hooks:
     - id: flake8-conda
+      additional_dependencies: [
+          flake8-bugbear,
+          flake8-builtins,
+          flake8-comprehensions,
+          flake8-docstrings,
+          flake8-print,
+          pep8-naming,
+        ]
  - repo: https://github.com/Quantco/pre-commit-mirrors-isort
-   rev: 4.3.21
+   rev: 5.1.1
    hooks:
     - id: isort-conda
       additional_dependencies: [toml]
  - repo: https://github.com/Quantco/pre-commit-mirrors-mypy
-   rev: "0.770"
+   rev: "0.761"
    hooks:
     - id: mypy-conda
+      args:
+       - --check-untyped-defs
+       - --ignore-missing-imports
+       - --namespace-packages
  - repo: https://github.com/Quantco/pre-commit-mirrors-pyupgrade
    rev: 1.26.0
    hooks:


### PR DESCRIPTION
I updated the pre-commit hooks. Please take a look and see if you find any of the complaints useful. There's a lot of nitpicking about docstrings. The old version has the docstrings checks in the wrong place, so that's why we never got any complaints.

```
2020-08-05T22:01:52.4235090Z [INFO] This may take a few minutes...
2020-08-05T22:02:08.3915949Z black-conda..............................................................Passed
2020-08-05T22:02:11.3417721Z flake8-conda.............................................................Failed
2020-08-05T22:02:11.3418873Z - hook id: flake8-conda
2020-08-05T22:02:11.3419256Z - exit code: 1
2020-08-05T22:02:11.3419336Z 
2020-08-05T22:02:11.3425965Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1:1: D200 One-line docstring should fit on one line with quotes
2020-08-05T22:02:11.3426251Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1:1: D400 First line should end with a period
2020-08-05T22:02:11.3426433Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:96:1: D401 First line should be in imperative mood
2020-08-05T22:02:11.3426878Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:104:1: D209 Multi-line docstring closing quotes should be on a separate line
2020-08-05T22:02:11.3427083Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:244:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3427259Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:247:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3427433Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:250:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3427603Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:253:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3427772Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:256:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3427936Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:263:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3428097Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:266:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3428269Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:269:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3428431Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:272:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3428594Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:275:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3428758Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:282:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3428904Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:285:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3429065Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:288:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3429228Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:291:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3429388Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:295:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3429568Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:301:1: D412 No blank lines allowed between a section header and its content
2020-08-05T22:02:11.3429744Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:368:1: D401 First line should be in imperative mood
2020-08-05T22:02:11.3429915Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:450:1: D407 Missing dashed underline after section
2020-08-05T22:02:11.3430279Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:530:1: D301 Use r""" if any backslashes in a docstring
2020-08-05T22:02:11.3430474Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:752:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3430807Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:813:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3430973Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:813:1: D400 First line should end with a period
2020-08-05T22:02:11.3431239Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:823:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3431400Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:846:1: D400 First line should end with a period
2020-08-05T22:02:11.3431558Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:853:1: D400 First line should end with a period
2020-08-05T22:02:11.3431717Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:860:1: D400 First line should end with a period
2020-08-05T22:02:11.3431868Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:867:1: D400 First line should end with a period
2020-08-05T22:02:11.3432020Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:885:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3432175Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:888:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3432335Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:891:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3432496Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:909:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3432649Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:912:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3432805Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:915:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3433335Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1411:13: B007 Loop control variable 'k' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3438314Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1458:1: D301 Use r""" if any backslashes in a docstring
2020-08-05T22:02:11.3438729Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2490:1: D301 Use r""" if any backslashes in a docstring
2020-08-05T22:02:11.3442083Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2536:1: D301 Use r""" if any backslashes in a docstring
2020-08-05T22:02:11.3442337Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2536:1: D400 First line should end with a period
2020-08-05T22:02:11.3442652Z src/quantcore/glm_benchmarks/bench_r_glmnet.py:16:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3442944Z src/quantcore/glm_benchmarks/bench_r_glmnet.py:22:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3443373Z src/quantcore/glm_benchmarks/bench_r_glmnet.py:36:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3443541Z src/quantcore/glm_benchmarks/bench_r_glmnet.py:42:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3444123Z src/quantcore/glm_benchmarks/bench_r_glmnet.py:52:20: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3444293Z src/quantcore/glm_benchmarks/bench_r_glmnet.py:65:110: B950 line too long (109 > 88 characters)
2020-08-05T22:02:11.3444453Z src/quantcore/glm_benchmarks/bench_glmnet_python.py:12:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3444851Z src/quantcore/glm_benchmarks/bench_glmnet_python.py:22:20: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3445024Z src/quantcore/glm_benchmarks/bench_glmnet_python.py:33:110: B950 line too long (109 > 88 characters)
2020-08-05T22:02:11.3445385Z src/quantcore/glm/_util.py:32:1: D209 Multi-line docstring closing quotes should be on a separate line
2020-08-05T22:02:11.3445684Z src/quantcore/glm/_util.py:54:1: D401 First line should be in imperative mood
2020-08-05T22:02:11.3445857Z src/quantcore/glm_benchmarks/problems.py:26:1: D101 Missing docstring in public class
2020-08-05T22:02:11.3446024Z src/quantcore/glm_benchmarks/problems.py:46:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3446186Z src/quantcore/glm_benchmarks/problems.py:46:1: D400 First line should end with a period
2020-08-05T22:02:11.3446347Z src/quantcore/glm_benchmarks/problems.py:131:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3446847Z src/quantcore/glm_benchmarks/problems.py:142:16: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3447012Z src/quantcore/glm_benchmarks/util.py:21:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3447439Z src/quantcore/glm_benchmarks/util.py:23:9: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3447627Z src/quantcore/glm_benchmarks/util.py:31:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3447787Z src/quantcore/glm_benchmarks/util.py:41:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3447954Z src/quantcore/glm_benchmarks/util.py:138:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3448116Z src/quantcore/glm_benchmarks/util.py:138:1: D400 First line should end with a period
2020-08-05T22:02:11.3448267Z src/quantcore/glm_benchmarks/util.py:181:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3448426Z src/quantcore/glm_benchmarks/util.py:187:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3448580Z src/quantcore/glm_benchmarks/util.py:205:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3448912Z src/quantcore/glm_benchmarks/util.py:209:143: B950 line too long (142 > 88 characters)
2020-08-05T22:02:11.3449075Z src/quantcore/glm_benchmarks/util.py:213:130: B950 line too long (129 > 88 characters)
2020-08-05T22:02:11.3449213Z src/quantcore/glm_benchmarks/util.py:218:132: B950 line too long (131 > 88 characters)
2020-08-05T22:02:11.3449361Z src/quantcore/glm_benchmarks/util.py:223:122: B950 line too long (121 > 88 characters)
2020-08-05T22:02:11.3449508Z src/quantcore/glm_benchmarks/util.py:228:149: B950 line too long (148 > 88 characters)
2020-08-05T22:02:11.3449655Z src/quantcore/glm_benchmarks/util.py:247:170: B950 line too long (169 > 88 characters)
2020-08-05T22:02:11.3449805Z src/quantcore/glm_benchmarks/util.py:282:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3449962Z src/quantcore/glm_benchmarks/util.py:286:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3450122Z src/quantcore/glm_benchmarks/util.py:306:1: D202 No blank lines allowed after function docstring
2020-08-05T22:02:11.3450279Z src/quantcore/glm_benchmarks/util.py:319:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3450430Z src/quantcore/glm_benchmarks/util.py:323:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3450593Z src/quantcore/glm_benchmarks/benchmark_sparse_sandwich.py:18:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3450761Z src/quantcore/glm_benchmarks/benchmark_sparse_sandwich.py:28:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3456005Z src/quantcore/glm_benchmarks/benchmark_sparse_sandwich.py:36:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3456206Z src/quantcore/glm_benchmarks/benchmark_sparse_sandwich.py:45:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3456947Z src/quantcore/glm_benchmarks/benchmark_sparse_sandwich.py:66:13: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3457142Z src/quantcore/glm_benchmarks/benchmark_sparse_sandwich.py:86:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3457306Z tests/benchmark/test_cli.py:104:106: B950 line too long (105 > 88 characters)
2020-08-05T22:02:11.3458178Z tests/benchmark/test_cli.py:105:114: B950 line too long (113 > 88 characters)
2020-08-05T22:02:11.3458381Z tests/benchmark/test_cli.py:106:110: B950 line too long (109 > 88 characters)
2020-08-05T22:02:11.3458541Z tests/benchmark/test_cli.py:107:118: B950 line too long (117 > 88 characters)
2020-08-05T22:02:11.3459039Z tests/benchmark/test_cli.py:115:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3459215Z src/quantcore/glm_benchmarks/cli_analyze.py:34:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3459491Z src/quantcore/glm_benchmarks/cli_analyze.py:109:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3459655Z src/quantcore/glm_benchmarks/cli_analyze.py:159:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3459821Z src/quantcore/glm_benchmarks/cli_analyze.py:187:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3459999Z src/quantcore/glm_benchmarks/bench_orig_sklearn_fork.py:14:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3460170Z src/quantcore/glm_benchmarks/bench_orig_sklearn_fork.py:18:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3460662Z src/quantcore/glm_benchmarks/bench_orig_sklearn_fork.py:30:14: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3460843Z src/quantcore/glm_benchmarks/bench_orig_sklearn_fork.py:36:107: B950 line too long (106 > 88 characters)
2020-08-05T22:02:11.3461153Z performance/test_performance.py:18:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3461311Z performance/test_performance.py:23:1: D400 First line should end with a period
2020-08-05T22:02:11.3461459Z performance/test_performance.py:33:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3461607Z performance/test_performance.py:39:1: D105 Missing docstring in magic method
2020-08-05T22:02:11.3461760Z performance/test_performance.py:48:1: D105 Missing docstring in magic method
2020-08-05T22:02:11.3461917Z performance/test_performance.py:53:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3462297Z performance/test_performance.py:57:16: C407 Unnecessary list comprehension - 'sum' can take a generator.
2020-08-05T22:02:11.3462660Z performance/test_performance.py:66:16: C407 Unnecessary list comprehension - 'sum' can take a generator.
2020-08-05T22:02:11.3462816Z performance/test_performance.py:70:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3463275Z performance/test_performance.py:91:13: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3463454Z performance/test_performance.py:115:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3463612Z src/quantcore/glm_benchmarks/bench_h2o.py:14:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3463770Z src/quantcore/glm_benchmarks/bench_h2o.py:20:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3463931Z src/quantcore/glm_benchmarks/bench_h2o.py:27:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3464300Z src/quantcore/glm_benchmarks/bench_h2o.py:38:20: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3464444Z src/quantcore/glm_benchmarks/bench_h2o.py:42:100: B950 line too long (99 > 88 characters)
2020-08-05T22:02:11.3464606Z src/quantcore/glm/_solvers.py:26:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3464764Z src/quantcore/glm/_solvers.py:26:1: D400 First line should end with a period
2020-08-05T22:02:11.3464925Z src/quantcore/glm/_solvers.py:26:1: D401 First line should be in imperative mood
2020-08-05T22:02:11.3465081Z src/quantcore/glm/_solvers.py:78:1: D202 No blank lines allowed after function docstring
2020-08-05T22:02:11.3465239Z src/quantcore/glm/_solvers.py:78:1: D401 First line should be in imperative mood; try rephrasing
2020-08-05T22:02:11.3465394Z src/quantcore/glm/_solvers.py:187:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3465639Z src/quantcore/glm/_solvers.py:193:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3465808Z src/quantcore/glm/_solvers.py:226:1: D202 No blank lines allowed after function docstring
2020-08-05T22:02:11.3465959Z src/quantcore/glm/_solvers.py:226:1: D400 First line should end with a period
2020-08-05T22:02:11.3466120Z src/quantcore/glm/_solvers.py:226:1: D412 No blank lines allowed between a section header and its content
2020-08-05T22:02:11.3466287Z src/quantcore/glm/_solvers.py:344:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3495992Z src/quantcore/glm/_solvers.py:344:1: D400 First line should end with a period
2020-08-05T22:02:11.3496278Z src/quantcore/glm/_solvers.py:347:258: B950 line too long (257 > 88 characters)
2020-08-05T22:02:11.3496418Z src/quantcore/glm/_solvers.py:348:98: B950 line too long (97 > 88 characters)
2020-08-05T22:02:11.3496549Z src/quantcore/glm/_solvers.py:356:1: D105 Missing docstring in magic method
2020-08-05T22:02:11.3496699Z src/quantcore/glm/_solvers.py:367:131: B950 line too long (130 > 88 characters)
2020-08-05T22:02:11.3496826Z src/quantcore/glm/_solvers.py:372:1: D105 Missing docstring in magic method
2020-08-05T22:02:11.3496951Z src/quantcore/glm/_solvers.py:376:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3497052Z src/quantcore/glm/_solvers.py:390:1: D101 Missing docstring in public class
2020-08-05T22:02:11.3497175Z src/quantcore/glm/_solvers.py:447:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3497300Z src/quantcore/glm/_solvers.py:461:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3497433Z src/quantcore/glm/_solvers.py:468:1: D101 Missing docstring in public class
2020-08-05T22:02:11.3497555Z src/quantcore/glm/_solvers.py:524:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3497678Z src/quantcore/glm/_solvers.py:556:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3497801Z src/quantcore/glm/_solvers.py:607:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3497922Z src/quantcore/glm/_solvers.py:625:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3498041Z src/quantcore/glm/_solvers.py:649:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3498160Z src/quantcore/glm/_solvers.py:669:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3498276Z src/quantcore/glm/_solvers.py:684:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3498396Z src/quantcore/glm/_solvers.py:701:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3499142Z src/quantcore/glm/_solvers.py:725:9: B007 Loop control variable 'k' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3499299Z src/quantcore/glm/_solvers.py:741:5: B010 Do not call setattr with a constant attribute value, it is not any safer than normal property access.
2020-08-05T22:02:11.3499447Z src/quantcore/glm/_glm_cv.py:26:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3499579Z src/quantcore/glm/_glm_cv.py:26:1: D301 Use r""" if any backslashes in a docstring
2020-08-05T22:02:11.3499702Z src/quantcore/glm/_glm_cv.py:26:1: D400 First line should end with a period
2020-08-05T22:02:11.3499824Z src/quantcore/glm/_glm_cv.py:241:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3499954Z src/quantcore/glm_benchmarks/data/simulated_glm.py:11:1: D401 First line should be in imperative mood
2020-08-05T22:02:11.3500091Z src/quantcore/glm_benchmarks/data/simulated_glm.py:31:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3500227Z src/quantcore/glm_benchmarks/data/simulated_glm.py:47:103: B950 line too long (102 > 88 characters)
2020-08-05T22:02:11.3500361Z src/quantcore/glm_benchmarks/data/simulated_glm.py:52:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3500497Z tests/glm/test_cv_glm.py:27:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3500999Z tests/glm/test_cv_glm.py:27:1: D400 First line should end with a period
2020-08-05T22:02:11.3501151Z tests/glm/test_cv_glm.py:81:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3501278Z tests/glm/test_cv_glm.py:81:1: D400 First line should end with a period
2020-08-05T22:02:11.3501409Z src/quantcore/glm_benchmarks/data/create.py:13:102: B950 line too long (101 > 88 characters)
2020-08-05T22:02:11.3501543Z src/quantcore/glm_benchmarks/data/create.py:17:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3501675Z src/quantcore/glm_benchmarks/data/create.py:74:106: B950 line too long (105 > 88 characters)
2020-08-05T22:02:11.3501896Z src/quantcore/glm_benchmarks/data/create.py:89:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3502028Z src/quantcore/glm_benchmarks/data/create.py:89:1: D400 First line should end with a period
2020-08-05T22:02:11.3502168Z src/quantcore/glm_benchmarks/data/create.py:99:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3502305Z src/quantcore/glm_benchmarks/data/create.py:99:1: D400 First line should end with a period
2020-08-05T22:02:11.3502434Z src/quantcore/glm_benchmarks/data/create.py:149:102: B950 line too long (101 > 88 characters)
2020-08-05T22:02:11.3502561Z src/quantcore/glm_benchmarks/data/create.py:298:99: B950 line too long (98 > 88 characters)
2020-08-05T22:02:11.3502689Z src/quantcore/glm_benchmarks/data/create.py:305:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3502822Z src/quantcore/glm_benchmarks/data/create.py:328:1: D202 No blank lines allowed after function docstring
2020-08-05T22:02:11.3502957Z src/quantcore/glm_benchmarks/data/create.py:341:1: D202 No blank lines allowed after function docstring
2020-08-05T22:02:11.3503084Z src/quantcore/glm_benchmarks/data/create.py:400:1: D202 No blank lines allowed after function docstring
2020-08-05T22:02:11.3503335Z tests/glm/test_sklearn.py:72:1: D400 First line should end with a period
2020-08-05T22:02:11.3503739Z tests/glm/test_sklearn.py:173:9: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3503881Z tests/glm/test_sklearn.py:219:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3504170Z tests/glm/test_sklearn.py:219:1: D209 Multi-line docstring closing quotes should be on a separate line
2020-08-05T22:02:11.3504296Z tests/glm/test_sklearn.py:585:1: D400 First line should end with a period
2020-08-05T22:02:11.3504582Z tests/glm/test_sklearn.py:864:1: D209 Multi-line docstring closing quotes should be on a separate line
2020-08-05T22:02:11.3504866Z tests/glm/test_sklearn.py:1023:1: D209 Multi-line docstring closing quotes should be on a separate line
2020-08-05T22:02:11.3505003Z src/quantcore/glm/_distribution.py:28:1: D412 No blank lines allowed between a section header and its content
2020-08-05T22:02:11.3505138Z src/quantcore/glm/_distribution.py:93:1: D401 First line should be in imperative mood
2020-08-05T22:02:11.3505269Z src/quantcore/glm/_distribution.py:175:1: D407 Missing dashed underline after section
2020-08-05T22:02:11.3505404Z src/quantcore/glm/_distribution.py:255:1: D301 Use r""" if any backslashes in a docstring
2020-08-05T22:02:11.3505538Z src/quantcore/glm/_distribution.py:301:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3505669Z src/quantcore/glm/_distribution.py:301:1: D400 First line should end with a period
2020-08-05T22:02:11.3505800Z src/quantcore/glm/_distribution.py:339:1: D202 No blank lines allowed after function docstring
2020-08-05T22:02:11.3505932Z src/quantcore/glm/_distribution.py:339:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3506062Z src/quantcore/glm/_distribution.py:339:1: D400 First line should end with a period
2020-08-05T22:02:11.3506289Z src/quantcore/glm/_distribution.py:339:1: D401 First line should be in imperative mood; try rephrasing
2020-08-05T22:02:11.3506436Z src/quantcore/glm/_distribution.py:339:1: D404 First word of the docstring should not be `This`
2020-08-05T22:02:11.3506567Z src/quantcore/glm/_distribution.py:386:1: D202 No blank lines allowed after function docstring
2020-08-05T22:02:11.3506701Z src/quantcore/glm/_distribution.py:386:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3506829Z src/quantcore/glm/_distribution.py:386:1: D400 First line should end with a period
2020-08-05T22:02:11.3506989Z src/quantcore/glm/_distribution.py:386:1: D401 First line should be in imperative mood; try rephrasing
2020-08-05T22:02:11.3507190Z src/quantcore/glm/_distribution.py:386:1: D404 First word of the docstring should not be `This`
2020-08-05T22:02:11.3507318Z src/quantcore/glm/_distribution.py:435:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3507446Z src/quantcore/glm/_distribution.py:498:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3507578Z src/quantcore/glm/_distribution.py:498:1: D400 First line should end with a period
2020-08-05T22:02:11.3507704Z src/quantcore/glm/_distribution.py:509:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3507829Z src/quantcore/glm/_distribution.py:580:1: D400 First line should end with a period
2020-08-05T22:02:11.3507953Z src/quantcore/glm/_distribution.py:587:1: D400 First line should end with a period
2020-08-05T22:02:11.3508077Z src/quantcore/glm/_distribution.py:594:1: D400 First line should end with a period
2020-08-05T22:02:11.3508200Z src/quantcore/glm/_distribution.py:601:1: D400 First line should end with a period
2020-08-05T22:02:11.3508326Z src/quantcore/glm/_distribution.py:619:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3508447Z src/quantcore/glm/_distribution.py:622:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3508565Z src/quantcore/glm/_distribution.py:625:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3508662Z src/quantcore/glm/_distribution.py:643:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3508782Z src/quantcore/glm/_distribution.py:646:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3508899Z src/quantcore/glm/_distribution.py:649:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3509022Z src/quantcore/glm/_distribution.py:752:1: D400 First line should end with a period
2020-08-05T22:02:11.3509153Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:8:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3509287Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:14:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3509423Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:20:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3509843Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:22:9: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3509998Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:37:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3510741Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:44:11: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3511020Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:71:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3511195Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:91:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3511360Z src/quantcore/glm/_link.py:77:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3511533Z src/quantcore/glm/_link.py:80:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3511684Z src/quantcore/glm/_link.py:83:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3511832Z src/quantcore/glm/_link.py:86:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3512172Z src/quantcore/glm/_link.py:89:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3512346Z src/quantcore/glm/_link.py:96:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3512650Z src/quantcore/glm/_link.py:99:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3512798Z src/quantcore/glm/_link.py:102:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3513144Z src/quantcore/glm/_link.py:105:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3513294Z src/quantcore/glm/_link.py:108:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3513439Z src/quantcore/glm/_link.py:115:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3513697Z src/quantcore/glm/_link.py:118:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3514033Z src/quantcore/glm/_link.py:122:1: D205 1 blank line required between summary line and description
2020-08-05T22:02:11.3514185Z src/quantcore/glm/_link.py:122:1: D400 First line should end with a period
2020-08-05T22:02:11.3514335Z src/quantcore/glm/_link.py:136:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3514481Z src/quantcore/glm/_link.py:140:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3514608Z src/quantcore/glm/_link.py:145:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3514753Z src/quantcore/glm/_link.py:164:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3514895Z src/quantcore/glm/_link.py:176:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3515036Z src/quantcore/glm/_link.py:179:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3515182Z src/quantcore/glm/_link.py:183:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3515320Z src/quantcore/glm/_link.py:188:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3515457Z src/quantcore/glm/_link.py:193:1: D102 Missing docstring in public method
2020-08-05T22:02:11.3515608Z src/quantcore/glm_benchmarks/bench_quantcore_glm.py:15:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3515773Z src/quantcore/glm_benchmarks/bench_quantcore_glm.py:21:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3516320Z src/quantcore/glm_benchmarks/bench_quantcore_glm.py:33:14: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3516484Z src/quantcore/glm_benchmarks/bench_quantcore_glm.py:86:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3516927Z src/quantcore/glm_benchmarks/bench_quantcore_glm.py:92:9: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3517112Z src/quantcore/glm_benchmarks/zeros_benchmark.py:7:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3517459Z tests/glm/test_golden_master.py:58:12: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3517800Z tests/glm/test_golden_master.py:358:33: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3518138Z tests/glm/test_golden_master.py:395:19: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3518298Z src/quantcore/glm_benchmarks/cli_run.py:57:101: B950 line too long (100 > 88 characters)
2020-08-05T22:02:11.3518456Z src/quantcore/glm_benchmarks/cli_run.py:60:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3518883Z src/quantcore/glm_benchmarks/cli_run.py:68:13: B007 Loop control variable 'P' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3519522Z src/quantcore/glm_benchmarks/cli_run.py:69:17: B007 Loop control variable 'L' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3519703Z src/quantcore/glm_benchmarks/cli_run.py:87:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3519861Z src/quantcore/glm_benchmarks/cli_run.py:146:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3520021Z src/quantcore/glm_benchmarks/cli_run.py:167:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3520274Z src/quantcore/glm_benchmarks/cli_run.py:180:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3520446Z src/quantcore/glm_benchmarks/cli_run.py:191:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3520599Z src/quantcore/glm_benchmarks/cli_run.py:195:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3520757Z src/quantcore/glm_benchmarks/bench_liblinear.py:12:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3520917Z src/quantcore/glm_benchmarks/bench_liblinear.py:16:1: D103 Missing docstring in public function
2020-08-05T22:02:11.3521409Z src/quantcore/glm_benchmarks/bench_liblinear.py:27:20: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3521577Z src/quantcore/glm_benchmarks/bench_liblinear.py:32:106: B950 line too long (105 > 88 characters)
2020-08-05T22:02:11.3521737Z src/quantcore/glm_benchmarks/bench_liblinear.py:64:104: B950 line too long (103 > 88 characters)
2020-08-05T22:02:11.3521903Z src/quantcore/glm_benchmarks/bench_liblinear.py:65:107: B950 line too long (106 > 88 characters)
2020-08-05T22:02:11.3522061Z src/quantcore/glm_benchmarks/bench_liblinear.py:66:100: B950 line too long (99 > 88 characters)
2020-08-05T22:02:11.3522220Z src/quantcore/glm_benchmarks/bench_liblinear.py:67:109: B950 line too long (108 > 88 characters)
2020-08-05T22:02:11.3522593Z tests/glm/test_benchmark_golden_master.py:91:19: C408 Unnecessary dict call - rewrite as a literal.
2020-08-05T22:02:11.3523158Z tests/glm/test_benchmark_golden_master.py:93:13: B007 Loop control variable 'P' not used within the loop body. If this is intended, start the name with an underscore.
2020-08-05T22:02:11.3523274Z 
2020-08-05T22:02:11.8984797Z isort-conda..............................................................Failed
2020-08-05T22:02:11.8985204Z - hook id: isort-conda
2020-08-05T22:02:11.8985490Z - files were modified by this hook
2020-08-05T22:02:11.8985561Z 
2020-08-05T22:02:11.8985896Z Fixing /github/workspace/src/quantcore/glm/_util.py
2020-08-05T22:02:11.8986046Z Fixing /github/workspace/src/quantcore/glm_benchmarks/problems.py
2020-08-05T22:02:11.8986217Z Fixing /github/workspace/src/quantcore/glm_benchmarks/util.py
2020-08-05T22:02:11.8986370Z Fixing /github/workspace/src/quantcore/glm_benchmarks/benchmark_sparse_sandwich.py
2020-08-05T22:02:11.8986525Z Fixing /github/workspace/tests/benchmark/test_cli.py
2020-08-05T22:02:11.8986674Z Fixing /github/workspace/src/quantcore/glm_benchmarks/cli_analyze.py
2020-08-05T22:02:11.8986827Z Fixing /github/workspace/performance/test_performance.py
2020-08-05T22:02:11.8986976Z Fixing /github/workspace/src/quantcore/glm/_glm.py
2020-08-05T22:02:11.8987113Z Fixing /github/workspace/tests/glm/test_cv_glm.py
2020-08-05T22:02:11.8987257Z Fixing /github/workspace/tests/glm/test_offset_weight_obj_equivalent.py
2020-08-05T22:02:11.8987385Z Fixing /github/workspace/tests/glm/test_sklearn.py
2020-08-05T22:02:11.8987577Z Fixing /github/workspace/src/quantcore/glm/_distribution.py
2020-08-05T22:02:11.8987736Z Fixing /github/workspace/src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py
2020-08-05T22:02:11.8987893Z Fixing /github/workspace/tests/glm/test_golden_master.py
2020-08-05T22:02:11.8988039Z Fixing /github/workspace/src/quantcore/glm_benchmarks/cli_run.py
2020-08-05T22:02:11.8988188Z Fixing /github/workspace/tests/glm/test_benchmark_golden_master.py
2020-08-05T22:02:11.8988279Z 
2020-08-05T22:02:20.2213575Z mypy-conda...............................................................Failed
2020-08-05T22:02:20.2214063Z - hook id: mypy-conda
2020-08-05T22:02:20.2214364Z - exit code: 1
2020-08-05T22:02:20.2214432Z 
2020-08-05T22:02:20.2214942Z src/quantcore/glm_benchmarks/benchmark_dense_sandwich.py:45: error: Need type annotation for 'out' (hint: "out: Dict[<type>, <type>] = ...")
2020-08-05T22:02:20.2215146Z tests/glm/test_sklearn.py:290: error: Incompatible types in assignment (expression has type "List[List[int]]", variable has type "int")
2020-08-05T22:02:20.2215585Z tests/glm/test_sklearn.py:295: error: Incompatible types in assignment (expression has type "List[int]", variable has type "int")
2020-08-05T22:02:20.2215791Z tests/glm/test_sklearn.py:300: error: Incompatible types in assignment (expression has type "List[int]", variable has type "int")
2020-08-05T22:02:20.2215958Z tests/glm/test_sklearn.py:307: error: Incompatible types in assignment (expression has type "List[int]", variable has type "int")
2020-08-05T22:02:20.2216125Z tests/glm/test_sklearn.py:832: error: Dict entry 1 has incompatible type "str": "int"; expected "str": "str"
2020-08-05T22:02:20.2216407Z tests/glm/test_sklearn.py:832: error: Dict entry 2 has incompatible type "str": "float"; expected "str": "str"
2020-08-05T22:02:20.2216600Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:350: error: "ExponentialDispersionModel" has no attribute "_lower_bound"; maybe "lower_bound" or "include_lower_bound"?
2020-08-05T22:02:20.2216801Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:355: error: "ExponentialDispersionModel" has no attribute "_upper_bound"; maybe "upper_bound" or "include_upper_bound"?
2020-08-05T22:02:20.2216999Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:360: error: "ExponentialDispersionModel" has no attribute "_include_lower_bound"; maybe "include_lower_bound" or "include_upper_bound"?
2020-08-05T22:02:20.2217198Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:365: error: "ExponentialDispersionModel" has no attribute "_include_upper_bound"; maybe "include_upper_bound" or "include_lower_bound"?
2020-08-05T22:02:20.2217396Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:770: error: Unsupported operand types for < ("int" and "Real")
2020-08-05T22:02:20.2217575Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:776: error: Unsupported operand types for < ("int" and "Real")
2020-08-05T22:02:20.2217746Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:784: error: Unsupported operand types for < ("int" and "Real")
2020-08-05T22:02:20.2217918Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:792: error: Unsupported operand types for < ("int" and "Real")
2020-08-05T22:02:20.2218094Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1839: error: Unsupported operand types for > ("int" and "Number")
2020-08-05T22:02:20.2218268Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1846: error: Unsupported operand types for > ("int" and "Number")
2020-08-05T22:02:20.2218433Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1847: error: Unsupported operand types for < ("int" and "Number")
2020-08-05T22:02:20.2218595Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1870: error: Unsupported operand types for < ("int" and "Number")
2020-08-05T22:02:20.2218767Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:1884: error: Unsupported operand types for >= ("int" and "Number")
2020-08-05T22:02:20.2218923Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2038: error: Unsupported left operand type for * ("Number")
2020-08-05T22:02:20.2219098Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2039: error: Unsupported operand types for * ("Number" and "int")
2020-08-05T22:02:20.2219567Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2039: error: Unsupported operand types for - ("int" and "Number")
2020-08-05T22:02:20.2219948Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2123: error: Cannot determine type of 'intercept_'
2020-08-05T22:02:20.2220324Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2123: error: Cannot determine type of 'coef_'
2020-08-05T22:02:20.2220689Z src/quantcore/glm_benchmarks/orig_sklearn_fork/_glm.py:2125: error: Cannot determine type of 'coef_'
2020-08-05T22:02:20.2220879Z src/quantcore/glm/_distribution.py:76: error: "ExponentialDispersionModel" has no attribute "_lower_bound"; maybe "lower_bound" or "include_lower_bound"?
2020-08-05T22:02:20.2221077Z src/quantcore/glm/_distribution.py:81: error: "ExponentialDispersionModel" has no attribute "_upper_bound"; maybe "upper_bound" or "include_upper_bound"?
2020-08-05T22:02:20.2221371Z src/quantcore/glm/_distribution.py:86: error: "ExponentialDispersionModel" has no attribute "_include_lower_bound"; maybe "include_lower_bound" or "include_upper_bound"?
2020-08-05T22:02:20.2221586Z src/quantcore/glm/_distribution.py:91: error: "ExponentialDispersionModel" has no attribute "_include_upper_bound"; maybe "include_upper_bound" or "include_lower_bound"?
2020-08-05T22:02:20.2221771Z src/quantcore/glm/_distribution.py:454: error: Unsupported operand types for < ("int" and "Real")
2020-08-05T22:02:20.2221934Z src/quantcore/glm/_distribution.py:460: error: Unsupported operand types for < ("int" and "Real")
2020-08-05T22:02:20.2222175Z src/quantcore/glm/_distribution.py:468: error: Unsupported operand types for < ("int" and "Real")
2020-08-05T22:02:20.2222338Z src/quantcore/glm/_distribution.py:476: error: Unsupported operand types for < ("int" and "Real")
2020-08-05T22:02:20.2222511Z src/quantcore/glm/_solvers.py:527: error: Incompatible types in assignment (expression has type "float", variable has type "int")
2020-08-05T22:02:20.2222906Z performance/test_performance.py:35: error: Cannot determine type of 'memory_usage'
2020-08-05T22:02:20.2223250Z performance/test_performance.py:36: error: Cannot determine type of 'max_memory'
2020-08-05T22:02:20.2223587Z performance/test_performance.py:36: error: Cannot determine type of 'memory_usage'
2020-08-05T22:02:20.2223750Z src/quantcore/glm_benchmarks/util.py:283: error: "Command" has no attribute "out"
2020-08-05T22:02:20.2223913Z src/quantcore/glm/_glm_cv.py:405: error: Value of type "Union[float, Any]" is not indexable
2020-08-05T22:02:20.2224073Z Found 40 errors in 8 files (checked 35 source files)
2020-08-05T22:02:20.2224164Z 
2020-08-05T22:02:20.8034976Z pyupgrade-conda..........................................................Passed
```