### PR TITLE
Release 2.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ Changelog
 UNRELEASED
 ----------
 
+2.2.1 - 2022-11-25
+------------------
+
+**Other changes:**
+
+- Fixing pypi upload issue. Version 2.2.0 will not be available through the standard distribution channels.
+
 2.2.0 - 2022-11-25
 ------------------
 


### PR DESCRIPTION
Fixing the release pipeline. `cibuildwheel` is now activated in the organization.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry
