### PR TITLE
Rename method to "deviance"

### DIFF
--- a/src/quantcore/glm/_distribution.py
+++ b/src/quantcore/glm/_distribution.py
@@ -451,7 +451,7 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         ddof : int, optional (default=1)
             Degrees of freedom consumed by the model for ``mu``.
 
-        method = {'pearson', 'residuals'}, optional (default='pearson')
+        method = {'pearson', 'deviance'}, optional (default='pearson')
             Whether to base the estimate on the Pearson residuals or the deviance.
 
         Returns
@@ -466,7 +466,7 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
                 numerator = pearson_residuals.sum()
             else:
                 numerator = np.dot(pearson_residuals, sample_weight)
-        elif method == "residuals":
+        elif method == "deviance":
             numerator = self.deviance(y, mu, sample_weight)
         else:
             raise NotImplementedError(f"Method {method} hasn't been implemented.")
@@ -733,7 +733,7 @@ class TweedieDistribution(ExponentialDispersionModel):
         ddof : int, optional (default=1)
             Degrees of freedom consumed by the model for ``mu``.
 
-        method = {'pearson', 'residuals'}, optional (default='pearson')
+        method = {'pearson', 'deviance'}, optional (default='pearson')
             Whether to base the estimate on the Pearson residuals or the deviance.
 
         Returns
@@ -972,7 +972,7 @@ class BinomialDistribution(ExponentialDispersionModel):
         ddof : int, optional (default=1)
             Degrees of freedom consumed by the model for ``mu``.
 
-        method = {'pearson', 'residuals'}, optional (default='pearson')
+        method = {'pearson', 'deviance'}, optional (default='pearson')
             Whether to base the estimate on the Pearson residuals or the deviance.
 
         Returns

--- a/tests/glm/test_distribution.py
+++ b/tests/glm/test_distribution.py
@@ -249,12 +249,14 @@ def test_poisson_deviance_dispersion_loglihood(weighted):
     mu = regressor.fit(x, y, sample_weight=wgts).predict(x)
     family = regressor._family_instance
 
-    # R bases dispersion on the deviance for log_likelihood
     ll = family.log_likelihood(
         y,
         mu,
         sample_weight=wgts,
-        dispersion=family.deviance(y, mu, sample_weight=wgts) / 5,
+        # R bases dispersion on the deviance for log_likelihood
+        dispersion=family.dispersion(
+            y, mu, sample_weight=wgts, method="deviance", ddof=0
+        ),
     )
 
     np.testing.assert_approx_equal(regressor.coef_[0], 0.1823216)
@@ -297,12 +299,14 @@ def test_gamma_deviance_dispersion_loglihood(weighted):
     mu = regressor.fit(x, y, sample_weight=wgts).predict(x)
     family = regressor._family_instance
 
-    # R bases dispersion on the deviance for log_likelihood
     ll = family.log_likelihood(
         y,
         mu,
         sample_weight=wgts,
-        dispersion=family.deviance(y, mu, sample_weight=wgts) / 5,
+        # R bases dispersion on the deviance for log_likelihood
+        dispersion=family.dispersion(
+            y, mu, sample_weight=wgts, method="deviance", ddof=0
+        ),
     )
 
     np.testing.assert_approx_equal(regressor.coef_[0], 0.8754687)
@@ -343,12 +347,14 @@ def test_gaussian_deviance_dispersion_loglihood(weighted):
     mu = regressor.fit(x, y, sample_weight=wgts).predict(x)
     family = regressor._family_instance
 
-    # R bases dispersion on the deviance for log_likelihood
     ll = family.log_likelihood(
         y,
         mu,
         sample_weight=wgts,
-        dispersion=family.deviance(y, mu, sample_weight=wgts) / 5,
+        # R bases dispersion on the deviance for log_likelihood
+        dispersion=family.dispersion(
+            y, mu, sample_weight=wgts, method="deviance", ddof=0
+        ),
     )
 
     np.testing.assert_approx_equal(regressor.coef_[0], 0.2)
@@ -390,12 +396,14 @@ def test_tweedie_deviance_dispersion_loglihood(weighted):
     mu = regressor.fit(x, y, sample_weight=wgts).predict(x)
     family = regressor._family_instance
 
-    # R bases dispersion on the deviance for log_likelihood
     ll = family.log_likelihood(
         y,
         mu,
         sample_weight=wgts,
-        dispersion=family.deviance(y, mu, sample_weight=wgts) / 5,
+        # R bases dispersion on the deviance for log_likelihood
+        dispersion=family.dispersion(
+            y, mu, sample_weight=wgts, method="deviance", ddof=0
+        ),
     )
 
     np.testing.assert_approx_equal(regressor.coef_[0], 0.1823216)
@@ -443,7 +451,9 @@ def test_binomial_deviance_dispersion_loglihood(weighted):
         y,
         mu,
         sample_weight=wgts,
-        dispersion=family.deviance(y, mu, sample_weight=wgts) / 5,
+        dispersion=family.dispersion(
+            y, mu, sample_weight=wgts, method="deviance", ddof=0
+        ),
     )
 
     np.testing.assert_approx_equal(regressor.coef_[0], -0.4054651)


### PR DESCRIPTION
It should have been `"deviance"` all along, clearly. Also adapted tests to use it.

Closes #427.