### PR TITLE
Fix formula test: consider presence of intercept in full rankness check when constructing the model matrix externally

### DIFF
--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -2967,7 +2967,7 @@ def get_mixed_data():
         pytest.param("y ~ c1 + 1", id="categorical_intercept"),
         pytest.param("y ~ x1 * c1 * c2", id="interaction"),
         pytest.param("y ~ x1 + x2 + c1 + c2", id="numeric_and_categorical"),
-        pytest.param("y ~ x1 + x2 + c1 + c2 + 1", id="numeric_and_categorical"),
+        pytest.param("y ~ x1 + x2 + c1 + c2 + 1", id="numeric_and_categorical_intercept"),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
`test_formula` compares a `GeneralizedLinearRegressor` set up with a `formula` argument to one that receives an externally created model matrix via `formulaic.model_matrix`. The test used to fail for one case because the full rank check in the externally created model matrix did not take into account whether the formula implied an intercept or not.