### PR TITLE
Use boa to build conda packages in CI

### DIFF
--- a/.github/workflows/conda-build.sh
+++ b/.github/workflows/conda-build.sh
@@ -7,5 +7,5 @@ export CONDA_BUILD_YML=$1
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${SCRIPT_DIR}/base.sh $*
 conda activate base
-mamba install -y conda-build
-conda build -m .ci_support/${CONDA_BUILD_YML}.yaml conda.recipe
+mamba install -y boa conda-build
+conda mambabuild -m .ci_support/${CONDA_BUILD_YML}.yaml conda.recipe

--- a/.github/workflows/macos-conda-build.sh
+++ b/.github/workflows/macos-conda-build.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${SCRIPT_DIR}/base.sh $*
 conda activate base
 
-mamba install -y conda-build -c conda-forge
+mamba install -y conda-build boa -c conda-forge
 # Don't test cross-compiled result (there is no emulation) and use the latest MacOS SDK.
 if grep -q "osx-arm64" .ci_support/${CONDA_BUILD_YML}.yaml; then
   CONDA_BUILD_ARGS="--no-test"
@@ -16,4 +16,4 @@ CONDA_BUILD_SYSROOT:
  - "${CONDA_BUILD_SYSROOT}"
 EOF
 fi
-conda build -m .ci_support/${CONDA_BUILD_YML}.yaml conda.recipe ${CONDA_BUILD_ARGS:-}
+conda mambabuild -m .ci_support/${CONDA_BUILD_YML}.yaml conda.recipe ${CONDA_BUILD_ARGS:-}


### PR DESCRIPTION
We currently still use `conda build`, which is slow.

(NB: we could also re-consider dropping the conda build steps completely, see #473)