### PR TITLE
Removes unused scikit-learn imports from _cd_fast.pyx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ UNRELEASED
 
 - Fixed an issue with :meth:`~glum.ExponentialDispersionModel._score_matrix` which failed when called with a tabmat matrix input. 
 
+2.4.1 - 2023-03-14
+------------------
+
+**Other changes**:
+
+- Removes unused scikit-learn cython imports.
+  
 2.4.0 - 2023-01-31
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,15 +7,12 @@
 Changelog
 =========
 
-UNRELEASED
-----------
+2.4.1 - 2023-03-14
+------------------
 
 **Bug fixes:**
 
 - Fixed an issue with :meth:`~glum.ExponentialDispersionModel._score_matrix` which failed when called with a tabmat matrix input. 
-
-2.4.1 - 2023-03-14
-------------------
 
 **Other changes**:
 

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -21,11 +21,6 @@ from cython.parallel import prange
 import warnings
 from sklearn.exceptions import ConvergenceWarning
 
-from sklearn.utils._cython_blas cimport (_axpy, _dot, _asum, _ger, _gemv, _nrm2,
-                                   _copy, _scal)
-from sklearn.utils._cython_blas cimport RowMajor, ColMajor, Trans, NoTrans
-
-
 from sklearn.utils._random cimport our_rand_r
 
 ctypedef np.float64_t DOUBLE

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -11,11 +11,9 @@
 from libc.math cimport fabs
 cimport numpy as np
 import numpy as np
-import numpy.linalg as linalg
 from numpy.math cimport INFINITY
 
 cimport cython
-from cpython cimport bool
 from cython cimport floating
 from cython.parallel import prange
 import warnings

--- a/src/glum/_functions.pyx
+++ b/src/glum/_functions.pyx
@@ -3,9 +3,7 @@
 from cython cimport floating
 from cython.parallel import prange
 
-from libc.math cimport M_PI, ceil, exp, floor, fmax, lgamma, log
-
-import numpy as np
+from libc.math cimport M_PI, ceil, exp, floor, lgamma, log
 
 ctypedef fused numeric:
     short


### PR DESCRIPTION
This removes unused imports from scikit-learn within _cd_fast.pyx. The imports referenced functions that have seen type signature changes in the latest nightly builds of scikit-learn which can cause linking issues when deploying glum in environments with this build. (https://github.com/Quantco/glum/issues/614)

Checklist
* [x] Added a `CHANGELOG.rst` entry
