### PR TITLE
[docs] remove python upper bound

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - scikit-learn >= 0.23
   - scipy
   - tqdm
-  - python<3.10
 
   # development tools
   - black


### PR DESCRIPTION
Upstream bug was fixed and readthedocs is now successful without the need to pin python.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] ~~Added a `CHANGELOG.rst` entry~~
