### PR TITLE
Add `diag_fisher` functionality to allow the Hessian to be computed "on the fly"

### DIFF
--- a/diag_fisher_benchmarks.py
+++ b/diag_fisher_benchmarks.py
@@ -1,0 +1,35 @@
+# %%
+
+# %load_ext autoreload
+# %autoreload 2
+
+# %%
+
+import numpy as np
+from libsvmdata import fetch_libsvm
+
+from glum import GeneralizedLinearRegressor
+
+X, y = fetch_libsvm("finance")
+
+# %%
+
+np.random.seed(42)
+cols = np.random.randint(0, X.shape[1], size=(200000))
+
+X_trunc = X[:, cols]
+
+# %%
+
+# NOTE: If you run this script as is, you'll get a memory error because
+# use_sparse_hessian is not yet implemented in this branch (and 200,000 columns is
+# too much for the original code to handle). If you have both the use_sparse_hessian
+# and diag_fisher integrated already, then the following line (with
+# use_sparse_hessian=True) will give you a good idea of how diag_fisher=True compares
+# to diag_fisher=False in terms of runtime.
+
+clf = GeneralizedLinearRegressor(
+    family="gaussian", l1_ratio=1, alpha=0.1, diag_fisher=True
+).fit(X_trunc, y)
+
+# %%

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - numexpr
   - pandas
   - tabmat>=3.0.1
-  - scikit-learn >= 0.23
+  - scikit-learn >=0.23,<1.1.0
   - scipy
   - tqdm
 

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -271,11 +271,11 @@ def enet_coordinate_descent_gram_diag_fisher(
                     Q_active_set_ii[0] = hessian_rows.sum()
                     Q_active_set_ii[1:] = X.transpose_matvec(hessian_rows)
                 else:
-                    cur_col = X[:, active_set_ii - 1]  # Does this reduce memory?
+                    cur_col = X.getcol(active_set_ii - 1)
                     Q_active_set_ii[0] = cur_col.transpose_matvec(hessian_rows)
                     Q_active_set_ii[1:] = X.transpose_matvec(cur_col.multiply(hessian_rows).ravel())
             else:
-                cur_col = X[:, active_set_ii]
+                cur_col = X.getcol(active_set_ii)
                 Q_active_set_ii = X.transpose_matvec(cur_col.multiply(hessian_rows).ravel())
 
             if ii < <unsigned int>intercept:

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -9,7 +9,7 @@
 #
 # cython: boundscheck=False, wraparound=False, cdivision=True
 from libc.math cimport fabs
-cimport numpy as np  # is it a problem that these two imports have same name???
+cimport numpy as np
 import numpy as np
 import numpy.linalg as linalg
 from numpy.math cimport INFINITY
@@ -116,9 +116,8 @@ def enet_coordinate_descent_gram(int[::1] active_set,
         q = X^T y
     """
 
-    # get the data information into easy vars
     cdef unsigned int n_active_features = active_set.shape[0]
-    cdef unsigned int n_features = Q.shape[0]  # are you sure this is CORRECT?
+    cdef unsigned int n_features = Q.shape[0]  # are you sure this is correct?
     # n_features is exactly now the same as n_active_features; should it be q.shape[0]?
     # however, the variable is never used again, so I guess we are okay
 
@@ -142,22 +141,22 @@ def enet_coordinate_descent_gram(int[::1] active_set,
         for n_iter in range(max_iter):
             w_max = 0.0
             d_w_max = 0.0
-            for f_iter in range(n_active_features):  # Loop over coordinates
+            for f_iter in range(n_active_features):
                 if random:
                     active_set_ii = rand_int(n_active_features, rand_r_state)
                 else:
-                    active_set_ii = f_iter  # _ii is an index
-                ii = active_set[active_set_ii]  # odd syntax; gets the active set's row
+                    active_set_ii = f_iter
+                ii = active_set[active_set_ii]
 
-                if ii < <unsigned int>intercept:  # but `intercept` is binary!?
+                if ii < <unsigned int>intercept:
                     P1_ii = 0.0
                 else:
                     P1_ii = P1[ii - intercept]
 
-                if Q[active_set_ii, active_set_ii] == 0.0:  # no need to multiply zeros
+                if Q[active_set_ii, active_set_ii] == 0.0:
                     continue
 
-                w_ii = w[ii]  # Store previous value, the iith element of w
+                w_ii = w[ii]
 
                 qii_temp = q[ii] - w[ii] * Q[active_set_ii, active_set_ii]
                 w[ii] = fsign(-qii_temp) * fmax(fabs(qii_temp) - P1_ii, 0) / Q[active_set_ii, active_set_ii]
@@ -207,15 +206,11 @@ def enet_coordinate_descent_gram(int[::1] active_set,
     return np.asarray(w), norm_min_subgrad, max_min_subgrad, tol, n_iter + 1
 
 def enet_coordinate_descent_gram_diag_fisher(
-                                 #floating[:,:] X, 
-                                 #floating[:] hessian_rows,
-                                 #np.ndarray[np.float64_t, ndim=2] X,
                                  X,
                                  np.ndarray[np.float64_t, ndim=1] hessian_rows,
                                  int[::1] active_set,
                                  floating[::1] w,
                                  floating[::1] P1,
-                                 floating[:,:] Q,
                                  floating[::1] q,
                                  int max_iter, floating tol, object rng,
                                  bint intercept, bint random,
@@ -230,13 +225,13 @@ def enet_coordinate_descent_gram_diag_fisher(
         which amounts to the L1 problem when:
         Q = X^T X (Gram matrix)
         q = X^T y
-    """
-    # The CD that never calculates the entire Hessian matrix; only rows, when they are
-    # necessary.
 
-    # get the data information into easy vars
+        This version, for diag_fisher=True, never calculates the entire Hessian matrix; 
+        only rows, when necessary. The inefficiency here is that we must re-calculate 
+        the rows of Q for every iteration up to max_iter.
+    """
+
     cdef unsigned int n_active_features = active_set.shape[0]
-    # cdef unsigned int n_features = q.shape[0]  # check that this is the same as Q.shape[0]
 
     cdef floating w_ii
     cdef floating P1_ii
@@ -254,111 +249,51 @@ def enet_coordinate_descent_gram_diag_fisher(
     cdef UINT32_t rand_r_state_seed = rng.randint(0, RAND_R_MAX)
     cdef UINT32_t* rand_r_state = &rand_r_state_seed
 
-    #cdef np.ndarray[np.float64_t, dtype=q.dtype] Qj  # will hold rows of the Q matrix
-    # cdef floating[:] Q_active_set_ii = np.empty(n_active_features, dtype=np.float64)
+    # Equivalent to Q[active_set_ii] in the diag_fisher=False version
     cdef np.ndarray[np.float64_t, ndim=1] Q_active_set_ii = np.empty(n_active_features, dtype=np.float64)
-    # is empty bad?
 
-    cdef cur_col  # makes sure we can overwrite this and not take up too much memory?
-
-    # used to check correctness of code - compare with Q from non-diag-fisher
-    # cdef np.ndarray[np.float64_t, ndim=2] Q_check = np.empty((n_active_features, n_active_features), dtype=np.float64)
-
-    # THE inefficiency here is that we must re-calculate the rows of Q for every iteration.
-
-    # with nogil:
+    cdef cur_col  # Does the cdef here (rather than using it as a local variable) reduce memory?
+    
+    # nogil is incompatible with our slicing, numpy, and sparse matrix operations, but 
+    # may be necessary to increase performance
+    # with nogil:  
     for n_iter in range(max_iter):
         w_max = 0.0
         d_w_max = 0.0
-        for f_iter in range(n_active_features):  # Loop over coordinates
+        for f_iter in range(n_active_features):
             if random:
                 active_set_ii = rand_int(n_active_features, rand_r_state)
             else:
-                active_set_ii = f_iter  # _ii is an index
-            ii = active_set[active_set_ii]  # odd syntax; gets an active row
+                active_set_ii = f_iter
+            ii = active_set[active_set_ii]
 
-            # remember, Q hasn't been created yet.
-            # and the only row we need for this iteration is Q[active_set_ii]
-            # also remember, sandwich product is between data.X, state.hessian_rows
-            # only use first column of X in the X^T part of the sandwich
-
-            # if intercept == 1:  # maybe this should go into the next if statement?
-                # Q_active_set_ii[0] = hessian_rows.sum()
-                # this is perfectly valid because hessian_rows has length 16087
-
-            if active_set[0] < <unsigned int>intercept:
+            # Check logic here
+            if active_set[0] < <unsigned int>intercept:  
                 if ii == 0:
                     Q_active_set_ii[0] = hessian_rows.sum()
                     Q_active_set_ii[1:] = X.transpose_matvec(hessian_rows)
-                    # Q_active_set_ii[1:] = np.matmul(hessian_rows, X)  
                 else:
-                    cur_col = X[:, active_set_ii - 1]
+                    cur_col = X[:, active_set_ii - 1]  # Does this reduce memory?
                     Q_active_set_ii[0] = cur_col.transpose_matvec(hessian_rows)
                     Q_active_set_ii[1:] = X.transpose_matvec(cur_col.multiply(hessian_rows).ravel())
-
-                    # Q_active_set_ii[0] = X[:, active_set_ii - 1].transpose_matvec(hessian_rows)
-                    # Q_active_set_ii[1:] = X.transpose_matvec(X[:, active_set_ii - 1].multiply(hessian_rows).ravel())
-
-                    # Q_active_set_ii[1:] = X.transpose_matvec(hessian_rows * X[:, active_set_ii - 1].A.ravel())
-                    # Q_active_set_ii[1:] = X.transpose_matvec(hessian_rows * X.A[:, active_set_ii - 1]) 
-                    # Q_active_set_ii[0] = np.dot(hessian_rows, X[:, active_set_ii - 1])
-                    # Q_active_set_ii[1:] = np.matmul((hessian_rows * X[:, active_set_ii - 1]), X)  # use matvec
-
-            # if ii < <unsigned int>intercept:
-            #     # Q_active_set_ii[1:] = np.matmul(hessian_rows, X[:, 1:])
-            #     # Q_active_set_ii[0] = hessian_rows.sum()
-            #     Q_active_set_ii[1:] = np.matmul(hessian_rows, X)
-
-            # the next condition in the original code checks for sparseness.
-            # we won't worry about that here. but we will have to go elem by elem
-                # actually no, we don't have to go elem by elem. Cython can handle.
-            # do i have to worry about intercept term? or does X already ignore it?
-
-            # what about the active features? do we only need to multiply by those?
-            # correct. i believe we only need to multiply by those
-            # so X can actually be passed in as X[(active_set_ii) cartesian product (active_set_ii)], right?
-            # the only problem is that it would mess up the active_set_ii / active_set_jj logic...
-
-            # NB! We care about the intercept column as well, and must treat differently.
-            # does feature_list in sklearnfork include the intercept column?
             else:
                 cur_col = X[:, active_set_ii]
                 Q_active_set_ii = X.transpose_matvec(cur_col.multiply(hessian_rows).ravel())
 
-                # Q_active_set_ii = X.transpose_matvec(hessian_rows * X[:, active_set_ii].A.ravel())
-                # Q_active_set_ii = X.transpose_matvec(hessian_rows * X.A[:, active_set_ii]) 
-                # Q_active_set_ii = np.matmul((hessian_rows * X[:, active_set_ii]), X)
-                # Q_active_set_ii[intercept:] = np.matmul((hessian_rows * X[:, active_set_ii - intercept]), X)
-                # Q_active_set_ii[intercept:] = np.matmul((hessian_rows * X[:, active_set_ii]), X[:, intercept:])
-                # CHECK that we've covered all the cases!!!!!
-
-
-                # Q_active_set_ii[intercept:] = np.matmul((hessian_rows * X[:, intercept + active_set_ii]), X)
-
-            # Q_check[active_set_ii] = Q_active_set_ii  # for checking correctness
-
-            # for col_idx in range(X.shape[1]):
-            #     for row_idx in range(X.shape[0]):
-            #         Q_active_set_ii[intercept + col_idx] = <array multiplication>
-
-            # the next if statement checks for P2, but we're only using this for L1
-            # regularization, so we don't need to worry about it. and that's all!
-
-            # If the above works, can merge the following into the above if-else!!!!
-            if ii < <unsigned int>intercept:  # equiv. to (ii=0 and intercept=1)
+            if ii < <unsigned int>intercept:
                 P1_ii = 0.0
             else:
                 P1_ii = P1[ii - intercept]
 
-            if Q_active_set_ii[active_set_ii] == 0.0:  # no need to multiply zeros
+            if Q_active_set_ii[active_set_ii] == 0.0:
                 continue
 
-            w_ii = w[ii]  # Store previous value, the iith element of w
+            w_ii = w[ii]
 
-            qii_temp = q[ii] - w[ii] * Q_active_set_ii[active_set_ii]  ##
+            qii_temp = q[ii] - w[ii] * Q_active_set_ii[active_set_ii]
             w[ii] = fsign(-qii_temp) * fmax(fabs(qii_temp) - P1_ii, 0) / Q_active_set_ii[active_set_ii]
 
-            if ii >= <unsigned int>intercept: # this is big-brain logic
+            if ii >= <unsigned int>intercept:
                 if has_lower_bounds:
                     if w[ii] < lower_bounds[ii - intercept]:
                         w[ii] = lower_bounds[ii - intercept]
@@ -370,7 +305,6 @@ def enet_coordinate_descent_gram_diag_fisher(
                 # q +=  (w[ii] - w_ii) * Q[ii] # Update q = X.T (X w - y)
                 for active_set_jj in range(n_active_features):
                     jj = active_set[active_set_jj]
-                    # this is equivalent to A += Bj * z
                     q[jj] += (w[ii] - w_ii) * Q_active_set_ii[active_set_jj]
 
             # update the maximum absolute coefficient update
@@ -403,113 +337,6 @@ def enet_coordinate_descent_gram_diag_fisher(
 
     return np.asarray(w), norm_min_subgrad, max_min_subgrad, tol, n_iter + 1 # , Q_check
 
-def enet_coordinate_descent_gram_diag_only(int[::1] active_set,
-                                 floating[::1] w,
-                                 floating[::1] P1,
-                                 floating[:,:] Q,
-                                 floating[::1] q,
-                                 int max_iter, floating tol, object rng,
-                                 bint intercept, bint random,
-                                 bint has_lower_bounds,
-                                 floating[:] lower_bounds,
-                                 bint has_upper_bounds,
-                                 floating[:] upper_bounds):
-    """Cython version of the coordinate descent algorithm
-        for Elastic-Net regression
-        We minimize
-        (1/2) * w^T Q w - q^T w + P1 norm(w, 1)
-        which amount to the Elastic-Net problem when:
-        Q = X^T X (Gram matrix)
-        q = X^T y
-    """
-    # In this version, we don't access the off-diagonal elements. And see what happens.
-
-    # get the data information into easy vars
-    cdef unsigned int n_active_features = active_set.shape[0]
-    cdef unsigned int n_features = Q.shape[0]
-
-    cdef floating w_ii
-    cdef floating P1_ii
-    cdef floating qii_temp
-    cdef floating d_w_max
-    cdef floating w_max
-    cdef floating d_w_ii
-    cdef floating d_w_tol = tol
-    cdef floating norm_min_subgrad = 0
-    cdef floating max_min_subgrad
-    cdef unsigned int active_set_ii, active_set_jj
-    cdef unsigned int ii, jj
-    cdef int n_iter = 0
-    cdef unsigned int f_iter
-    cdef UINT32_t rand_r_state_seed = rng.randint(0, RAND_R_MAX)
-    cdef UINT32_t* rand_r_state = &rand_r_state_seed
-
-    with nogil:
-        for n_iter in range(max_iter):
-            w_max = 0.0
-            d_w_max = 0.0
-            for f_iter in range(n_active_features):  # Loop over coordinates
-                if random:
-                    active_set_ii = rand_int(n_active_features, rand_r_state)
-                else:
-                    active_set_ii = f_iter
-                ii = active_set[active_set_ii]
-
-                if ii < <unsigned int>intercept:
-                    P1_ii = 0.0
-                else:
-                    P1_ii = P1[ii - intercept]
-
-                if Q[active_set_ii, active_set_ii] == 0.0:
-                    continue
-
-                w_ii = w[ii]  # Store previous value
-
-                qii_temp = q[ii] - w[ii] * Q[active_set_ii, active_set_ii]
-                w[ii] = fsign(-qii_temp) * fmax(fabs(qii_temp) - P1_ii, 0) / Q[active_set_ii, active_set_ii]
-
-                if ii >= <unsigned int>intercept:
-                    if has_lower_bounds:
-                        if w[ii] < lower_bounds[ii - intercept]:
-                            w[ii] = lower_bounds[ii - intercept]
-                    if has_upper_bounds:
-                        if w[ii] > upper_bounds[ii - intercept]:
-                            w[ii] = upper_bounds[ii - intercept]
-
-                # if w[ii] != 0.0 or w_ii != 0.0:
-                #     for active_set_jj in range(n_active_features):
-                #         jj = active_set[active_set_jj]
-                #         q[jj] += (w[ii] - w_ii) * Q[active_set_ii, active_set_jj]
-
-                # update the maximum absolute coefficient update
-                d_w_ii = fabs(w[ii] - w_ii)
-                if d_w_ii > d_w_max:
-                    d_w_max = d_w_ii
-
-                if fabs(w[ii]) > w_max:
-                    w_max = fabs(w[ii])
-
-            if w_max == 0.0 or d_w_max / w_max < d_w_tol or n_iter == max_iter - 1:
-                # the biggest coordinate update of this iteration was smaller than
-                # the tolerance: check the minimum norm subgradient as the
-                # ultimate stopping criterion
-                cython_norm_min_subgrad(
-                    active_set,
-                    w, q, P1, intercept,
-                    has_lower_bounds, lower_bounds, has_upper_bounds, upper_bounds,
-                    &norm_min_subgrad, &max_min_subgrad
-                )
-                if norm_min_subgrad <= tol:
-                    break
-        else:
-            # for/else, runs if for doesn't end with a `break`
-            with gil:
-                warnings.warn("Coordinate descent did not converge. You might want to "
-                              "increase the number of iterations. Minimum norm "
-                              "subgradient: {}, tolerance: {}".format(norm_min_subgrad, tol),
-                              ConvergenceWarning)
-
-    return np.asarray(w), norm_min_subgrad, max_min_subgrad, tol, n_iter + 1
 
 cdef void cython_norm_min_subgrad(
     int[::1] active_set,

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -9,7 +9,7 @@
 #
 # cython: boundscheck=False, wraparound=False, cdivision=True
 from libc.math cimport fabs
-cimport numpy as np
+cimport numpy as np  # is it a problem that these two imports have same name???
 import numpy as np
 import numpy.linalg as linalg
 from numpy.math cimport INFINITY
@@ -111,10 +111,300 @@ def enet_coordinate_descent_gram(int[::1] active_set,
         for Elastic-Net regression
         We minimize
         (1/2) * w^T Q w - q^T w + P1 norm(w, 1)
+        which amounts to the L1 problem when:
+        Q = X^T X (Gram matrix)
+        q = X^T y
+    """
+
+    # get the data information into easy vars
+    cdef unsigned int n_active_features = active_set.shape[0]
+    cdef unsigned int n_features = Q.shape[0]  # are you sure this is CORRECT?
+    # n_features is exactly now the same as n_active_features; should it be q.shape[0]?
+    # however, the variable is never used again, so I guess we are okay
+
+    cdef floating w_ii
+    cdef floating P1_ii
+    cdef floating qii_temp
+    cdef floating d_w_max
+    cdef floating w_max
+    cdef floating d_w_ii
+    cdef floating d_w_tol = tol
+    cdef floating norm_min_subgrad = 0
+    cdef floating max_min_subgrad
+    cdef unsigned int active_set_ii, active_set_jj
+    cdef unsigned int ii, jj
+    cdef int n_iter = 0
+    cdef unsigned int f_iter
+    cdef UINT32_t rand_r_state_seed = rng.randint(0, RAND_R_MAX)
+    cdef UINT32_t* rand_r_state = &rand_r_state_seed
+
+    with nogil:
+        for n_iter in range(max_iter):
+            w_max = 0.0
+            d_w_max = 0.0
+            for f_iter in range(n_active_features):  # Loop over coordinates
+                if random:
+                    active_set_ii = rand_int(n_active_features, rand_r_state)
+                else:
+                    active_set_ii = f_iter  # _ii is an index
+                ii = active_set[active_set_ii]  # odd syntax; gets the active set's row
+
+                if ii < <unsigned int>intercept:  # but `intercept` is binary!?
+                    P1_ii = 0.0
+                else:
+                    P1_ii = P1[ii - intercept]
+
+                if Q[active_set_ii, active_set_ii] == 0.0:  # no need to multiply zeros
+                    continue
+
+                w_ii = w[ii]  # Store previous value, the iith element of w
+
+                qii_temp = q[ii] - w[ii] * Q[active_set_ii, active_set_ii]
+                w[ii] = fsign(-qii_temp) * fmax(fabs(qii_temp) - P1_ii, 0) / Q[active_set_ii, active_set_ii]
+
+                if ii >= <unsigned int>intercept:
+                    if has_lower_bounds:
+                        if w[ii] < lower_bounds[ii - intercept]:
+                            w[ii] = lower_bounds[ii - intercept]
+                    if has_upper_bounds:
+                        if w[ii] > upper_bounds[ii - intercept]:
+                            w[ii] = upper_bounds[ii - intercept]
+
+                if w[ii] != 0.0 or w_ii != 0.0:
+                    # q +=  (w[ii] - w_ii) * Q[ii] # Update q = X.T (X w - y)
+                    for active_set_jj in range(n_active_features):
+                        jj = active_set[active_set_jj]
+                        q[jj] += (w[ii] - w_ii) * Q[active_set_ii, active_set_jj]
+
+                # update the maximum absolute coefficient update
+                d_w_ii = fabs(w[ii] - w_ii)
+                if d_w_ii > d_w_max:
+                    d_w_max = d_w_ii
+
+                if fabs(w[ii]) > w_max:
+                    w_max = fabs(w[ii])
+
+            if w_max == 0.0 or d_w_max / w_max < d_w_tol or n_iter == max_iter - 1:
+                # the biggest coordinate update of this iteration was smaller than
+                # the tolerance: check the minimum norm subgradient as the
+                # ultimate stopping criterion
+                cython_norm_min_subgrad(
+                    active_set,
+                    w, q, P1, intercept,
+                    has_lower_bounds, lower_bounds, has_upper_bounds, upper_bounds,
+                    &norm_min_subgrad, &max_min_subgrad
+                )
+                if norm_min_subgrad <= tol:
+                    break
+        else:
+            # for/else, runs if for doesn't end with a `break`
+            with gil:
+                warnings.warn("Coordinate descent did not converge. You might want to "
+                              "increase the number of iterations. Minimum norm "
+                              "subgradient: {}, tolerance: {}".format(norm_min_subgrad, tol),
+                              ConvergenceWarning)
+
+    return np.asarray(w), norm_min_subgrad, max_min_subgrad, tol, n_iter + 1
+
+def enet_coordinate_descent_gram_diag_fisher(
+                                 #floating[:,:] X, 
+                                 #floating[:] hessian_rows,
+                                 np.ndarray[np.float64_t, ndim=2] X,
+                                 np.ndarray[np.float64_t, ndim=1] hessian_rows,
+                                 int[::1] active_set,
+                                 floating[::1] w,
+                                 floating[::1] P1,
+                                 floating[:,:] Q,
+                                 floating[::1] q,
+                                 int max_iter, floating tol, object rng,
+                                 bint intercept, bint random,
+                                 bint has_lower_bounds,
+                                 floating[:] lower_bounds,
+                                 bint has_upper_bounds,
+                                 floating[:] upper_bounds):
+    """Cython version of the coordinate descent algorithm
+        for Elastic-Net regression
+        We minimize
+        (1/2) * w^T Q w - q^T w + P1 norm(w, 1)
+        which amounts to the L1 problem when:
+        Q = X^T X (Gram matrix)
+        q = X^T y
+    """
+    # The CD that never calculates the entire Hessian matrix; only rows, when they are
+    # necessary.
+
+    # get the data information into easy vars
+    cdef unsigned int n_active_features = active_set.shape[0]
+    # cdef unsigned int n_features = q.shape[0]  # check that this is the same as Q.shape[0]
+
+    cdef floating w_ii
+    cdef floating P1_ii
+    cdef floating qii_temp
+    cdef floating d_w_max
+    cdef floating w_max
+    cdef floating d_w_ii
+    cdef floating d_w_tol = tol
+    cdef floating norm_min_subgrad = 0
+    cdef floating max_min_subgrad
+    cdef unsigned int active_set_ii, active_set_jj
+    cdef unsigned int ii, jj
+    cdef int n_iter = 0
+    cdef unsigned int f_iter
+    cdef UINT32_t rand_r_state_seed = rng.randint(0, RAND_R_MAX)
+    cdef UINT32_t* rand_r_state = &rand_r_state_seed
+
+    #cdef np.ndarray[np.float64_t, dtype=q.dtype] Qj  # will hold rows of the Q matrix
+    # cdef floating[:] Q_active_set_ii = np.empty(n_active_features, dtype=np.float64)
+    cdef np.ndarray[np.float64_t, ndim=1] Q_active_set_ii = np.empty(n_active_features, dtype=np.float64)
+    # is empty bad?
+
+    # used to check correctness of code - compare with Q from non-diag-fisher
+    cdef np.ndarray[np.float64_t, ndim=2] Q_check = np.empty((n_active_features, n_active_features), dtype=np.float64)
+
+    # THE inefficiency here is that we must re-calculate the rows of Q for ever iteration.
+
+    # with nogil:
+    for n_iter in range(max_iter):
+        w_max = 0.0
+        d_w_max = 0.0
+        for f_iter in range(n_active_features):  # Loop over coordinates
+            if random:
+                active_set_ii = rand_int(n_active_features, rand_r_state)
+            else:
+                active_set_ii = f_iter  # _ii is an index
+            ii = active_set[active_set_ii]  # odd syntax; gets an active row
+
+            # remember, Q hasn't been created yet.
+            # and the only row we need for this iteration is Q[active_set_ii]
+            # also remember, sandwich product is between data.X, state.hessian_rows
+            # only use first column of X in the X^T part of the sandwich
+
+            # if intercept == 1:  # maybe this should go into the next if statement?
+                # Q_active_set_ii[0] = hessian_rows.sum()
+                # this is perfectly valid because hessian_rows has length 16087
+
+            if active_set[0] < <unsigned int>intercept:
+                if ii == 0:
+                    Q_active_set_ii[0] = hessian_rows.sum()
+                    Q_active_set_ii[1:] = np.matmul(hessian_rows, X)
+                else:
+                    Q_active_set_ii[0] = np.dot(hessian_rows, X[:, active_set_ii - 1])
+                    Q_active_set_ii[1:] = np.matmul((hessian_rows * X[:, active_set_ii - 1]), X)
+
+            # if ii < <unsigned int>intercept:
+            #     # Q_active_set_ii[1:] = np.matmul(hessian_rows, X[:, 1:])
+            #     # Q_active_set_ii[0] = hessian_rows.sum()
+            #     Q_active_set_ii[1:] = np.matmul(hessian_rows, X)
+
+            # the next condition in the original code checks for sparseness.
+            # we won't worry about that here. but we will have to go elem by elem
+                # actually no, we don't have to go elem by elem. Cython can handle.
+            # do i have to worry about intercept term? or does X already ignore it?
+
+            # what about the active features? do we only need to multiply by those?
+            # correct. i believe we only need to multiply by those
+            # so X can actually be passed in as X[(active_set_ii) cartesian product (active_set_ii)], right?
+            # the only problem is that it would mess up the active_set_ii / active_set_jj logic...
+
+            # NB! We care about the intercept column as well, and must treat differently.
+            # does feature_list in sklearnfork include the intercept column?
+            else:
+                Q_active_set_ii = np.matmul((hessian_rows * X[:, active_set_ii]), X)
+                # Q_active_set_ii[intercept:] = np.matmul((hessian_rows * X[:, active_set_ii - intercept]), X)
+                # Q_active_set_ii[intercept:] = np.matmul((hessian_rows * X[:, active_set_ii]), X[:, intercept:])
+                # CHECK that we've covered all the cases!!!!!
+
+
+                # Q_active_set_ii[intercept:] = np.matmul((hessian_rows * X[:, intercept + active_set_ii]), X)
+
+            Q_check[active_set_ii] = Q_active_set_ii
+
+            # for col_idx in range(X.shape[1]):
+            #     for row_idx in range(X.shape[0]):
+            #         Q_active_set_ii[intercept + col_idx] = <array multiplication>
+
+            # the next if statement checks for P2, but we're only using this for L1
+            # regularization, so we don't need to worry about it. and that's all!
+
+            # If the above works, can merge the following into the above if-else!!!!
+            if ii < <unsigned int>intercept:  # equiv. to (ii=0 and intercept=1)
+                P1_ii = 0.0
+            else:
+                P1_ii = P1[ii - intercept]
+
+            if Q_active_set_ii[active_set_ii] == 0.0:  # no need to multiply zeros
+                continue
+
+            w_ii = w[ii]  # Store previous value, the iith element of w
+
+            qii_temp = q[ii] - w[ii] * Q_active_set_ii[active_set_ii]  ##
+            w[ii] = fsign(-qii_temp) * fmax(fabs(qii_temp) - P1_ii, 0) / Q_active_set_ii[active_set_ii]
+
+            if ii >= <unsigned int>intercept: # this is big-brain logic
+                if has_lower_bounds:
+                    if w[ii] < lower_bounds[ii - intercept]:
+                        w[ii] = lower_bounds[ii - intercept]
+                if has_upper_bounds:
+                    if w[ii] > upper_bounds[ii - intercept]:
+                        w[ii] = upper_bounds[ii - intercept]
+
+            if w[ii] != 0.0 or w_ii != 0.0:
+                # q +=  (w[ii] - w_ii) * Q[ii] # Update q = X.T (X w - y)
+                for active_set_jj in range(n_active_features):
+                    jj = active_set[active_set_jj]
+                    # this is equivalent to A += Bj * z
+                    q[jj] += (w[ii] - w_ii) * Q_active_set_ii[active_set_jj]
+
+            # update the maximum absolute coefficient update
+            d_w_ii = fabs(w[ii] - w_ii)
+            if d_w_ii > d_w_max:
+                d_w_max = d_w_ii
+
+            if fabs(w[ii]) > w_max:
+                w_max = fabs(w[ii])
+
+        if w_max == 0.0 or d_w_max / w_max < d_w_tol or n_iter == max_iter - 1:
+            # the biggest coordinate update of this iteration was smaller than
+            # the tolerance: check the minimum norm subgradient as the
+            # ultimate stopping criterion
+            cython_norm_min_subgrad(
+                active_set,
+                w, q, P1, intercept,
+                has_lower_bounds, lower_bounds, has_upper_bounds, upper_bounds,
+                &norm_min_subgrad, &max_min_subgrad
+            )
+            if norm_min_subgrad <= tol:
+                break
+    else:
+        # for/else, runs if for doesn't end with a `break`
+        # with gil:
+        warnings.warn("Coordinate descent did not converge. You might want to "
+                            "increase the number of iterations. Minimum norm "
+                            "subgradient: {}, tolerance: {}".format(norm_min_subgrad, tol),
+                            ConvergenceWarning)
+
+    return np.asarray(w), norm_min_subgrad, max_min_subgrad, tol, n_iter + 1, Q_check
+
+def enet_coordinate_descent_gram_diag_only(int[::1] active_set,
+                                 floating[::1] w,
+                                 floating[::1] P1,
+                                 floating[:,:] Q,
+                                 floating[::1] q,
+                                 int max_iter, floating tol, object rng,
+                                 bint intercept, bint random,
+                                 bint has_lower_bounds,
+                                 floating[:] lower_bounds,
+                                 bint has_upper_bounds,
+                                 floating[:] upper_bounds):
+    """Cython version of the coordinate descent algorithm
+        for Elastic-Net regression
+        We minimize
+        (1/2) * w^T Q w - q^T w + P1 norm(w, 1)
         which amount to the Elastic-Net problem when:
         Q = X^T X (Gram matrix)
         q = X^T y
     """
+    # In this version, we don't access the off-diagonal elements. And see what happens.
 
     # get the data information into easy vars
     cdef unsigned int n_active_features = active_set.shape[0]
@@ -168,11 +458,10 @@ def enet_coordinate_descent_gram(int[::1] active_set,
                         if w[ii] > upper_bounds[ii - intercept]:
                             w[ii] = upper_bounds[ii - intercept]
 
-                if w[ii] != 0.0 or w_ii != 0.0:
-                    # q +=  (w[ii] - w_ii) * Q[ii] # Update q = X.T (X w - y)
-                    for active_set_jj in range(n_active_features):
-                        jj = active_set[active_set_jj]
-                        q[jj] += (w[ii] - w_ii) * Q[active_set_ii, active_set_jj]
+                # if w[ii] != 0.0 or w_ii != 0.0:
+                #     for active_set_jj in range(n_active_features):
+                #         jj = active_set[active_set_jj]
+                #         q[jj] += (w[ii] - w_ii) * Q[active_set_ii, active_set_jj]
 
                 # update the maximum absolute coefficient update
                 d_w_ii = fabs(w[ii] - w_ii)

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -111,7 +111,7 @@ def enet_coordinate_descent_gram(int[::1] active_set,
         for Elastic-Net regression
         We minimize
         (1/2) * w^T Q w - q^T w + P1 norm(w, 1)
-        which amounts to the Elastic-Net problem when:
+        which amount to the Elastic-Net problem when:
         Q = X^T X (Gram matrix)
         q = X^T y
     """

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -117,9 +117,6 @@ def enet_coordinate_descent_gram(int[::1] active_set,
     """
 
     cdef unsigned int n_active_features = active_set.shape[0]
-    cdef unsigned int n_features = Q.shape[0]  # are you sure this is correct?
-    # n_features is exactly now the same as n_active_features; should it be q.shape[0]?
-    # however, the variable is never used again, so I guess we are okay
 
     cdef floating w_ii
     cdef floating P1_ii
@@ -141,7 +138,7 @@ def enet_coordinate_descent_gram(int[::1] active_set,
         for n_iter in range(max_iter):
             w_max = 0.0
             d_w_max = 0.0
-            for f_iter in range(n_active_features):
+            for f_iter in range(n_active_features):  # Loop over coordinates
                 if random:
                     active_set_ii = rand_int(n_active_features, rand_r_state)
                 else:
@@ -227,8 +224,8 @@ def enet_coordinate_descent_gram_diag_fisher(
         q = X^T y
 
         This version, for diag_fisher=True, never calculates the entire Hessian matrix; 
-        only rows, when necessary. The inefficiency here is that we must re-calculate 
-        the rows of Q for every iteration up to max_iter.
+        only rows, when necessary. This requires less memory. However, the inefficiency 
+        is that we must re-calculate the rows of Q for every iteration up to max_iter.
     """
 
     cdef unsigned int n_active_features = active_set.shape[0]
@@ -260,14 +257,13 @@ def enet_coordinate_descent_gram_diag_fisher(
     for n_iter in range(max_iter):
         w_max = 0.0
         d_w_max = 0.0
-        for f_iter in range(n_active_features):
+        for f_iter in range(n_active_features):  # Loop over coordinates
             if random:
                 active_set_ii = rand_int(n_active_features, rand_r_state)
             else:
                 active_set_ii = f_iter
             ii = active_set[active_set_ii]
 
-            # Check logic here
             if active_set[0] < <unsigned int>intercept:  
                 if ii == 0:
                     Q_active_set_ii[0] = hessian_rows.sum()
@@ -335,7 +331,7 @@ def enet_coordinate_descent_gram_diag_fisher(
                             "subgradient: {}, tolerance: {}".format(norm_min_subgrad, tol),
                             ConvergenceWarning)
 
-    return np.asarray(w), norm_min_subgrad, max_min_subgrad, tol, n_iter + 1 # , Q_check
+    return np.asarray(w), norm_min_subgrad, max_min_subgrad, tol, n_iter + 1
 
 
 cdef void cython_norm_min_subgrad(

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -111,11 +111,12 @@ def enet_coordinate_descent_gram(int[::1] active_set,
         for Elastic-Net regression
         We minimize
         (1/2) * w^T Q w - q^T w + P1 norm(w, 1)
-        which amounts to the L1 problem when:
+        which amounts to the Elastic-Net problem when:
         Q = X^T X (Gram matrix)
         q = X^T y
     """
 
+    # get the data information into easy vars
     cdef unsigned int n_active_features = active_set.shape[0]
 
     cdef floating w_ii
@@ -153,7 +154,7 @@ def enet_coordinate_descent_gram(int[::1] active_set,
                 if Q[active_set_ii, active_set_ii] == 0.0:
                     continue
 
-                w_ii = w[ii]
+                w_ii = w[ii]  # Store previous value
 
                 qii_temp = q[ii] - w[ii] * Q[active_set_ii, active_set_ii]
                 w[ii] = fsign(-qii_temp) * fmax(fabs(qii_temp) - P1_ii, 0) / Q[active_set_ii, active_set_ii]
@@ -228,6 +229,7 @@ def enet_coordinate_descent_gram_diag_fisher(
         is that we must re-calculate the rows of Q for every iteration up to max_iter.
     """
 
+    # get the data information into easy vars
     cdef unsigned int n_active_features = active_set.shape[0]
 
     cdef floating w_ii
@@ -284,7 +286,7 @@ def enet_coordinate_descent_gram_diag_fisher(
             if Q_active_set_ii[active_set_ii] == 0.0:
                 continue
 
-            w_ii = w[ii]
+            w_ii = w[ii]  # Store previous value
 
             qii_temp = q[ii] - w[ii] * Q_active_set_ii[active_set_ii]
             w[ii] = fsign(-qii_temp) * fmax(fabs(qii_temp) - P1_ii, 0) / Q_active_set_ii[active_set_ii]

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -672,7 +672,8 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         A_ineq: Optional[np.ndarray] = None,
         b_ineq: Optional[np.ndarray] = None,
         force_all_finite: bool = True,
-        diag_fisher=False,
+        use_sparse_hessian: bool = True,
+        diag_fisher: bool = False,
     ):
         self.l1_ratio = l1_ratio
         self.P1 = P1
@@ -702,6 +703,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         self.A_ineq = A_ineq
         self.b_ineq = b_ineq
         self.force_all_finite = force_all_finite
+        self.use_sparse_hessian = use_sparse_hessian
         self.diag_fisher = diag_fisher
 
     @property
@@ -971,6 +973,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 lower_bounds=lower_bounds,
                 upper_bounds=upper_bounds,
                 verbose=self.verbose > 0,
+                use_sparse_hessian=self.use_sparse_hessian,
                 diag_fisher=self.diag_fisher,
             )
             if self._solver == "irls-ls":
@@ -979,7 +982,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 )
             # 4.2 coordinate descent ##############################################
             elif self._solver == "irls-cd":
-                # [Alan] This is the case we're concerned with for wide problems.
+                # This is the case we're concerned with for wide problems.
                 coef, self.n_iter_, self._n_cycles, self.diagnostics_ = _irls_solver(
                     _cd_solver, coef, irls_data
                 )
@@ -2092,6 +2095,12 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
         ``A_ineq w <= b_ineq``. Refer to the documentation of ``A_ineq`` for
         details.
 
+    use_sparse_hessian : boolean, optional, (default=True)
+        If ``True``, stores the current state of the Hessian as a sparse COO matrix.
+        If ``False``, stores as a dense matrix of size `num_cols` x `num_cols`, where
+        `num_cols` is the number of columns in the data X. Use ``True`` to avoid memory
+        issues when working with extremely wide data.
+
     diag_fisher : boolean, optional, (default=False)
         Only relevant for solver 'cd' (see also ``start_params='guess'``).
         If ``False``, the full Fisher matrix (expected Hessian) is computed in
@@ -2183,7 +2192,8 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
         A_ineq: Optional[np.ndarray] = None,
         b_ineq: Optional[np.ndarray] = None,
         force_all_finite: bool = True,
-        diag_fisher=False,
+        use_sparse_hessian: bool = True,
+        diag_fisher: bool = False,
     ):
         self.alphas = alphas
         self.alpha = alpha
@@ -2216,6 +2226,7 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
             A_ineq=A_ineq,
             b_ineq=b_ineq,
             force_all_finite=force_all_finite,
+            use_sparse_hessian=use_sparse_hessian,
             diag_fisher=diag_fisher,
         )
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -672,7 +672,6 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         A_ineq: Optional[np.ndarray] = None,
         b_ineq: Optional[np.ndarray] = None,
         force_all_finite: bool = True,
-        use_sparse_hessian: bool = True,
         diag_fisher: bool = False,
     ):
         self.l1_ratio = l1_ratio
@@ -703,7 +702,6 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         self.A_ineq = A_ineq
         self.b_ineq = b_ineq
         self.force_all_finite = force_all_finite
-        self.use_sparse_hessian = use_sparse_hessian
         self.diag_fisher = diag_fisher
 
     @property
@@ -973,7 +971,6 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 lower_bounds=lower_bounds,
                 upper_bounds=upper_bounds,
                 verbose=self.verbose > 0,
-                use_sparse_hessian=self.use_sparse_hessian,
                 diag_fisher=self.diag_fisher,
             )
             if self._solver == "irls-ls":
@@ -2095,12 +2092,6 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
         ``A_ineq w <= b_ineq``. Refer to the documentation of ``A_ineq`` for
         details.
 
-    use_sparse_hessian : boolean, optional, (default=True)
-        If ``True``, stores the current state of the Hessian as a sparse COO matrix.
-        If ``False``, stores as a dense matrix of size `num_cols` x `num_cols`, where
-        `num_cols` is the number of columns in the data X. Use ``True`` to avoid memory
-        issues when working with extremely wide data.
-
     diag_fisher : boolean, optional, (default=False)
         Only relevant for solver 'cd' (see also ``start_params='guess'``).
         If ``False``, the full Fisher matrix (expected Hessian) is computed in
@@ -2192,7 +2183,6 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
         A_ineq: Optional[np.ndarray] = None,
         b_ineq: Optional[np.ndarray] = None,
         force_all_finite: bool = True,
-        use_sparse_hessian: bool = True,
         diag_fisher: bool = False,
     ):
         self.alphas = alphas
@@ -2226,7 +2216,6 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
             A_ineq=A_ineq,
             b_ineq=b_ineq,
             force_all_finite=force_all_finite,
-            use_sparse_hessian=use_sparse_hessian,
             diag_fisher=diag_fisher,
         )
 

--- a/src/glum/_solvers.py
+++ b/src/glum/_solvers.py
@@ -60,13 +60,16 @@ def _least_squares_solver(state, data, hessian):
 def _cd_solver(state, data, active_hessian, diag_fisher=False):
     if diag_fisher:
         if data.fit_intercept:
-            if 0 in state.active_set:
+            # the following line should be equivalent to the if/else below it
+            # X_active = data.X[:, state.active_set[(state.active_set[0] == 0):] - 1].A
+            if state.active_set[0] == 0:
                 # remove the zero, subtract one from everything else
-                X_active = data.X[:, state.active_set[1:] - 1].A
+                X_active = data.X[:, state.active_set[1:] - 1]  # .A
             else:
-                X_active = data.X[:, state.active_set - 1].A
+                X_active = data.X[:, state.active_set - 1]  # .A
         else:
-            X_active = data.X[:, state.active_set].A
+            # for some reason, active_set here is massive (everything!)
+            X_active = data.X[:, state.active_set]  # .A
         # instead of passing in data.X, we should pass in
         # but remember! X is sparse. But X is not necessarily square
         # we may need active rows and columns
@@ -77,7 +80,7 @@ def _cd_solver(state, data, active_hessian, diag_fisher=False):
             _,
             _,
             n_cycles,
-            Q_check,
+            # Q_check,
         ) = enet_coordinate_descent_gram_diag_fisher(
             X_active,  # new
             state.hessian_rows,  # new

--- a/src/glum/_solvers.py
+++ b/src/glum/_solvers.py
@@ -175,7 +175,6 @@ def update_hessian(state, data, active_set):
         # 2) use all the rows
         # 3) Include the P2 components
         # 4) just like an update, we only update the active_set
-
         hessian_init = build_hessian_delta(
             data.X,
             state.hessian_rows,
@@ -184,25 +183,9 @@ def update_hessian(state, data, active_set):
             np.arange(data.X.shape[0], dtype=np.int32),
             active_set,
         )
-
-        # In the sparse Hessian case, state.hessian is a coo_matrix.
-        # hessian_init is np array of size active_set.shape[0] x active_set.shape[0];
-        # we can convert this to a coo_matrix and simply add it to the state.hessian
-        if data.use_sparse_hessian:
-            coo_data = hessian_init.ravel(order="C")
-            coo_rows = np.repeat(active_set, active_set.shape[0])
-            coo_cols = np.tile(active_set, active_set.shape[0])
-
-            state.hessian = sparse.coo_matrix(
-                (coo_data, (coo_rows, coo_cols)),
-                shape=(state.coef.shape[0], state.coef.shape[0]),
-            )
-        else:
-            state.hessian[np.ix_(active_set, active_set)] = hessian_init
-
+        state.hessian[np.ix_(active_set, active_set)] = hessian_init
         state.hessian_initialized = True
         n_active_rows = data.X.shape[0]
-
     else:
 
         # In an update iteration, we want to:
@@ -211,7 +194,6 @@ def update_hessian(state, data, active_set):
         # 3) Ignore the P2 components because those don't change and have
         #    already been added
         # 4) only update the active set subset of the hessian.
-
         hessian_rows_diff, active_rows = identify_active_rows(
             state.gradient_rows,
             state.hessian_rows,
@@ -226,32 +208,13 @@ def update_hessian(state, data, active_set):
             active_rows=active_rows,
             active_cols=active_set,
         )
-
-        if data.use_sparse_hessian:
-            coo_data = hessian_delta.ravel(order="C")
-            coo_rows = np.repeat(active_set, active_set.shape[0])
-            coo_cols = np.tile(active_set, active_set.shape[0])
-
-            state.hessian += sparse.coo_matrix(
-                (coo_data, (coo_rows, coo_cols)),
-                shape=(state.coef.shape[0], state.coef.shape[0]),
-            )
-        else:
-            state.hessian[np.ix_(active_set, active_set)] += hessian_delta
-
+        state.hessian[np.ix_(active_set, active_set)] += hessian_delta
         n_active_rows = active_rows.shape[0]
 
-    # If state.hessian is in COO form, we have to convert to CSC in order to index the
-    # active set elements, which we then convert to a numpy array for compatibility with
-    # the rest of the code. This numpy array is dense, but we care about problems in
-    # which the active set is usually much smaller than the number of data columns.
-    if data.use_sparse_hessian:
-        return (
-            state.hessian.tocsc()[np.ix_(active_set, active_set)].toarray(),
-            n_active_rows,
-        )
-    else:
-        return state.hessian[np.ix_(active_set, active_set)], n_active_rows
+    return (
+        state.hessian[np.ix_(active_set, active_set)],
+        n_active_rows,
+    )
 
 
 def _is_subset(x, y):
@@ -509,7 +472,6 @@ class IRLSData:
         lower_bounds: Optional[np.ndarray] = None,
         upper_bounds: Optional[np.ndarray] = None,
         verbose: bool = False,
-        use_sparse_hessian: bool = True,
         diag_fisher: bool = False,
     ):
         self.X = X
@@ -542,7 +504,6 @@ class IRLSData:
 
         self.intercept_offset = 1 if self.fit_intercept else 0
         self.verbose = verbose
-        self.use_sparse_hessian = use_sparse_hessian
         self.diag_fisher = diag_fisher
 
         self._check_data()
@@ -606,18 +567,9 @@ class IRLSState:
         self.old_hessian_rows = np.zeros(data.X.shape[0], dtype=data.X.dtype)
         self.gradient_rows = None
         self.hessian_rows = None
-
-        # In order to avoid memory issues for very wide datasets (e.g. Issue #485), we
-        # can instantiate the Hessian as a sparse COO matrix.
-        if data.use_sparse_hessian:
-            self.hessian = sparse.coo_matrix(
-                (self.coef.shape[0], self.coef.shape[0]), dtype=data.X.dtype
-            )
-        else:
-            self.hessian = np.zeros(
-                (self.coef.shape[0], self.coef.shape[0]), dtype=data.X.dtype
-            )
-
+        self.hessian = np.zeros(
+            (self.coef.shape[0], self.coef.shape[0]), dtype=data.X.dtype
+        )
         self.hessian_initialized = False
         self.coef_P2 = None
         self.norm_min_subgrad = None

--- a/src/glum_benchmarks/README.md
+++ b/src/glum_benchmarks/README.md
@@ -6,7 +6,7 @@ Python package to benchmark GLM implementations.
 
 ## Running the benchmarks
 
-After installing the package, you should have two CLI tools: `glm_benchmarks_run` and `glm_benchmarks_analyze`. Use the `--help` flag for full details. Look in `src/glum/problems.py` to see the list of problems that will be run through each library.
+After installing the package, you should have two CLI tools: `glm_benchmarks_run` and `glm_benchmarks_analyze`. Use the `--help` flag for full details. Look in `src/glum/glum_benchmarks/problems.py` to see the list of problems that will be run through each library.
 
 To run the full benchmarking suite, just run `glm_benchmarks_run` with no flags. This will probably take a very long time.
 

--- a/src/glum_benchmarks/README.md
+++ b/src/glum_benchmarks/README.md
@@ -6,7 +6,7 @@ Python package to benchmark GLM implementations.
 
 ## Running the benchmarks
 
-After installing the package, you should have two CLI tools: `glm_benchmarks_run` and `glm_benchmarks_analyze`. Use the `--help` flag for full details. Look in `src/glum/glum_benchmarks/problems.py` to see the list of problems that will be run through each library.
+After installing the package, you should have two CLI tools: `glm_benchmarks_run` and `glm_benchmarks_analyze`. Use the `--help` flag for full details. Look in `src/glum/problems.py` to see the list of problems that will be run through each library.
 
 To run the full benchmarking suite, just run `glm_benchmarks_run` with no flags. This will probably take a very long time.
 

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -1135,6 +1135,23 @@ def test_binomial_enet(alpha):
     assert_allclose(log.coef_[0, :], glm.coef_, rtol=5.1e-6)
 
 
+def test_diag_fisher(regression_data):
+    """Test that the diag_fisher option gives the same results."""
+    X, y = regression_data
+
+    glm_diag_fisher_false = GeneralizedLinearRegressor(
+        family="gaussian", l1_ratio=1, alpha=0.1, diag_fisher=False
+    )
+    glm_diag_fisher_false.fit(X, y)
+
+    glm_diag_fisher_true = GeneralizedLinearRegressor(
+        family="gaussian", l1_ratio=1, alpha=0.1, diag_fisher=True
+    )
+    glm_diag_fisher_true.fit(X, y)
+
+    assert_allclose(glm_diag_fisher_false.coef_, glm_diag_fisher_true.coef_, rtol=1e-6)
+
+
 @pytest.mark.parametrize(
     "params",
     [


### PR DESCRIPTION
Instead of storing the entire Hessian matrix, `diag_fisher=True` calculates Hessian rows _only when they must be used_ (i.e. in the relevant step of coordinate descent). It accomplishes this by storing the current state of the 1-D array `hessian_rows` (which appears in the middle of the sandwich product). This necessitates a greater number of matrix operations (many of them redundant), but also saves memory.

To-Do: 
- `state.hessian` does not need to be instantiated if `diag_fisher=True`; this is not yet accounted for in the current code.
- Make sure we've addressed all entry points where the argument `diag_fisher` can be set by the user.
- How do we implement memory views (and possibly `nogil`) in `_cd_fast.pyx`?
