### PR TITLE
Fix covariance matrix mutating feature names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Changelog
 
 - Added the complementary log-log (`cloglog`) link function.
 
+**Bug fix**
+
+- Fixed :meth:`~glum.GeneralizedLinearRegressorBase.covariance_matrix` mutating feature names when called with a data frame. See `here <https://github.com/Quantco/glum/issues/669>`_.
+
 **Other changes:**
 
 - When computing the covariance matrix, check for ill-conditionedness for all types of input. Furthermore, do it in a more efficient way.


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry

This PR implements a minimal fix for #669. It replaces the (non-pure) `_set_up_and_check_fit_args` method call in `covariance_matrix()` with the side-effectless `check_X_y_tabmat_compliant` function plus a few more lines of code.

The fix does work, but I believe that the underlying issue is a bit deeper, and a proper solution would require some refactoring. Basically, it is not totally clear (at least to me) where the line lies between `_set_up_and_check_fit_args` and `check_X_y_tabmat_compliant`. For example, converting to `MatrixBase` and handling integer arrays is done in the former, while I feel it should belong to the latter.

It would be nice to have a method/function (could be `check_X_y_tabmat_compliant`), after which we can be sure that `X` is a nice, checked `MatrixBase` object, but which does not have side effects. It could also take care of aligning categorical features (I believe that the category alignment step was omitted from `covariance_matrix` before.), or, later on, materializing formuals.