### PR TITLE
Temporary sklearn pin to below 1.1 (due to dask)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - numexpr
   - pandas
   - tabmat>=3.0.1
-  - scikit-learn >= 0.23
+  - scikit-learn >=0.23,<1.1.0 # dask-ml does not support sklearn 1.1 yet
   - scipy
   - tqdm
 


### PR DESCRIPTION
The latest dask release does not support the latest version of scikit-learn. This is a quick fix to fix our failing tests.

This fixes #541.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
