### PR TITLE
Create feature names for non-pandas input, too

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changelog
 **New feature**
 
 - Added the complementary log-log (`cloglog`) link function.
+- The `feature_names_` attribute is populated for non-pandas input, as well
+- Added a `term_names_` attribute to the `GeneralizedLinearRegressor` and `GeneralizedLinearRegressorCV` classes. It contains the name of the column in the input data that each coefficient corresponds to.
 
 2.5.2 - 2023-06-02
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,10 +10,10 @@ Changelog
 2.6.0 - UNRELEASED
 ------------------
 
-**New feature**
+**New features**
 
 - Added the complementary log-log (`cloglog`) link function.
-- The `feature_names_` attribute is populated for non-pandas input, as well
+- The `feature_names_` attribute is populated for non-pandas input, as well.
 - Added a `term_names_` attribute to the `GeneralizedLinearRegressor` and `GeneralizedLinearRegressorCV` classes. It contains the name of the column in the input data that each coefficient corresponds to.
 
 2.5.2 - 2023-06-02

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -219,9 +219,9 @@ def _name_categorical_variables(
         f"{column_name}__{category}" for category in categories[int(drop_first) :]
     ]
     if len(new_names) == 0:
-        warnings.warn(
+        raise ValueError(
             f"Categorical column: {column_name}, contains only one category. "
-            + "This will be dropped from the feature matrix."
+            + "This should be dropped from the feature matrix."
         )
     return new_names
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -219,9 +219,9 @@ def _name_categorical_variables(
         f"{column_name}__{category}" for category in categories[int(drop_first) :]
     ]
     if len(new_names) == 0:
-        raise ValueError(
+        warnings.warn(
             f"Categorical column: {column_name}, contains only one category. "
-            + "This should be dropped from the feature matrix."
+            + "This will be dropped from the feature matrix."
         )
     return new_names
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1923,6 +1923,10 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             self.feature_names_ = names
             self.term_names_ = names
 
+        else:
+            # Should never happen
+            raise RuntimeError("X has no shape attribute")
+
 
 class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
     """Regression via a Generalized Linear Model (GLM) with penalties.

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1863,7 +1863,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         elif isinstance(X, np.ndarray):
             X = tm.DenseMatrix(X)
 
-        if not hasattr(self, "feature_names_") or not hasattr(self, "column_names_"):
+        if not hasattr(self, "feature_names_") or not hasattr(self, "term_names_"):
             self._get_feature_names(X)
 
         return X, y, sample_weight, offset, weights_sum, P1, P2
@@ -1880,7 +1880,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             Input data.
         """
         self.feature_names_ = []
-        self.column_names_ = []
+        self.term_names_ = []
 
         if isinstance(X, pd.DataFrame):
             for column, dtype in zip(X.columns, X.dtypes):
@@ -1889,10 +1889,10 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                         dtype.categories, column, self.drop_first
                     ):
                         self.feature_names_.append(name)
-                        self.column_names_.append(column)
+                        self.term_names_.append(column)
                 else:
                     self.feature_names_.append(column)
-                    self.column_names_.append(column)
+                    self.term_names_.append(column)
 
         elif isinstance(X, tm.StandardizedMatrix):
             self._get_feature_names(X.unstandardize())
@@ -1911,17 +1911,17 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                     cols = names
                     current_col += mat.shape[1]
                 self.feature_names_.extend(names)
-                self.column_names_.extend(cols)
+                self.term_names_.extend(cols)
 
         elif isinstance(X, tm.CategoricalMatrix):
             names = _name_categorical_variables(X.cat.categories, "C_0", X.drop_first)
             self.feature_names_ = names
-            self.column_names_ = ["C_0"] * len(names)
+            self.term_names_ = ["C_0"] * len(names)
 
         elif hasattr(X, "shape"):
             names = [f"X_{i}" for i in range(X.shape[1])]
             self.feature_names_ = names
-            self.column_names_ = names
+            self.term_names_ = names
 
 
 class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1744,10 +1744,9 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
 
         copy_X = self._should_copy_X()
 
-        self._get_feature_names(X)
-
         if isinstance(X, pd.DataFrame):
             self.feature_dtypes_ = X.dtypes.to_dict()
+            self._get_feature_names(X)
 
             if any(X.dtypes == "category"):
 
@@ -1864,9 +1863,22 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         elif isinstance(X, np.ndarray):
             X = tm.DenseMatrix(X)
 
+        if not hasattr(self, "feature_names_") or not hasattr(self, "column_names_"):
+            self._get_feature_names(X)
+
         return X, y, sample_weight, offset, weights_sum, P1, P2
 
     def _get_feature_names(self, X: ArrayLike):
+        """
+        Get feature names for the input data.
+
+        Stores them in the ``feature_names_`` and ``column_names_`` attributes.
+
+        Parameters
+        ----------
+        X : ArrayLike
+            Input data.
+        """
         self.feature_names_ = []
         self.column_names_ = []
 
@@ -1906,11 +1918,8 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             self.feature_names_ = names
             self.column_names_ = ["C_0"] * len(names)
 
-        else:
-            if hasattr(X, "shape"):
-                names = [f"X_{i}" for i in range(X.shape[1])]
-            else:
-                names = [f"X_{i}" for i in range(len(X[0]))]
+        elif hasattr(X, "shape"):
+            names = [f"X_{i}" for i in range(X.shape[1])]
             self.feature_names_ = names
             self.column_names_ = names
 

--- a/src/glum/_glm_cv.py
+++ b/src/glum/_glm_cv.py
@@ -308,6 +308,7 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
         cv=None,
         n_jobs: Optional[int] = None,
         drop_first: bool = False,
+        categorical_format: str = "{name}__{category}",
     ):
         self.alphas = alphas
         self.cv = cv
@@ -341,6 +342,7 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
             b_ineq=b_ineq,
             force_all_finite=force_all_finite,
             drop_first=drop_first,
+            categorical_format=categorical_format,
         )
 
     def _validate_hyperparameters(self) -> None:

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -1721,16 +1721,22 @@ def test_passing_noncontiguous_as_X():
 
 
 @pytest.mark.parametrize(
-    "X, feature_names",
+    "X, feature_names, term_names",
     [
-        (pd.DataFrame({"x1": np.arange(5), "x2": 2}), np.array(["x1", "x2"])),
+        (
+            pd.DataFrame({"x1": np.arange(5), "x2": 2}),
+            np.array(["x1", "x2"]),
+            np.array(["x1", "x2"]),
+        ),
         (
             pd.DataFrame({"x1": np.arange(5), "x2": 2}).to_numpy(),
+            np.array(["X_0", "X_1"]),
             np.array(["X_0", "X_1"]),
         ),
         (
             pd.DataFrame({"x1": pd.Categorical(np.arange(5)), "x2": 2}),
             np.array(["x1__0", "x1__1", "x1__2", "x1__3", "x1__4", "x2"]),
+            np.array(["x1", "x1", "x1", "x1", "x1", "x2"]),
         ),
         (
             pd.DataFrame(
@@ -1740,6 +1746,7 @@ def test_passing_noncontiguous_as_X():
                 }
             ),
             np.array(["x1__0", "x1__1", "x1__2", "x1__3", "x1__4", "x2__2"]),
+            np.array(["x1", "x1", "x1", "x1", "x1", "x2"]),
         ),
         (
             tm.SplitMatrix(
@@ -1754,12 +1761,14 @@ def test_passing_noncontiguous_as_X():
                 ]
             ),
             np.array(["C_0__2", "C_0__3", "X_1", "X_2", "C_3__1", "C_3__2"]),
+            np.array(["C_0", "C_0", "X_1", "X_2", "C_3", "C_3"]),
         ),
     ],
 )
-def test_feature_names(X, feature_names):
+def test_feature_names(X, feature_names, term_names):
     model = GeneralizedLinearRegressor(family="poisson").fit(X, np.arange(5))
-    np.testing.assert_array_equal(getattr(model, "feature_names_", None), feature_names)
+    np.testing.assert_array_equal(model.feature_names_, feature_names)
+    np.testing.assert_array_equal(model.term_names_, term_names)
 
 
 @pytest.mark.parametrize(

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -1724,7 +1724,10 @@ def test_passing_noncontiguous_as_X():
     "X, feature_names",
     [
         (pd.DataFrame({"x1": np.arange(5), "x2": 2}), np.array(["x1", "x2"])),
-        (pd.DataFrame({"x1": np.arange(5), "x2": 2}).to_numpy(), None),
+        (
+            pd.DataFrame({"x1": np.arange(5), "x2": 2}).to_numpy(),
+            np.array(["X_0", "X_1"]),
+        ),
         (
             pd.DataFrame({"x1": pd.Categorical(np.arange(5)), "x2": 2}),
             np.array(["x1__0", "x1__1", "x1__2", "x1__3", "x1__4", "x2"]),
@@ -1737,6 +1740,20 @@ def test_passing_noncontiguous_as_X():
                 }
             ),
             np.array(["x1__0", "x1__1", "x1__2", "x1__3", "x1__4", "x2__2"]),
+        ),
+        (
+            tm.SplitMatrix(
+                [
+                    tm.CategoricalMatrix(
+                        pd.Categorical([1, 2, 3, 2, 1]), drop_first=True
+                    ),
+                    tm.DenseMatrix(np.ones((5, 2))),
+                    tm.CategoricalMatrix(
+                        pd.Categorical([1, 2, 1, 2, 1]), drop_first=False
+                    ),
+                ]
+            ),
+            np.array(["C_0__2", "C_0__3", "X_1", "X_2", "C_3__1", "C_3__2"]),
         ),
     ],
 )

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -1772,6 +1772,76 @@ def test_feature_names(X, feature_names, term_names):
 
 
 @pytest.mark.parametrize(
+    "X, feature_names, term_names",
+    [
+        (
+            pd.DataFrame({"x1": pd.Categorical(np.arange(5)), "x2": 2}),
+            np.array(
+                [
+                    "<x1>[cat: 0]",
+                    "<x1>[cat: 1]",
+                    "<x1>[cat: 2]",
+                    "<x1>[cat: 3]",
+                    "<x1>[cat: 4]",
+                    "x2",
+                ]
+            ),
+            np.array(["x1", "x1", "x1", "x1", "x1", "x2"]),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "x1": pd.Categorical(np.arange(5)),
+                    "x2": pd.Categorical([2, 2, 2, 2, 2]),
+                }
+            ),
+            np.array(
+                [
+                    "<x1>[cat: 0]",
+                    "<x1>[cat: 1]",
+                    "<x1>[cat: 2]",
+                    "<x1>[cat: 3]",
+                    "<x1>[cat: 4]",
+                    "<x2>[cat: 2]",
+                ]
+            ),
+            np.array(["x1", "x1", "x1", "x1", "x1", "x2"]),
+        ),
+        (
+            tm.SplitMatrix(
+                [
+                    tm.CategoricalMatrix(
+                        pd.Categorical([1, 2, 3, 2, 1]), drop_first=True
+                    ),
+                    tm.DenseMatrix(np.ones((5, 2))),
+                    tm.CategoricalMatrix(
+                        pd.Categorical([1, 2, 1, 2, 1]), drop_first=False
+                    ),
+                ]
+            ),
+            np.array(
+                [
+                    "<C_0>[cat: 2]",
+                    "<C_0>[cat: 3]",
+                    "X_1",
+                    "X_2",
+                    "<C_3>[cat: 1]",
+                    "<C_3>[cat: 2]",
+                ]
+            ),
+            np.array(["C_0", "C_0", "X_1", "X_2", "C_3", "C_3"]),
+        ),
+    ],
+)
+def test_feature_names_customized(X, feature_names, term_names):
+    model = GeneralizedLinearRegressor(
+        family="poisson", categorical_format="<{name}>[cat: {category}]"
+    ).fit(X, np.arange(5))
+    np.testing.assert_array_equal(model.feature_names_, feature_names)
+    np.testing.assert_array_equal(model.term_names_, term_names)
+
+
+@pytest.mark.parametrize(
     "X, dtypes",
     [
         (pd.DataFrame({"x1": np.arange(5)}, dtype="int64"), {"x1": np.int64}),


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry

## Main changes
 - The `feature_names_` attribute is populated for non-pandas input, too. It uses the `X_{i}` format for numerical columns, and (in the case of a `SplitMatrix`) the `C_{i}__{cat}` format for categorical columns. It would be a breaking change for users who relied on the `feature_names_` attribute being unassigned in the case of non-pandas input, but I cannot imagine how that would be usefu ([you never know](https://xkcd.com/1172/), though).
 - A `term_names_` attribute is also assigned during fit. It contains the name of the column in the *original input data* that corresponds to each column of the design matrix. In the case of numerical variables, it is the same as `feature_names_`. In the case of categorical columns, it differs in that it does not include the category at the end.

## Reason
A separate PR for Wald-tests will soon follow, for which it will be useful to have a simple way to refer to columns by names. The same goes for what I call terms here. I am submitting this as a separate PR as it is relatively self-contained and it might be easier to review.