### PR TITLE
Add pip requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+2.0.3 - 2021-11-05
+------------------
+
+**Other:**
+
+- We are now specifying the run time dependencies in ``setup.py``, so that missing dependencies are automatically installed from PyPI when installing ``glum`` via pip.
+
+
 2.0.2 - 2021-11-03
 ------------------
 
@@ -15,7 +23,7 @@ Changelog
 - Fixed the sign of the log likelihood of the Gaussian distribution (not used for fitting coefficients).
 - Fixed the wide benchmarks which had duplicated columns (categorical and numerical).
 
-** Other:**
+**Other:**
 
 - The CI now builds the wheels and upload to pypi with every new release.
 - Renamed functions checking for qc.matrix compliance to refer to tabmat.

--- a/setup.py
+++ b/setup.py
@@ -73,12 +73,12 @@ setup(
         else ["glum", "glum_benchmarks"],
     ),
     install_requires=[
-        "numpy",
         "joblib",
-        "scipy",
         "numexpr",
-        "scikit-learn>=0.23",
+        "numpy",
         "pandas",
+        "scikit-learn>=0.23",
+        "scipy",
         "tabmat>=3.0.1",
     ],
     entry_points=None

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,15 @@ setup(
         if os.environ.get("CONDA_BUILD")
         else ["glum", "glum_benchmarks"],
     ),
-    install_requires=[],
+    install_requires=[
+        "numpy",
+        "joblib",
+        "scipy",
+        "numexpr",
+        "scikit-learn>=0.23",
+        "pandas",
+        "tabmat>=3.0.1",
+    ],
     entry_points=None
     if os.environ.get("CONDA_BUILD")
     else """


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry

Currently, when we do `pip install glum`, we're not installing run time dependencies. I'm now adding them to setup.py. I'm skipping `tqdm`, because we're treating it as optional:

https://github.com/Quantco/glum/blob/5c06a9067e2d49243c390edd86ca3d41d75257ee/src/glum/_solvers.py#L383-L384

