### PR TITLE
Pin to working `types-setuptools`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
        - --ignore-missing-imports
        - --namespace-packages
       exclude: ^tests/
-      additional_dependencies: [-c, conda-forge, types-setuptools, attrs]
+      additional_dependencies: [-c, conda-forge, types-setuptools=67.5, attrs]
  - repo: https://github.com/Quantco/pre-commit-mirrors-pyupgrade
    rev: 3.3.1
    hooks:


### PR DESCRIPTION
The latest releases don't seem to work with `**kwargs`. Thus pin to the last known working version.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] ~Added a `CHANGELOG.rst` entry~