### PR TITLE
Daily run failure: add `n_samples` keyword argument to `ColumnTransformer` in benchmarks

### DIFF
--- a/src/glum_benchmarks/data/create_insurance.py
+++ b/src/glum_benchmarks/data/create_insurance.py
@@ -181,7 +181,7 @@ class ColumnTransformer(sklearn.compose.ColumnTransformer):
         )
 
     def _hstack(
-        self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples: int = None
+        self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples=None
     ):
         """Stacks X horizontally."""
         _ = n_samples  # for compatibility

--- a/src/glum_benchmarks/data/create_insurance.py
+++ b/src/glum_benchmarks/data/create_insurance.py
@@ -180,9 +180,7 @@ class ColumnTransformer(sklearn.compose.ColumnTransformer):
             transformer_weights=transformer_weights,
         )
 
-    def _hstack(
-        self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples=None
-    ):
+    def _hstack(self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples=None):
         """Stacks X horizontally."""
         _ = n_samples  # for compatibility
         return pd.concat(Xs, axis="columns")

--- a/src/glum_benchmarks/data/create_insurance.py
+++ b/src/glum_benchmarks/data/create_insurance.py
@@ -180,7 +180,9 @@ class ColumnTransformer(sklearn.compose.ColumnTransformer):
             transformer_weights=transformer_weights,
         )
 
-    def _hstack(self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples: int = None):
+    def _hstack(
+        self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples: int = None
+    ):
         """Stacks X horizontally."""
         _ = n_samples  # for compatibility
         return pd.concat(Xs, axis="columns")

--- a/src/glum_benchmarks/data/create_insurance.py
+++ b/src/glum_benchmarks/data/create_insurance.py
@@ -182,7 +182,6 @@ class ColumnTransformer(sklearn.compose.ColumnTransformer):
 
     def _hstack(self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples=None):
         """Stacks X horizontally."""
-        _ = n_samples  # for compatibility
         return pd.concat(Xs, axis="columns")
 
 

--- a/src/glum_benchmarks/data/create_insurance.py
+++ b/src/glum_benchmarks/data/create_insurance.py
@@ -180,7 +180,7 @@ class ColumnTransformer(sklearn.compose.ColumnTransformer):
             transformer_weights=transformer_weights,
         )
 
-    def _hstack(self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples: int):
+    def _hstack(self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples: int = None):
         """Stacks X horizontally."""
         _ = n_samples  # for compatibility
         return pd.concat(Xs, axis="columns")

--- a/src/glum_benchmarks/data/create_insurance.py
+++ b/src/glum_benchmarks/data/create_insurance.py
@@ -180,8 +180,9 @@ class ColumnTransformer(sklearn.compose.ColumnTransformer):
             transformer_weights=transformer_weights,
         )
 
-    def _hstack(self, Xs: Iterable[Union[pd.Series, pd.DataFrame]]):
+    def _hstack(self, Xs: Iterable[Union[pd.Series, pd.DataFrame]], *, n_samples: int):
         """Stacks X horizontally."""
+        _ = n_samples  # for compatibility
         return pd.concat(Xs, axis="columns")
 
 


### PR DESCRIPTION
Sklearn's `ColumnTransformer` now expects `n_samples` as non-optional keyword argument, see [here](https://github.com/scikit-learn/scikit-learn/commit/4a28ba34af9a042dd4c146b463d17c273903c2c0).