### PR TITLE
Preparing for 2.0.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+2.0.1 - 2021-10-11
+------------------
+
+**Bug fix:**
+
+- Fixed pyproject.toml. We now support installing through pip and pep517.
+
 2.0.0 - 2021-10-08
 ------------------
 


### PR DESCRIPTION
PR #454 fixed the pyproject file. This enabled support for pip and pep517. To make it available on pypi, we need a new, clean release.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry
