### PR TITLE
Fix cython performance regression

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,12 @@
 Changelog
 =========
 
-2.7.0 - 2023-10-xx
-------------------
+Unreleased
+----------
+
+**Bug fix:**
+
+- Added cython compiler directive legacy_implicit_noexcept = True to fix performance regression with cython 3.
 
 **Other changes:**
 

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,18 @@ setup(
         glm_benchmarks_run = glum_benchmarks.cli_run:cli_run
         glm_benchmarks_analyze = glum_benchmarks.cli_analyze:cli_analyze
     """,
-    ext_modules=cythonize(ext_modules, annotate=False),
+    ext_modules=cythonize(
+        ext_modules,
+        annotate=False,
+        compiler_directives={
+            "language_level": "3",
+            "boundscheck": False,
+            "wraparound": False,
+            "initializedcheck": False,
+            "nonecheck": False,
+            "cdivision": True,
+            "legacy_implicit_noexcept": True,
+        },
+    ),
     zip_safe=False,
 )

--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -7,7 +7,6 @@
 # License: BSD 3 clause
 #         Substantial modifications by Ben Thompson <t.ben.thompson@gmail.com>
 #
-# cython: boundscheck=False, wraparound=False, cdivision=True
 from libc.math cimport fabs
 cimport numpy as np
 import numpy as np

--- a/src/glum/_functions.pyx
+++ b/src/glum/_functions.pyx
@@ -1,5 +1,3 @@
-# cython: boundscheck=False, wraparound=False, cdivision=True
-
 from cython cimport floating
 from cython.parallel import prange
 


### PR DESCRIPTION
Fixes #721.

With cython 3, a major change in the way functions deal with exceptions happened. Before cython 3, if a function didn't have an explicit handling of exception, exceptions were ignored. With cython 3, the default is for a function to always propagate. This leads to a significant performance hit for us. This PR reverts to cython <3 behavior by using the `legacy_implicit_noexcept` compiler directive.

At the same time, I moved the compiler directives from a comment at the top of the cython files and centralized them in the setup.py file.

Testing with the code snippet in the linked issue gives me back the old performance (around 2ms)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
