### PR TITLE
Fix issue with SplitMatrix in `std_errors`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Changelog
 UNRELEASED
 ----------
 
+**Bug fixes:**
+
+- Fixed an issue with :meth:`~glum.ExponentialDispersionModel._score_matrix` which failed when called with a tabmat matrix input. 
 
 2.4.0 - 2023-01-31
 ------------------

--- a/src/glum/_distribution.py
+++ b/src/glum/_distribution.py
@@ -5,7 +5,13 @@ from typing import Tuple, Union
 import numexpr
 import numpy as np
 from scipy import sparse, special
-from tabmat import CategoricalMatrix, MatrixBase, SplitMatrix, StandardizedMatrix
+from tabmat import (
+    CategoricalMatrix,
+    DenseMatrix,
+    MatrixBase,
+    SplitMatrix,
+    StandardizedMatrix,
+)
 
 from ._functions import (
     binomial_logit_eta_mu_deviance,
@@ -524,8 +530,10 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         ).reshape(-1, 1)
 
         if fit_intercept:
-            if sparse.issparse(X) or isinstance(X, (SplitMatrix, CategoricalMatrix)):
+            if sparse.issparse(X):
                 return sparse.hstack((W, X.multiply(W)))
+            elif isinstance(X, (SplitMatrix, CategoricalMatrix)):
+                return SplitMatrix((DenseMatrix(W), X.multiply(W)))
             else:
                 return np.hstack((W, np.multiply(X, W)))
         else:


### PR DESCRIPTION
Fixes #610.

This PR fixes an issue when std_errors is called with a tabmat matrix. The call to `sparse.hstack` is not compatible with tabmat matrices.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry
