### PR TITLE
Do not fail when an estimator misses class members that are new in v3

### DIFF
--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -906,7 +906,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         X = tm.from_pandas(
             df,
             drop_first=self.drop_first,
-            categorical_format=getattr(  # categorical format prior to v3
+            categorical_format=getattr(  # convention prior to v3
                 self, "categorical_format", "{name}__{category}"
             ),
             cat_missing_method=cat_missing_method_after_alignment,
@@ -2787,7 +2787,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 X = tm.from_pandas(
                     X,
                     drop_first=self.drop_first,
-                    categorical_format=getattr(
+                    categorical_format=getattr(  # convention prior to v3
                         self, "categorical_format", "{name}__{category}"
                     ),
                     cat_missing_method=getattr(self, "cat_missing_method", "fail"),

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -890,9 +890,9 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 df,
                 self.feature_dtypes_,
                 getattr(self, "has_missing_category_", {}),
-                getattr(self, "cat_missing_method", "fail"),
+                cat_missing_method_after_alignment,
             )
-            if getattr(self, "cat_missing_method", "fail") == "convert":
+            if cat_missing_method_after_alignment == "convert":
                 df = _add_missing_categories(
                     df=df,
                     dtypes=self.feature_dtypes_,

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -910,8 +910,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         X = tm.from_pandas(
             df,
             drop_first=self.drop_first,
-            # prior to v3, categorical format used underscore
-            categorical_format=getattr(
+            categorical_format=getattr(  # categorical format prior to v3
                 self, "categorical_format", "{name}__{category}"
             ),
             cat_missing_method=cat_missing_method_after_alignment,

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -889,11 +889,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             df = _align_df_categories(
                 df,
                 self.feature_dtypes_,
-                getattr(
-                    self,
-                    "has_missing_category_",
-                    {f: False for f in self.feature_dtypes_.keys()},
-                ),
+                getattr(self, "has_missing_category_", {}),
                 getattr(self, "cat_missing_method", "fail"),
             )
             if getattr(self, "cat_missing_method", "fail") == "convert":

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -896,10 +896,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 ),
                 getattr(self, "cat_missing_method", "fail"),
             )
-            if (
-                hasattr(self, "categorical_format")
-                and self.cat_missing_method == "convert"
-            ):
+            if getattr(self, "cat_missing_method", "fail"):
                 df = _add_missing_categories(
                     df=df,
                     dtypes=self.feature_dtypes_,

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1631,7 +1631,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         )
         if num_lhs_specs != 1:
             raise ValueError(
-                "Exactly one of R, features terms or formula must be specified. "
+                "Exactly one of R, features, terms or formula must be specified. "
                 f"Received {num_lhs_specs} specifications."
             )
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -896,7 +896,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 ),
                 getattr(self, "cat_missing_method", "fail"),
             )
-            if getattr(self, "cat_missing_method", "fail"):
+            if getattr(self, "cat_missing_method", "fail") == "convert":
                 df = _add_missing_categories(
                     df=df,
                     dtypes=self.feature_dtypes_,


### PR DESCRIPTION
So that, in v3, we can still use models that were trained on glum < 3.0.
