### PR TITLE
Skip musllinux wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skip_glob = '\.eggs/*,\.git/*,\.venv/*,build/*,dist/*'
 default_section = 'THIRDPARTY'
 
 [tool.cibuildwheel]
-skip = ["cp310-*", "pp*"]
+skip = ["cp310-*", "pp*", "*-musllinux_*"]
 test-requires = ["pytest", "pytest-xdist"]
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
Starting with 2.2.0, cibuildwheel builds wheels for musllinux by default. We will wait until musllinux is supported by numpy before introducing it for glum. See PR #480 for background.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] ~~Added a `CHANGELOG.rst` entry~~ (no need for a changelog since we were not supporting musllinux before)
