### PR TITLE
use oldest-supported-numpy at build time instead of numpy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
 **Other:**
 
 - The CI now runs daily unit tests against the nightly builds of numpy, pandas and scikit-learn.
+- ``oldest-supported-numpy`` is used for build. 
 
 2.0.3 - 2021-11-05
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   'setuptools-scm',
   'wheel',
   'Cython',
-  'numpy',
+  'oldest-supported-numpy',
   'scikit-learn',
 ]
 


### PR DESCRIPTION
Because of ABI backward compatibility, building a package with an old version of numpy will work with a more recent version of numpy. We should then always build glum with the oldest supported version of numpy. This was already the case in tabmat but was overlooked in glum.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
