### PR TITLE
Improve the check for multicollinear columns in `.covariance_matrix()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Changelog
 
 - Added the complementary log-log (`cloglog`) link function.
 
+**Other changes:**
+
+- When computing the covariance matrix, check for ill-conditionedness for all types of input. Furthermore, do it in a more efficient way.
+
 2.5.2 - 2023-06-02
 ------------------
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1490,10 +1490,10 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 method="pearson",
             )
 
-        if (
-            np.linalg.cond(X.sandwich(np.ones(X.shape[0])))
-            > 1 / sys.float_info.epsilon**2
-        ):
+        XTX = X.sandwich(np.ones(X.shape[0]))
+        if sparse.issparse(XTX):
+            XTX = XTX.todense()
+        if np.linalg.cond(XTX) > 1 / sys.float_info.epsilon**2:
             raise np.linalg.LinAlgError(
                 "Matrix is singular. Cannot estimate standard errors."
             )

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1490,13 +1490,13 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 method="pearson",
             )
 
-        if not (
-            sparse.issparse(X) or isinstance(X, (tm.SplitMatrix, tm.CategoricalMatrix))
+        if (
+            np.linalg.cond(X.sandwich(np.ones(X.shape[0])))
+            > 1 / sys.float_info.epsilon**2
         ):
-            if np.linalg.cond(X) > 1 / sys.float_info.epsilon:
-                raise np.linalg.LinAlgError(
-                    "Matrix is singular. Cannot estimate standard errors."
-                )
+            raise np.linalg.LinAlgError(
+                "Matrix is singular. Cannot estimate standard errors."
+            )
 
         if robust or clusters is not None:
             if expected_information:

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1490,10 +1490,10 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 method="pearson",
             )
 
-        XTX = X.sandwich(np.ones(X.shape[0]))
-        if sparse.issparse(XTX):
-            XTX = XTX.todense()
-        if np.linalg.cond(XTX) > 1 / sys.float_info.epsilon**2:
+        if (
+            np.linalg.cond(_safe_toarray(X.sandwich(np.ones(X.shape[0]))))
+            > 1 / sys.float_info.epsilon**2
+        ):
             raise np.linalg.LinAlgError(
                 "Matrix is singular. Cannot estimate standard errors."
             )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry

In the `GeneralizedLinearRegressor.covariance_matrix` method, the condition number (`numpy.linalg.cond`) of `X` is calculated to make sure it is full rank before proceeding. However, this check is only done if the input is a `DenseMatrix`.

This PR proposes to calculate the condition number of `X.T @ X` instead, which is the square of the condition number of `X`. This approach has two main advantages:
 - We can do it for every kind of matrix by leveraging the `.sandwich()` method.
 - It is much faster in the case of tall matrices even when `X` is dense. (In fact, for certain inputs, the majority of the runtime of `covariance_matrix()` was spent on the `numpy.linalg.cond(X)` line before this change.)