### PR TITLE
Use tm.from_pandas for any pd.dataframe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ Changelog
 UNRELEASED
 ----------
 
+**Bug fixes:**
+
+- A dataframe with dense and sparse columns was transformed to a dense matrix instead of a split matrix by :meth:`~glum.GeneralizedLinearRegressor._set_up_and_check_fit_args`.
+  Fixed by calling ``tabmat.from_pandas`` on any dataframe.
+
 2.2.1 - 2022-11-25
 ------------------
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1788,6 +1788,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 X = tm.from_pandas(X, drop_first=self.drop_first)
             else:
                 self.feature_names_ = X.columns
+                X = tm.from_pandas(X)
 
         if not self._is_contiguous(X):
             if self.copy_X is not None and not self.copy_X:


### PR DESCRIPTION
Closes #589. This PR suggests that we call `tabmat.from_pandas` on any dataframe. In the case that it does not contain any categoricals, we don't drop any levels. 
 
Checklist
* [x] Added a `CHANGELOG.rst` entry
