### PR TITLE
`family_instance` and `link_instance`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Unreleased
 - :class:`BinomialDistribution` and :class:`TweedieDistribution` gain a :meth:`log_likelihood` method.
 - The :meth:`fit` method of :class:`~quantcore.glm.GeneralizedLinearRegressor` and :class:`~quantcore.glm.GeneralizedLinearRegressorCV`
   now saves the column types of pandas data frames.
+- :class:`~quantcore.glm.GeneralizedLinearRegressor` and :class:`~quantcore.glm.GeneralizedLinearRegressorCV` gain two properties: ``family_instance`` and ``link_instance``.
 
 **Other:**
 

--- a/src/quantcore/glm/_glm.py
+++ b/src/quantcore/glm/_glm.py
@@ -675,6 +675,22 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         self.b_ineq = b_ineq
         self.force_all_finite = force_all_finite
 
+    @property
+    def family_instance(self) -> ExponentialDispersionModel:
+        """Return an :class:`~quantcore.glm._distribution.ExponentialDispersionModel`."""
+        if hasattr(self, "_family_instance"):
+            return self._family_instance
+        else:
+            return get_family(self.family)
+
+    @property
+    def link_instance(self) -> Link:
+        """Return a :class:`~quantcore.glm._link.Link`."""
+        if hasattr(self, "_link_instance"):
+            return self._link_instance
+        else:
+            return get_link(self.link, self.family_instance)
+
     def get_start_coef(
         self,
         start_params,


### PR DESCRIPTION
This PR proposes two new properties for the regressor: `family_instance` and `link_instance`. They allow users to access the appropriate objects, even if they specified `family` and `link` as strings, without having to access private attributes (`_family_instance` and `_link_instance`). I think it's more elegant, especially when users want to use the evaluation methods of the underlying distribution. They also work when the regressor hasn't been fitted yet, which is a bonus.