### PR TITLE
Add the option to store the covariance matrix to avoid recomputing it

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 **New feature**
 
 - Added the complementary log-log (`cloglog`) link function.
+- Added the option to store the covariance matrix after estimating it. In this case, the covariance matrix does not have to be recomputed when calling inference methods.
 
 2.5.2 - 2023-06-02
 ------------------

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1336,9 +1336,9 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         offset=None,
         sample_weight=None,
         dispersion=None,
-        robust=True,
+        robust=None,
         clusters: np.ndarray = None,
-        expected_information=False,
+        expected_information=None,
         store_covariance_matrix=False,
     ):
         """Calculate standard errors for generalized linear models.
@@ -1360,14 +1360,16 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             Individual weights for each sample.
         dispersion : float, optional, default=None
             The dispersion parameter. Estimated if absent.
-        robust : boolean, optional, default=True
+        robust : boolean, optional, default=None
             Whether to compute robust standard errors instead of normal ones.
+            If not specified, the model's ``robust`` attribute is used.
         clusters : array-like, optional, default=None
             Array with clusters membership. Clustered standard errors are
             computed if clusters is not None.
-        expected_information : boolean, optional, default=False
+        expected_information : boolean, optional, default=None
             Whether to use the expected or observed information matrix.
             Only relevant when computing robust std-errors.
+            If not specified, the model's ``expected_information`` attribute is used.
         store_covariance_matrix : boolean, optional, default=False
             Whether to store the covariance matrix in the model instance.
             If a covariance matrix has already been stored, it will be overwritten.
@@ -1395,9 +1397,9 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         offset=None,
         sample_weight=None,
         dispersion=None,
-        robust=True,
+        robust=None,
         clusters: Optional[np.ndarray] = None,
-        expected_information=False,
+        expected_information=None,
         store_covariance_matrix=False,
         skip_checks=False,
     ):
@@ -1419,14 +1421,16 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             Individual weights for each sample.
         dispersion : float, optional, default=None
             The dispersion parameter. Estimated if absent.
-        robust : boolean, optional, default=True
+        robust : boolean, optional, default=None
             Whether to compute robust standard errors instead of normal ones.
+            If not specified, the model's ``robust`` attribute is used.
         clusters : array-like, optional, default=None
             Array with clusters membership. Clustered standard errors are
             computed if clusters is not None.
-        expected_information : boolean, optional, default=False
+        expected_information : boolean, optional, default=None
             Whether to use the expected or observed information matrix.
             Only relevant when computing robust standard errors.
+            If not specified, the model's ``expected_information`` attribute is used.
         store_covariance_matrix : boolean, optional, default=False
             Whether to store the covariance matrix in the model instance.
             If a covariance matrix has already been stored, it will be overwritten.
@@ -1477,6 +1481,16 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
 
         self.covariance_matrix_: Union[np.ndarray, None]
 
+        if robust is None:
+            _robust = self.robust
+        else:
+            _robust = robust
+
+        if expected_information is None:
+            _expected_information = self.expected_information
+        else:
+            _expected_information = expected_information
+
         if (
             (hasattr(self, "alpha") and self.alpha is None)
             or (
@@ -1518,9 +1532,9 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                     or offset is not None
                     or sample_weight is not None
                     or dispersion is not None
-                    or robust != self.robust
+                    or robust is not None
                     or clusters is not None
-                    or expected_information != self.expected_information
+                    or expected_information is not None
                 ):
                     raise ValueError(
                         "Cannot reestimate the covariance matrix with different "
@@ -1573,8 +1587,8 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                     "Matrix is singular. Cannot estimate standard errors."
                 )
 
-        if robust or clusters is not None:
-            if expected_information:
+        if _robust or clusters is not None:
+            if _expected_information:
                 oim_fct = self._family_instance._fisher_information
             else:
                 oim_fct = self._family_instance._observed_information

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1477,11 +1477,20 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
 
         self.covariance_matrix_: Union[np.ndarray, None]
 
-        if self.alpha_search or self.alpha is None or self.alpha > 0:
+        if (
+            (hasattr(self, "alpha") and self.alpha is None)
+            or (
+                hasattr(self, "alpha")
+                and isinstance(self.alpha, (int, float))
+                and self.alpha > 0
+            )
+            or (hasattr(self, "alpha_") and self.alpha_ > 0)  # glm_cv
+            or (hasattr(self, "_alphas") and self._alphas[-1] > 0)  # alpha_search
+        ):
             warnings.warn(
                 "Covariance matrix estimation assumes that the model is not "
-                "penalized. You are possibly estimating a penalized model. "
-                "The estimated covariance matrix might be incorrect."
+                "penalized. You are estimating a penalized model. The covariance "
+                "matrix will be incorrect."
             )
 
         if not skip_checks:
@@ -2445,14 +2454,6 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
         """
 
         self._validate_hyperparameters()
-
-        penalized = self.alpha_search or self.alpha is None or self.alpha > 0
-        if store_covariance_matrix and penalized:
-            warnings.warn(
-                "Covariance matrix estimation assumes that the model is not "
-                "penalized. You are possibly estimating a penalized model. "
-                "The estimated covariance matrix might be incorrect."
-            )
 
         # NOTE: This function checks if all the entries in X and y are
         # finite. That can be expensive. But probably worthwhile.

--- a/src/glum/_glm_cv.py
+++ b/src/glum/_glm_cv.py
@@ -365,6 +365,8 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
         y: ArrayLike,
         sample_weight: Optional[ArrayLike] = None,
         offset: Optional[ArrayLike] = None,
+        store_covariance_matrix: bool = False,
+        clusters: Optional[np.ndarray] = None,
     ):
         r"""
         Choose the best model along a 'regularization path' by cross-validation.
@@ -398,6 +400,15 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
             Added to linear predictor. An offset of 3 will increase expected
             ``y`` by 3 if the link is linear and will multiply expected ``y`` by
             3 if the link is logarithmic.
+
+        store_covariance_matrix : bool, optional (default=False)
+            Whether to store the covariance matrix of the parameter estimates
+            corresponding to the best best model.
+
+        clusters : array-like, optional, default=None
+            Array with clusters membership. Clustered standard errors are
+            computed if clusters is not None.
+
         """
         self._validate_hyperparameters()
 
@@ -695,5 +706,17 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
         self._tear_down_from_fit()
 
         self.covariance_matrix_ = None
+        if store_covariance_matrix:
+            self.covariance_matrix(
+                X=X.unstandardize(),
+                y=y,
+                offset=offset,
+                sample_weight=sample_weight * weights_sum,
+                robust=self.robust,
+                clusters=clusters,
+                expected_information=self.expected_information,
+                store_covariance_matrix=True,
+                skip_checks=True,
+            )
 
         return self

--- a/src/glum/_glm_cv.py
+++ b/src/glum/_glm_cv.py
@@ -694,4 +694,6 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
 
         self._tear_down_from_fit()
 
+        self.covariance_matrix_ = None
+
         return self

--- a/src/glum/_glm_cv.py
+++ b/src/glum/_glm_cv.py
@@ -273,6 +273,13 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
 
     deviance_path_: array, shape(n_folds, n_alphas)
         Deviance for the test set on each fold, varying alpha.
+
+    robust : bool, optional (default = False)
+        If true, then robust standard errors are computed by default.
+
+    expected_information : bool, optional (default = False)
+        If true, then the expected information matrix is computed by default.
+        Only relevant when computing robust standard errors.
     """
 
     def __init__(
@@ -308,6 +315,8 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
         cv=None,
         n_jobs: Optional[int] = None,
         drop_first: bool = False,
+        robust: bool = True,
+        expected_information: bool = False,
     ):
         self.alphas = alphas
         self.cv = cv
@@ -341,6 +350,8 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
             b_ineq=b_ineq,
             force_all_finite=force_all_finite,
             drop_first=drop_first,
+            robust=robust,
+            expected_information=expected_information,
         )
 
     def _validate_hyperparameters(self) -> None:

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -2137,14 +2137,14 @@ def test_store_covariance_matrix(
     )
     regressor.fit(X, y, store_covariance_matrix=True, clusters=clu)
 
-    np.testing.assert_array_equal(
+    np.testing.assert_array_almost_equal(
         regressor.covariance_matrix(
             X, y, robust=robust, expected_information=expected_information, clusters=clu
         ),
         regressor.covariance_matrix(),
     )
 
-    np.testing.assert_array_equal(
+    np.testing.assert_array_almost_equal(
         regressor.std_errors(
             X, y, robust=robust, expected_information=expected_information, clusters=clu
         ),
@@ -2206,7 +2206,7 @@ def test_store_covariance_matrix_alpha_search(
     with pytest.warns(match="Covariance matrix estimation assumes"):
         regressor.fit(X, y, store_covariance_matrix=True, clusters=clu)
 
-    np.testing.assert_array_equal(
+    np.testing.assert_array_almost_equal(
         regressor.covariance_matrix(
             X, y, robust=robust, expected_information=expected_information, clusters=clu
         ),
@@ -2238,7 +2238,7 @@ def test_store_covariance_matrix_cv(
         # regressor.alpha_ == 1e-5 > 0
         regressor.fit(X, y, store_covariance_matrix=True, clusters=clu)
 
-    np.testing.assert_array_equal(
+    np.testing.assert_array_almost_equal(
         regressor.covariance_matrix(
             X, y, robust=robust, expected_information=expected_information, clusters=clu
         ),

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -2153,7 +2153,32 @@ def test_store_covariance_matrix_errors(regression_data):
         regressor.covariance_matrix(X, y, store_covariance_matrix=True)
 
     regressor_penalized = GeneralizedLinearRegressor(family="gaussian", alpha=0.1)
-    with pytest.warns(
-        match="Covariance matrix estimation assumes that the model is not penalized"
-    ):
+    with pytest.warns(match="Covariance matrix estimation assumes"):
         regressor_penalized.fit(X, y, store_covariance_matrix=True)
+
+
+def test_store_covariance_matrix_alpha_search(regression_data):
+    X, y = regression_data
+
+    regressor = GeneralizedLinearRegressor(
+        family="gaussian", alpha=[0, 0.1, 0.5], alpha_search=True
+    )
+    with pytest.warns(match="Covariance matrix estimation assumes"):
+        regressor.fit(X, y, store_covariance_matrix=True)
+
+    np.testing.assert_array_equal(
+        regressor.covariance_matrix(X, y), regressor.covariance_matrix()
+    )
+
+
+def test_store_covariance_matrix_cv(regression_data):
+    X, y = regression_data
+
+    regressor = GeneralizedLinearRegressorCV(family="gaussian")
+    with pytest.warns(match="Covariance matrix estimation assumes"):
+        # regressor.alpha_ == 1e-5 > 0
+        regressor.fit(X, y, store_covariance_matrix=True)
+
+    np.testing.assert_array_equal(
+        regressor.covariance_matrix(X, y), regressor.covariance_matrix()
+    )

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -2113,3 +2113,47 @@ def test_P1_P2_with_drop_first():
     regressor.fit(X, y)
     regressor = GeneralizedLinearRegressor(alpha=0.1, l1_ratio=0.5, P1=P_1, P2=P_2)
     regressor.fit(X, y)
+
+
+def test_store_covariance_matrix(regression_data):
+    X, y = regression_data
+    regressor = GeneralizedLinearRegressor(family="gaussian", alpha=0)
+    regressor.fit(X, y, store_covariance_matrix=True)
+
+    np.testing.assert_array_equal(
+        regressor.covariance_matrix(X, y), regressor.covariance_matrix()
+    )
+
+    np.testing.assert_array_equal(regressor.std_errors(X, y), regressor.std_errors())
+
+
+def test_store_covariance_matrix_errors(regression_data):
+    X, y = regression_data
+
+    regressor = GeneralizedLinearRegressor(family="gaussian", alpha=0)
+    regressor.fit(X, y, store_covariance_matrix=False)
+
+    with pytest.raises(ValueError, match="Either X and y must be provided"):
+        regressor.covariance_matrix()
+
+    with pytest.raises(ValueError, match="Either X and y must be provided"):
+        regressor.covariance_matrix(X=X)
+
+    with pytest.raises(ValueError, match="Either X and y must be provided"):
+        regressor.covariance_matrix(y=y)
+
+    regressor.covariance_matrix(X, y, store_covariance_matrix=True)
+
+    with pytest.raises(
+        ValueError, match="Cannot reestimate the covariance matrix with different"
+    ):
+        regressor.covariance_matrix(robust=False)
+
+    with pytest.warns(match="A covariance matrix has already been computed."):
+        regressor.covariance_matrix(X, y, store_covariance_matrix=True)
+
+    regressor_penalized = GeneralizedLinearRegressor(family="gaussian", alpha=0.1)
+    with pytest.warns(
+        match="Covariance matrix estimation assumes that the model is not penalized"
+    ):
+        regressor_penalized.fit(X, y, store_covariance_matrix=True)

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -2115,16 +2115,41 @@ def test_P1_P2_with_drop_first():
     regressor.fit(X, y)
 
 
-def test_store_covariance_matrix(regression_data):
+@pytest.mark.parametrize("clustered", [True, False], ids=["clustered", "nonclustered"])
+@pytest.mark.parametrize("expected_information", [True, False], ids=["opg", "oim"])
+@pytest.mark.parametrize("robust", [True, False], ids=["robust", "nonrobust"])
+def test_store_covariance_matrix(
+    regression_data, robust, expected_information, clustered
+):
     X, y = regression_data
-    regressor = GeneralizedLinearRegressor(family="gaussian", alpha=0)
-    regressor.fit(X, y, store_covariance_matrix=True)
+
+    if clustered:
+        rng = np.random.default_rng(42)
+        clu = rng.integers(5, size=len(y))
+    else:
+        clu = None
+
+    regressor = GeneralizedLinearRegressor(
+        family="gaussian",
+        alpha=0,
+        robust=robust,
+        expected_information=expected_information,
+    )
+    regressor.fit(X, y, store_covariance_matrix=True, clusters=clu)
 
     np.testing.assert_array_equal(
-        regressor.covariance_matrix(X, y), regressor.covariance_matrix()
+        regressor.covariance_matrix(
+            X, y, robust=robust, expected_information=expected_information, clusters=clu
+        ),
+        regressor.covariance_matrix(),
     )
 
-    np.testing.assert_array_equal(regressor.std_errors(X, y), regressor.std_errors())
+    np.testing.assert_array_equal(
+        regressor.std_errors(
+            X, y, robust=robust, expected_information=expected_information, clusters=clu
+        ),
+        regressor.std_errors(),
+    )
 
 
 def test_store_covariance_matrix_errors(regression_data):
@@ -2157,28 +2182,65 @@ def test_store_covariance_matrix_errors(regression_data):
         regressor_penalized.fit(X, y, store_covariance_matrix=True)
 
 
-def test_store_covariance_matrix_alpha_search(regression_data):
+@pytest.mark.parametrize("clustered", [True, False], ids=["clustered", "nonclustered"])
+@pytest.mark.parametrize("expected_information", [True, False], ids=["opg", "oim"])
+@pytest.mark.parametrize("robust", [True, False], ids=["robust", "nonrobust"])
+def test_store_covariance_matrix_alpha_search(
+    regression_data, robust, expected_information, clustered
+):
     X, y = regression_data
+
+    if clustered:
+        rng = np.random.default_rng(42)
+        clu = rng.integers(5, size=len(y))
+    else:
+        clu = None
 
     regressor = GeneralizedLinearRegressor(
-        family="gaussian", alpha=[0, 0.1, 0.5], alpha_search=True
+        family="gaussian",
+        alpha=[0, 0.1, 0.5],
+        alpha_search=True,
+        robust=robust,
+        expected_information=expected_information,
     )
     with pytest.warns(match="Covariance matrix estimation assumes"):
-        regressor.fit(X, y, store_covariance_matrix=True)
+        regressor.fit(X, y, store_covariance_matrix=True, clusters=clu)
 
     np.testing.assert_array_equal(
-        regressor.covariance_matrix(X, y), regressor.covariance_matrix()
+        regressor.covariance_matrix(
+            X, y, robust=robust, expected_information=expected_information, clusters=clu
+        ),
+        regressor.covariance_matrix(),
     )
 
 
-def test_store_covariance_matrix_cv(regression_data):
+@pytest.mark.parametrize("clustered", [True, False], ids=["clustered", "nonclustered"])
+@pytest.mark.parametrize("expected_information", [True, False], ids=["opg", "oim"])
+@pytest.mark.parametrize("robust", [True, False], ids=["robust", "nonrobust"])
+def test_store_covariance_matrix_cv(
+    regression_data, robust, expected_information, clustered
+):
     X, y = regression_data
 
-    regressor = GeneralizedLinearRegressorCV(family="gaussian")
+    if clustered:
+        rng = np.random.default_rng(42)
+        clu = rng.integers(5, size=len(y))
+    else:
+        clu = None
+
+    regressor = GeneralizedLinearRegressorCV(
+        family="gaussian",
+        n_alphas=5,
+        robust=robust,
+        expected_information=expected_information,
+    )
     with pytest.warns(match="Covariance matrix estimation assumes"):
         # regressor.alpha_ == 1e-5 > 0
-        regressor.fit(X, y, store_covariance_matrix=True)
+        regressor.fit(X, y, store_covariance_matrix=True, clusters=clu)
 
     np.testing.assert_array_equal(
-        regressor.covariance_matrix(X, y), regressor.covariance_matrix()
+        regressor.covariance_matrix(
+            X, y, robust=robust, expected_information=expected_information, clusters=clu
+        ),
+        regressor.covariance_matrix(),
     )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

Add option to store the covariance matrix in the model object when computing it. Furthermore, add a `store_covariance_matrix` parameter to the regressors' constructor, which then automatically estimates and stores the covariance matrix after fitting the model. When a covariance matrix is stored, inference methods can be called without any arguments.

The purpose of this PR is twofold: (1) it makes statistical inference slightly more ergonomic, and (2) it avoids the possibly expensive step of recomputing the covariance matrix when multiple statistical tests are performed. The default is still *not* to store the covariance matrix, and changes are backwards-compatible.

At the moment, only the `std_errors` and `covariance_matrix` methods are affected. A subsequent PR will introduce more statistical inference methods (Wald-tests and p-values), which will also be able to use the stored covariance matrix.