### PR TITLE
MNT add reference to _tweedie_normalization

### DIFF
--- a/src/glum/_functions.pyx
+++ b/src/glum/_functions.pyx
@@ -335,6 +335,7 @@ cdef floating _tweedie_unit_loglikelihood(floating y, floating mu, floating powe
         return (theta * y - kappa) / dispersion + normalization
 
 cdef floating _tweedie_normalization(floating y, floating power, floating dispersion) nogil:
+    # This implementation follows https://doi.org/10.1007/s11222-005-4070-y.
 
     cdef int j, j_lower, j_upper
 


### PR DESCRIPTION
This PR adds the reference paper for the Tweedie log-likelihood calculation.

Checklist
* [ ] Added a `CHANGELOG.rst` entry
