### PR TITLE
Allow for training and predicting with different categories

### DIFF
--- a/src/quantcore/glm/_glm.py
+++ b/src/quantcore/glm/_glm.py
@@ -56,7 +56,7 @@ from ._solvers import (
     _least_squares_solver,
     _trust_constr_solver,
 )
-from ._util import _align_df_dtypes
+from ._util import _align_df_categories
 
 _float_itemsize_to_dtype = {8: np.float64, 4: np.float32, 2: np.float16}
 
@@ -1235,7 +1235,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             Predicted values times ``sample_weight``.
         """
         if isinstance(X, pd.DataFrame) and hasattr(self, "feature_dtypes_"):
-            X = _align_df_dtypes(X, self.feature_dtypes_)
+            X = _align_df_categories(X, self.feature_dtypes_)
 
         X = check_array_matrix_compliant(
             X,

--- a/src/quantcore/glm/_util.py
+++ b/src/quantcore/glm/_util.py
@@ -14,15 +14,12 @@ def _asanyarray(x, **kwargs):
     return x if pd.api.types.is_scalar(x) else np.asanyarray(x, **kwargs)
 
 
-def _align_df_dtypes(df, dtypes) -> pd.DataFrame:
+def _align_df_categories(df, dtypes) -> pd.DataFrame:
     """Align data types for prediction.
 
-    This function checks that columns are numeric if specified to be numeric in
-    ``dtypes`` to and that categorical columns have same categories in the same
-    order as specified in ``dtypes``. If an entry cannot be cast to numeric, it
-    will be set to ``numpy.nan``. If an entry has a numeric type other than that
-    prescribed by ``dtypes``, it is passed through. If an entry has a category
-    not specified in ``dtypes``, it will be set to ``numpy.nan``.
+    This function checks that categorical columns have same categories in the
+    same order as specified in ``dtypes``. If an entry has a category not
+    specified in ``dtypes``, it will be set to ``numpy.nan``.
 
     Parameters
     ----------
@@ -34,22 +31,12 @@ def _align_df_dtypes(df, dtypes) -> pd.DataFrame:
 
     changed_dtypes = {}
 
-    numeric_dtypes = [
-        column
-        for column, dtype in dtypes.items()
-        if pd.api.types.is_numeric_dtype(dtype) and (column in df)
-    ]
-
     categorical_dtypes = [
         column
         for column, dtype in dtypes.items()
         if pd.api.types.is_categorical_dtype(dtype) and (column in df)
     ]
 
-    for column in numeric_dtypes:
-        if not pd.api.types.is_numeric_dtype(df[column]):
-            _logger.info(f"Casting {column} to numeric.")
-            changed_dtypes[column] = pd.to_numeric(df[column], errors="coerce")
     for column in categorical_dtypes:
         if not pd.api.types.is_categorical_dtype(df[column]):
             _logger.info(f"Casting {column} to categorical.")

--- a/tests/glm/test_utils.py
+++ b/tests/glm/test_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from quantcore.glm._util import _align_df_dtypes
+from quantcore.glm._util import _align_df_categories
 
 
 @pytest.fixture()
@@ -20,7 +20,7 @@ def df():
     )
 
 
-def test_align_df_dtypes_numeric(df):
+def test_align_df_categories_numeric(df):
 
     dtypes = {column: np.float64 for column in df}
 
@@ -29,17 +29,17 @@ def test_align_df_dtypes_numeric(df):
             "x1": np.array([0, 1], dtype="int64"),
             "x2": np.array([0, 1], dtype="bool"),
             "x3": np.array([0, 1], dtype="float64"),
-            "x4": np.array([0, 1], dtype="int64"),
-            "x5": np.array([np.nan, np.nan], dtype="float64"),
-            "x6": np.array([np.nan, np.nan], dtype="float64"),
-            "x7": np.array([np.nan, np.nan], dtype="float64"),
+            "x4": ["0", "1"],
+            "x5": ["a", "b"],
+            "x6": pd.Categorical(["a", "b"]),
+            "x7": pd.Categorical(["a", "b"], categories=["b", "a"]),
         }
     )
 
-    pd.testing.assert_frame_equal(_align_df_dtypes(df, dtypes), expected)
+    pd.testing.assert_frame_equal(_align_df_categories(df, dtypes), expected)
 
 
-def test_align_df_dtypes_categorical(df):
+def test_align_df_categories_categorical(df):
 
     dtypes = {column: pd.CategoricalDtype(["a", "b"]) for column in df}
 
@@ -49,36 +49,36 @@ def test_align_df_dtypes_categorical(df):
             "x2": [np.nan, np.nan],
             "x3": [np.nan, np.nan],
             "x4": [np.nan, np.nan],
-            "x5": ["a", "b"],
-            "x6": ["a", "b"],
-            "x7": ["a", "b"],
+            "x5": pd.Categorical(["a", "b"]),
+            "x6": pd.Categorical(["a", "b"]),
+            "x7": pd.Categorical(["a", "b"]),
         },
         dtype=pd.CategoricalDtype(["a", "b"]),
     )
 
-    pd.testing.assert_frame_equal(_align_df_dtypes(df, dtypes), expected)
+    pd.testing.assert_frame_equal(_align_df_categories(df, dtypes), expected)
 
 
-def test_align_df_dtypes_excess_columns(df):
+def test_align_df_categories_excess_columns(df):
 
-    dtypes = {"x4": np.float64}
+    dtypes = {"x1": np.float64}
 
     expected = pd.DataFrame(
         {
             "x1": np.array([0, 1], dtype="int64"),
             "x2": np.array([0, 1], dtype="bool"),
             "x3": np.array([0, 1], dtype="float64"),
-            "x4": np.array([0, 1], dtype="int64"),
+            "x4": ["0", "1"],
             "x5": ["a", "b"],
             "x6": pd.Categorical(["a", "b"]),
             "x7": pd.Categorical(["a", "b"], categories=["b", "a"]),
         }
     )
 
-    pd.testing.assert_frame_equal(_align_df_dtypes(df, dtypes), expected)
+    pd.testing.assert_frame_equal(_align_df_categories(df, dtypes), expected)
 
 
-def test_align_df_dtypes_missing_columns(df):
+def test_align_df_categories_missing_columns(df):
 
     dtypes = {"x0": np.float64}
 
@@ -94,9 +94,9 @@ def test_align_df_dtypes_missing_columns(df):
         }
     )
 
-    pd.testing.assert_frame_equal(_align_df_dtypes(df, dtypes), expected)
+    pd.testing.assert_frame_equal(_align_df_categories(df, dtypes), expected)
 
 
-def test_align_df_dtypes_not_df():
+def test_align_df_categories_not_df():
     with pytest.raises(TypeError):
-        _align_df_dtypes(np.array([[0], [1]]), {"x0": np.float64})
+        _align_df_categories(np.array([[0], [1]]), {"x0": np.float64})


### PR DESCRIPTION
This PR adds a utility function to align categorical types in `predict`.

The original implementation was more strict: it also made sure that all columns were in the same order, that we weren't missing any columns and that we didn't have excess columns. As [this test](https://github.com/Quantco/quantcore.glm/blob/721510a55f0d0198334741bb00646be0982c40c1/tests/glm/test_glm.py#L1673) shows, however, we want to allow users to replace categorical columns with their encoded counterparts in `predict` and vice-versa, so those extra checks have been dropped.

Closes #330.
