### PR TITLE
Fix nightly 2.0

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,6 +2,7 @@ name: Daily runs
 on:
   schedule:
     - cron: '0 5 * * *'
+  workflow_dispatch:
   push:
     paths:
     - '.github/workflows/daily.yml'
@@ -37,8 +38,7 @@ jobs:
           micromamba install -y c-compiler cxx-compiler 'cython!=3.0.4' jemalloc-local libgomp mako xsimd
 
           PRE_WHEELS="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
-          # FIXME: re-add NumPy when pandas supports NumPy>=2
-          for pkg in pandas scikit-learn scipy; do
+          for pkg in numpy pandas scikit-learn scipy; do
             echo "Installing $pkg nightly"
             micromamba remove -y --force $pkg
             pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS $pkg

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -45,7 +45,7 @@ jobs:
           done
           echo Install pyarrow nightly
           micromamba remove -y --force pyarrow
-          micromamba install -y -c arrow-nightlies pyarrow
+          pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --prefer-binary --pre --no-deps pyarrow
           echo Install tabmat nightly
           micromamba remove -y --force tabmat
           pip install --no-use-pep517 --no-deps git+https://github.com/Quantco/tabmat

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -43,6 +43,9 @@ jobs:
             micromamba remove -y --force $pkg
             pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS $pkg
           done
+          echo Install pyarrow nightly
+          micromamba remove -y --force pyarrow
+          micromamba install -y -c arrow-nightlies pyarrow
           echo Install tabmat nightly
           micromamba remove -y --force tabmat
           pip install --no-use-pep517 --no-deps git+https://github.com/Quantco/tabmat

--- a/src/glum/_distribution.py
+++ b/src/glum/_distribution.py
@@ -616,7 +616,7 @@ class TweedieDistribution(ExponentialDispersionModel):
         :math:`0 < \mathrm{power} < 1`, no distribution exists.
     """
 
-    upper_bound = np.Inf
+    upper_bound = np.inf
     include_upper_bound = False
 
     def __init__(self, power=0):
@@ -630,7 +630,7 @@ class TweedieDistribution(ExponentialDispersionModel):
     def lower_bound(self) -> float:
         """Return the lowest value of ``y`` allowed."""
         if self.power <= 0:
-            return -np.Inf
+            return -np.inf
         if self.power >= 1:
             return 0
         raise ValueError
@@ -904,8 +904,8 @@ class GeneralizedHyperbolicSecant(ExponentialDispersionModel):
     The GHS distribution is for targets ``y`` in ``(-∞, +∞)``.
     """
 
-    lower_bound = -np.Inf
-    upper_bound = np.Inf
+    lower_bound = -np.inf
+    upper_bound = np.inf
     include_lower_bound = False
     include_upper_bound = False
 
@@ -1133,7 +1133,7 @@ class NegativeBinomialDistribution(ExponentialDispersionModel):
     """
 
     lower_bound = 0
-    upper_bound = np.Inf
+    upper_bound = np.inf
     include_lower_bound = True
     include_upper_bound = False
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -929,7 +929,11 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                     warnings.warn("`min_alpha` is set. Ignoring `min_alpha_ratio`.")
                 min_alpha = self.min_alpha
             return np.logspace(
-                np.log(max_alpha), np.log(min_alpha), self.n_alphas, base=np.e
+                np.log(max_alpha),
+                np.log(min_alpha),
+                self.n_alphas,
+                base=np.e,
+                dtype=X.dtype,
             )
 
         if np.all(P1_no_alpha == 0):
@@ -1631,7 +1635,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         # We want to calculate Rb_r^T (RVR)^{-1} Rb_r.
         # We can do it in a more numerically stable way by using `scipy.linalg.solve`:
         try:
-            test_stat = float(Rb_r.T @ linalg.solve(RVR, Rb_r))
+            test_stat = (Rb_r.T @ linalg.solve(RVR, Rb_r))[0]
         except linalg.LinAlgError as err:
             raise linalg.LinAlgError("The restriction matrix is not full rank") from err
         p_value = 1 - stats.chi2.cdf(test_stat, Q)
@@ -2286,7 +2290,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                             list(
                                 chain.from_iterable(
                                     [elmt for _ in dtype.categories[int(drop_first) :]]
-                                    if pd.api.types.is_categorical_dtype(dtype)
+                                    if isinstance(dtype, pd.CategoricalDtype)
                                     else [elmt]
                                     for elmt, dtype in zip(penalty, X.dtypes)
                                 )

--- a/src/glum/_glm_cv.py
+++ b/src/glum/_glm_cv.py
@@ -455,7 +455,8 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
             alphas = [self._get_alpha_path(l1, X, y, sample_weight) for l1 in l1_ratio]
         else:
             alphas = np.tile(
-                np.sort(self.alphas)[::-1], (len(l1_ratio), 1), dtype=X.dtype
+                np.sort(np.asarray(self.alphas, dtype=X.dtype))[::-1],
+                (len(l1_ratio), 1),
             )
 
         if len(l1_ratio) == 1:

--- a/src/glum/_glm_cv.py
+++ b/src/glum/_glm_cv.py
@@ -454,7 +454,9 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
         if self.alphas is None:
             alphas = [self._get_alpha_path(l1, X, y, sample_weight) for l1 in l1_ratio]
         else:
-            alphas = np.tile(np.sort(self.alphas)[::-1], (len(l1_ratio), 1))
+            alphas = np.tile(
+                np.sort(self.alphas)[::-1], (len(l1_ratio), 1), dtype=X.dtype
+            )
 
         if len(l1_ratio) == 1:
             self.alphas_ = alphas[0]

--- a/src/glum/_solvers.py
+++ b/src/glum/_solvers.py
@@ -916,7 +916,7 @@ def _trust_constr_solver(
         # we express constraints in the form A theta <= b
         constraints = LinearConstraint(
             A=A_ineq_,
-            lb=-np.Inf,
+            lb=-np.inf,
             ub=b_ineq,
         )
     else:

--- a/src/glum/_util.py
+++ b/src/glum/_util.py
@@ -34,11 +34,11 @@ def _align_df_categories(df, dtypes) -> pd.DataFrame:
     categorical_dtypes = [
         column
         for column, dtype in dtypes.items()
-        if pd.api.types.is_categorical_dtype(dtype) and (column in df)
+        if isinstance(dtype, pd.CategoricalDtype) and (column in df)
     ]
 
     for column in categorical_dtypes:
-        if not pd.api.types.is_categorical_dtype(df[column]):
+        if not isinstance(dtypes[column], pd.CategoricalDtype):
             _logger.info(f"Casting {column} to categorical.")
             changed_dtypes[column] = df[column].astype(dtypes[column])
         elif list(df[column].cat.categories) != list(dtypes[column].categories):

--- a/src/glum/_util.py
+++ b/src/glum/_util.py
@@ -38,7 +38,7 @@ def _align_df_categories(df, dtypes) -> pd.DataFrame:
     ]
 
     for column in categorical_dtypes:
-        if not isinstance(dtypes[column], pd.CategoricalDtype):
+        if not isinstance(df[column].dtype, pd.CategoricalDtype):
             _logger.info(f"Casting {column} to categorical.")
             changed_dtypes[column] = df[column].astype(dtypes[column])
         elif list(df[column].cat.categories) != list(dtypes[column].categories):

--- a/src/glum_benchmarks/orig_sklearn_fork/_glm.py
+++ b/src/glum_benchmarks/orig_sklearn_fork/_glm.py
@@ -757,15 +757,15 @@ class TweedieDistribution(ExponentialDispersionModel):
         if not isinstance(power, numbers.Real):
             raise TypeError("power must be a real number, input was {}".format(power))
 
-        self._upper_bound = np.Inf
+        self._upper_bound = np.inf
         self._include_upper_bound = False
         if power < 0:
             # Extreme Stable
-            self._lower_bound = -np.Inf
+            self._lower_bound = -np.inf
             self._include_lower_bound = False
         elif power == 0:
             # NormalDistribution
-            self._lower_bound = -np.Inf
+            self._lower_bound = -np.inf
             self._include_lower_bound = False
         elif (power > 0) and (power < 1):
             raise ValueError("For 0<power<1, no distribution exists.")
@@ -877,8 +877,8 @@ class GeneralizedHyperbolicSecant(ExponentialDispersionModel):
     """
 
     def __init__(self):
-        self._lower_bound = -np.Inf
-        self._upper_bound = np.Inf
+        self._lower_bound = -np.inf
+        self._upper_bound = np.inf
         self._include_lower_bound = False
         self._include_upper_bound = False
 

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -844,12 +844,12 @@ def test_poisson_ridge(solver, tol, scale_predictors, use_sparse):
     # true_beta = model["beta"][:, 0]
     # print(true_intercept, true_beta)
 
-    X_dense = np.array([[-2, -1, 1, 2], [0, 0, 1, 1]], dtype=np.float_).T
+    X_dense = np.array([[-2, -1, 1, 2], [0, 0, 1, 1]], dtype=np.float64).T
     if use_sparse:
         X = sparse.csc_matrix(X_dense)
     else:
         X = X_dense
-    y = np.array([0, 1, 1, 2], dtype=np.float_)
+    y = np.array([0, 1, 1, 2], dtype=np.float64)
     model_args = dict(
         alpha=1,
         l1_ratio=0,
@@ -891,8 +891,8 @@ def test_poisson_ridge(solver, tol, scale_predictors, use_sparse):
 
 @pytest.mark.parametrize("scale_predictors", [True, False])
 def test_poisson_ridge_bounded(scale_predictors):
-    X = np.array([[-1, 1, 1, 2], [0, 0, 1, 1]], dtype=np.float_).T
-    y = np.array([0, 1, 1, 2], dtype=np.float_)
+    X = np.array([[-1, 1, 1, 2], [0, 0, 1, 1]], dtype=np.float64).T
+    y = np.array([0, 1, 1, 2], dtype=np.float64)
     lb = np.array([-0.1, -0.1])
     ub = np.array([0.1, 0.1])
 
@@ -930,8 +930,8 @@ def test_poisson_ridge_bounded(scale_predictors):
 
 @pytest.mark.parametrize("scale_predictors", [True, False])
 def test_poisson_ridge_ineq_constrained(scale_predictors):
-    X = np.array([[-1, 1, 1, 2], [0, 0, 1, 1]], dtype=np.float_).T
-    y = np.array([0, 1, 1, 2], dtype=np.float_)
+    X = np.array([[-1, 1, 1, 2], [0, 0, 1, 1]], dtype=np.float64).T
+    y = np.array([0, 1, 1, 2], dtype=np.float64)
     A_ineq = np.array([[1, 0], [0, 1], [-1, 0], [0, -1]])
     b_ineq = 0.1 * np.ones(shape=(4))
 
@@ -1472,7 +1472,7 @@ def test_clonable(estimator):
 def test_get_best_intercept(
     link: Link, distribution: ExponentialDispersionModel, tol: float, offset
 ):
-    y = np.array([1, 1, 1, 2], dtype=np.float_)
+    y = np.array([1, 1, 1, 2], dtype=np.float64)
     if isinstance(distribution, BinomialDistribution):
         y -= 1
 
@@ -2077,7 +2077,7 @@ def test_wald_test_matrix(regression_data, family, fit_intercept, R, r):
     )
 
     np.testing.assert_allclose(
-        our_results.test_statistic, sm_results.statistic, rtol=1e-3
+        our_results.test_statistic, sm_results.statistic[0], rtol=1e-3
     )
     np.testing.assert_allclose(our_results.p_value, sm_results.pvalue, atol=1e-3)
     assert our_results.df == sm_results.df_denom
@@ -2090,7 +2090,7 @@ def test_wald_test_matrix(regression_data, family, fit_intercept, R, r):
     )
 
     np.testing.assert_allclose(
-        our_results.test_statistic, sm_results.statistic, rtol=1e-3
+        our_results.test_statistic, sm_results.statistic[0], rtol=1e-3
     )
     np.testing.assert_allclose(our_results.p_value, sm_results.pvalue, atol=1e-3)
     assert our_results.df == sm_results.df_denom
@@ -2103,7 +2103,7 @@ def test_wald_test_matrix(regression_data, family, fit_intercept, R, r):
     sm_results = sm_fit.wald_test((R, r), scalar=False)
 
     np.testing.assert_allclose(
-        our_results.test_statistic, sm_results.statistic, rtol=1e-3
+        our_results.test_statistic, sm_results.statistic[0], rtol=1e-3
     )
     np.testing.assert_allclose(our_results.p_value, sm_results.pvalue, atol=1e-3)
     assert our_results.df == sm_results.df_denom
@@ -2161,7 +2161,7 @@ def test_wald_test_matrix_fixed_cov(regression_data, R, r):
     sm_results = fit_sm.wald_test((R, r), cov_p=mdl.covariance_matrix(), scalar=False)
 
     np.testing.assert_allclose(
-        our_results.test_statistic, sm_results.statistic, rtol=1e-8
+        our_results.test_statistic, sm_results.statistic[0], rtol=1e-8
     )
     np.testing.assert_allclose(our_results.p_value, sm_results.pvalue, atol=1e-8)
     assert our_results.df == sm_results.df_denom


### PR DESCRIPTION
Fixing glum to support numpy 2.0. Here is a summary of the changes:

- directly support numpy 2.0:  e.g. `np.Inf` -> `np.inf`
- also use a nightly install of pyarrow (since the stable version doesn't support numpy 2.0)
- some weird changes that should be monitored: statsmodels results are returned as a 2d array while we are using 1d array. The test used to work but now fails. Seems to now be okay with both numpy 2.0 and 1.26, so the likely culprit is probably that before numpy 2.0, [[a]] == [a].

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
