### PR TITLE
changed exact pins for minimum versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -43,10 +43,10 @@ dependencies:
   - make
   - matplotlib-base
   - nbclassic>=0.2.8
-  - nbsphinx=0.8.3
+  - nbsphinx>=0.8.3
   - openml # used for downloading datasets in the tutorials.
   - shapely # used in docs/tutorials/regularization_housing_data
-  - sphinx=3.5.3
+  - sphinx>=3.5.3
   - sphinx_rtd_theme
   - sphinxcontrib-apidoc
   - statsmodels

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - scikit-learn >= 0.23
   - scipy
   - tqdm
+  - python<3.10
 
   # development tools
   - black


### PR DESCRIPTION
I don't know exactly why we pinned sphinx to a specific version. @tbenthompson maybe you remember?

I think this might solve the problem with the new readthedocs PR.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
