### PR TITLE
Set GLM_ARCHITECTURE to default for cibuildwheel

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -10,8 +10,6 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    env:
-      GLM_ARCHITECTURE: default
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,9 @@ skip_glob = '\.eggs/*,\.git/*,\.venv/*,build/*,dist/*'
 default_section = 'THIRDPARTY'
 
 [tool.cibuildwheel]
-skip = ["cp310-*", "pp*", "*-musllinux_*"]
+skip = ["pp*", "*-musllinux_*"]
 test-requires = ["pytest", "pytest-xdist"]
+environment = "GLM_ARCHITECTURE='default'"
 
 [tool.cibuildwheel.macos]
 before-all = [


### PR DESCRIPTION
Same as https://github.com/Quantco/tabmat/pull/194

Also, I'm adding a Python 3.10 wheel (same as in https://github.com/Quantco/tabmat/pull/193).

We should also replace Python 3.6 in CI with 3.10, but I'm leaving that for another PR.