### PR TITLE
Remove code that is not needed in tabmat v4 / glum v3

### DIFF
--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1424,16 +1424,6 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             )
             X = self._convert_from_pandas(X, context=captured_context)
 
-        X = check_array_tabmat_compliant(
-            X,
-            accept_sparse=["csr", "csc", "coo"],
-            dtype="numeric",
-            copy=self._should_copy_X(),
-            ensure_2d=True,
-            allow_nd=False,
-            drop_first=getattr(self, "drop_first", False),
-        )
-
         eta = self.linear_predictor(
             X, offset=offset, alpha_index=alpha_index, alpha=alpha
         )

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -228,20 +228,6 @@ def _check_offset(
     return offset
 
 
-def _name_categorical_variables(
-    categories: tuple[str], column_name: str, drop_first: bool
-):
-    new_names = [
-        f"{column_name}__{category}" for category in categories[int(drop_first) :]
-    ]
-    if len(new_names) == 0:
-        raise ValueError(
-            f"Categorical column: {column_name}, contains only one category. "
-            + "This should be dropped from the feature matrix."
-        )
-    return new_names
-
-
 def _parse_formula(
     formula: FormulaSpec, include_intercept: bool = True
 ) -> tuple[Optional[Formula], Formula]:
@@ -2708,18 +2694,6 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 self.feature_dtypes_ = X.dtypes.to_dict()
 
                 if any(X.dtypes == "category"):
-                    self.feature_names_ = list(
-                        chain.from_iterable(
-                            _name_categorical_variables(
-                                dtype.categories,
-                                column,
-                                getattr(self, "drop_first", False),
-                            )
-                            if isinstance(dtype, pd.CategoricalDtype)
-                            else [column]
-                            for column, dtype in zip(X.columns, X.dtypes)
-                        )
-                    )
 
                     def _expand_categorical_penalties(penalty, X, drop_first):
                         """


### PR DESCRIPTION
This PR removes two unnecessary pieces that made it back to the v3 branch:
- Variable name creation in glum, which is unnecessary becaue tabmat v4 does it internally. Also leads to a test failure in `tests/glm/test_glm.py::test_dropping_distinct_categorical_column`.
- Duplicate call of `check_array_tabmat_compliant` in `predict` (it already calls it via `linear_predictor`).
