### PR TITLE
Don't use march="native" on arm64 

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -5,6 +5,9 @@ on:
       - '.github/**'
       - '**/*.pyx'
       - '**/*.cpp'
+      - 'setup.py'
+      - 'environment.yml'
+      - 'environment-benchmark.yml'
 
 jobs:
   macos:

--- a/.github/workflows/tests-win.yml
+++ b/.github/workflows/tests-win.yml
@@ -5,8 +5,10 @@ on:
       - '.github/**'
       - '**/*.pyx'
       - '**/*.cpp'
+      - 'setup.py'
       - 'environment.yml'
       - 'environment-benchmark.yml'
+      
 jobs:
   windows-ci:
     name: "Win - tests - Python ${{ matrix.PYTHON_VERSION }}"

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # required for users (note: this is not where you specify new dependencies
   # for the conda packages. please put those `conda.recipe/meta.yaml`!!
-  - libblas>=0=*mkl  # uncomment for m1
+  - libblas>=0=*mkl  # comment for m1
   - numexpr
   - pandas
   - tabmat>=3.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # required for users (note: this is not where you specify new dependencies
   # for the conda packages. please put those `conda.recipe/meta.yaml`!!
-  - libblas>=0=*mkl
+  - libblas>=0=*mkl  # uncomment for m1
   - numexpr
   - pandas
   - tabmat>=3.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 
 import numpy as np
@@ -34,7 +35,10 @@ else:
 
 architecture = os.environ.get("GLM_ARCHITECTURE", "native")
 if architecture != "default":
-    extra_compile_args.append("-march=" + architecture)
+    # Don't set "-march=native" on macOS arm64 as this doesn't exist there.
+    # Note that "arm64" already implies macOS. On Linux this is called "aarch64".
+    if not (platform.machine() == "arm64" and architecture == "native"):
+        extra_compile_args.append("-march=" + architecture)
 
 extension_args = dict(
     include_dirs=[np.get_include()],


### PR DESCRIPTION
Closes #607.

Not trying to set `march='native'` anymore on arm64. Same as in [tabmat]( https://github.com/Quantco/tabmat/blob/11531bcae57086226d8a4508a92b406819fef8cf/setup.py#L105-L110).

Also: We're now running Windows and macOS CI when `setup.py` or one of the environment YAMLs get changed.

(Note: CI for macOS is currently failing)

