### PR TITLE
Restructure distributions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,14 +15,18 @@ Changelog
 - All arguments to :class:`~glum.GeneralizedLinearRegressorBase`, :class:`~glum.GeneralizedLinearRegressor`, and :class:`GeneralizedLinearRegressorCV` are now keyword-only.
 - All arguments to public methods of :class:`~glum.GeneralizedLinearRegressorBase`, :class:`~glum.GeneralizedLinearRegressor` or :class:`GeneralizedLinearRegressorCV` except `X`, `y`, `sample_weight`, and `offset` are now keyword-only.
 - :class:`~glum.GeneralizedLinearRegressor`'s default value for `alpha` is now `0`, i.e. no regularization.
+- :class:`~glum.GammaDistribution`, :class:`~glum.InverseGaussianDistribution`, :class:`~glum.NormalDistribution` and :class:`~glum.PoissonDistribution` no longer inherit from :class:`~glum.TweedieDistribution`.
+- The power parameter of :class:`~glum.TweedieLink` has been renamed from ``p`` to ``power``, in line with :class:`~glum.TweedieDistribution`.
+- :class:`~glum.TweedieLink` no longer instantiates :class:`~glum.IdentityLink` or :class:`~glum.LogLink` for ``power=0`` and ``power=1``, respectively. On the other hand, :class:`~glum.TweedieLink` is now compatible with ``power=0`` and ``power=1``.
 
 **New features:**
 
 - Added a formula interface for specifying models.
-- Improved feature name handling. Feature names are now created for non-pandas input matrices, too. Furthermore, the format of categorical features can be specified by the user.
+- Improved feature name handling. Feature names are now created for non-pandas input matrices too. Furthermore, the format of categorical features can be specified by the user.
 - Term names are now stored in the model's attributes. This is useful for categorical features, where they refer to the whole variable, not just single levels.
 - Added more options for treating missing values in categorical columns. They can either raise a `ValueError` (`"fail"`), be treated as all-zero indicators (`"zero"`) or represented as a new category (`"convert"`).
 - `meth:GeneralizedLinearRegressor.wald_test` can now perform tests based on a formula string and term names.
+- :class:`~glum.InverseGaussianDistribution` gains a :meth:`~glum.InverseGaussianDistribution.log_likelihood` method.
 
 
 2.7.0 - 2024-02-19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ default_section = 'THIRDPARTY'
 skip = [
   "*-win32",
   "*-manylinux_i686",
-  "pp*", 
+  "pp*",
   "*-musllinux_*",
   "cp36*",
   "cp37*",

--- a/src/glum/_distribution.py
+++ b/src/glum/_distribution.py
@@ -14,6 +14,10 @@ from ._functions import (
     gamma_log_eta_mu_deviance,
     gamma_log_likelihood,
     gamma_log_rowwise_gradient_hessian,
+    inv_gaussian_deviance,
+    inv_gaussian_log_eta_mu_deviance,
+    inv_gaussian_log_likelihood,
+    inv_gaussian_log_rowwise_gradient_hessian,
     negative_binomial_deviance,
     negative_binomial_log_eta_mu_deviance,
     negative_binomial_log_likelihood,
@@ -38,45 +42,23 @@ from ._util import _safe_lin_pred, _safe_sandwich_dot
 class ExponentialDispersionModel(metaclass=ABCMeta):
     r"""Base class for reproductive Exponential Dispersion Models (EDM).
 
-    The PDF of :math:`Y \sim \mathrm{EDM}(\mu, \phi)` is given by
+    The PDF of :math:`Y \sim \mathrm{EDM}(\theta, \phi)` is given by
 
     .. math::
 
         p(y \mid \theta, \phi)
-        &= c(y, \phi) \exp((\theta y - A(\theta)_ / \phi) \\
-        &= \tilde{c}(y, \phi) \exp(-d(y, \mu) / (2\phi))
+        &= \exp \left(\frac{y \theta - b(\theta)}{\phi / w} + c(y; w / \phi) \right),
 
-    with mean :math:`\mathrm{E}(Y) = A'(\theta) = \mu`, variance
-    :math:`\mathrm{var}(Y) = \phi \cdot v(\mu)`, unit variance
-    :math:`v(\mu)` and unit deviance :math:`d(y, \mu)`.
+    where :math:`\theta` is the scale parameter, :math:`\phi` is the dispersion
+    parameter, :math:`w` is a given weight, :math:`b` is the cumulant function
+    and :math:`c` is a normalization term.
 
-    Properties
-    ----------
-    lower_bound
-    upper_bound
-    include_lower_bound
-    include_upper_bound
-
-    Methods
-    -------
-    in_y_range
-    unit_variance
-    unit_variance_derivative
-    variance
-    variance_derivative
-    unit_deviance
-    unit_deviance_derivative
-    deviance
-    deviance_derivative
-    starting_mu
-
-    _mu_deviance_derivative
-    eta_mu_deviance
-    gradient_hessian
+    It can be shown that :math:`\mathrm{E}(Y) = b'(\theta)` and
+    :math:`\mathrm{var}(Y) = b''(\theta) \times \phi / w`.
 
     References
     ----------
-    https://en.wikipedia.org/wiki/Exponential_dispersion_model.
+    < https://en.wikipedia.org/wiki/Exponential_dispersion_model >.
     """
 
     @property
@@ -104,51 +86,39 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         pass
 
     def in_y_range(self, x) -> np.ndarray:
-        """Return ``True`` if ``x`` is in the valid range of the EDM.
-
-        Parameters
-        ----------
-        x : array-like, shape (n_samples,)
-            Target values.
-
-        Returns
-        -------
-        np.ndarray
-        """
+        """Return ``True`` if ``x`` is in the valid range of the EDM."""
         if self.include_lower_bound:
-            if self.include_upper_bound:
-                return np.logical_and(
-                    np.greater_equal(x, self.lower_bound),
-                    np.less_equal(x, self.upper_bound),
-                )
-            else:
-                return np.logical_and(
-                    np.greater_equal(x, self.lower_bound), np.less(x, self.upper_bound)
-                )
+            lb_op = np.greater_equal
         else:
-            if self.include_upper_bound:
-                return np.logical_and(
-                    np.greater(x, self.lower_bound), np.less_equal(x, self.upper_bound)
-                )
-            else:
-                return np.logical_and(
-                    np.greater(x, self.lower_bound), np.less(x, self.upper_bound)
-                )
+            lb_op = np.greater
+
+        if self.include_upper_bound:
+            ub_op = np.less_equal
+        else:
+            ub_op = np.less
+
+        return lb_op(x, self.lower_bound) & ub_op(x, self.upper_bound)
+
+    def to_tweedie(self):
+        """Return the Tweedie representation of a distribution if it exists."""
+        if hasattr(self, "__tweedie_repr__"):
+            return self.__tweedie_repr__()
+        return None
 
     @abstractmethod
     def unit_variance(self, mu):
-        r"""Compute the unit variance function.
+        r"""Compute the unit variance.
 
-        The unit variance :math:`v(\mu)` determines the variance as a function
-        of the mean :math:`\mu` by
-        :math:`\mathrm{var}(y_i) = (\phi / s_i) \times v(\mu_i)`. It can
-        also be derived from the unit deviance :math:`d(y, \mu)` as
+        The unit variance, :math:`v(\mu) \equiv b''((b')^{-1} (\mu))`,
+        determines the variance as a function of the mean :math:`\mu` by
+        :math:`\mathrm{var}(y_i) = v(\mu_i) \times \phi / w_i`. It can also be
+        derived from the unit deviance :math:`d(y, \mu)` as
 
         .. math::
 
-            v(\mu) = \frac{2}{\frac{\partial^2 d(y, \mu)}{\partial\mu^2}}\big|_{y=\mu}.
+            v(\mu) = 2 \div \frac{\partial^2 d(y, \mu)}{\partial\mu^2} \big| _{y=\mu}.
 
-        See also :func:`variance`.
+        See also :meth:`~ExponentialDispersionModel.variance`.
 
         Parameters
         ----------
@@ -161,8 +131,6 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
     def unit_variance_derivative(self, mu):
         r"""Compute the derivative of the unit variance with respect to ``mu``.
 
-        Return :math:`v'(\mu)`.
-
         Parameters
         ----------
         mu : array-like, shape (n_samples,)
@@ -170,12 +138,12 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         """
         pass
 
-    def variance(self, mu: np.ndarray, dispersion=1, sample_weight=1) -> np.ndarray:
+    def variance(self, mu, dispersion=1, sample_weight=1) -> np.ndarray:
         r"""Compute the variance function.
 
-        The variance of :math:`Y_i \sim \mathrm{EDM}(\mu_i, \phi / s_i)` is
-        :math:`\mathrm{var}(Y_i) = (\phi / s_i) * v(\mu_i)`, with unit variance
-        :math:`v(\mu)` and weights :math:`s_i`.
+        The variance of :math:`Y_i \sim \mathrm{EDM}(\mu_i, \phi / w_i)` takes
+        the form :math:`v(\mu_i) \times \phi / w_i`, where :math:`v(\mu)` is the
+        unit variance and :math:`w_i` are weights.
 
         Parameters
         ----------
@@ -198,8 +166,8 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         r"""Compute the derivative of the variance with respect to ``mu``.
 
         The derivative of the variance is equal to
-        :math:`(\phi / s_i) * v'(\mu_i)`, where :math:`v(\mu)` is the unit
-        variance and :math:`s_i` are weights.
+        :math:`v(\mu_i) \times \phi / w_i`, where :math:`v(\mu)` is the unit
+        variance and :math:`ws_i` are weights.
 
         Parameters
         ----------
@@ -222,8 +190,10 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
     def unit_deviance(self, y, mu):
         r"""Compute the unit deviance.
 
-        In terms of the log likelihood :math:`L`, the unit deviance is
-        :math:`-2\phi\times [L(y, \mu, \phi) - L(y, y, \phi)].`
+        In terms of the unit log likelihood :math:`\ell`, the unit deviance is
+        :math:`2 [\ell(y_i, y_i, \phi) - \ell(y_i, \mu, \phi)]`, i.e. twice the
+        difference between the log likelihood of a saturated model (with one
+        parameter per observation) and the model at hand.
 
         Parameters
         ----------
@@ -239,7 +209,7 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         r"""Compute the derivative of the unit deviance with respect to ``mu``.
 
         The derivative of the unit deviance is given by
-        :math:`-2 \times (y - \mu) / v(\mu)`, where :math:`v(\mu)` is the unit
+        :math:`2 \times (\mu - y) / v(\mu)`, where :math:`v(\mu)` is the unit
         variance.
 
         Parameters
@@ -256,13 +226,14 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         """
         return -2 * (y - mu) / self.unit_variance(mu)
 
-    def deviance(self, y, mu, sample_weight=1):
+    def deviance(self, y, mu, sample_weight=1) -> float:
         r"""Compute the deviance.
 
-        The deviance is a weighted sum of the unit deviances,
-        :math:`\sum_i s_i \times d(y_i, \mu_i)`, where :math:`d(y, \mu)` is the
-        unit deviance and :math:`s` are weights. In terms of the log likelihood,
-        it is :math:`-2\phi \times [L(y, \mu, \phi / s) - L(y, y, \phi / s)]`.
+        The deviance is a weighted sum of the unit deviances. In terms of the
+        unit log likelihood :math:`\ell`, it equals
+        :math:`2 \sum_i [\ell(y_i, y_i, \phi) - \ell(y_i, \mu, \phi)]`,
+        i.e. twice the difference between the log likelihood of a saturated
+        model (with one parameter per observation) and the model at hand.
 
         Parameters
         ----------
@@ -273,11 +244,7 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
             Predicted mean.
 
         sample_weight : array-like, shape (n_samples,), optional (default=1)
-            Weights or exposure to which variance is inversely proportional.
-
-        Returns
-        -------
-        float
+            Weights or exposure to which the variance is inversely proportional.
         """
         if sample_weight is None:
             return np.sum(self.unit_deviance(y, mu))
@@ -306,46 +273,41 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
 
     def _mu_deviance_derivative(
         self,
-        coef: np.ndarray,
-        X,
-        y: np.ndarray,
-        sample_weight: np.ndarray,
+        coef,
+        X: Union[MatrixBase, StandardizedMatrix],
+        y,
+        sample_weight,
         link: Link,
-        offset: np.ndarray = None,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """Compute ``mu`` and the derivative of the deviance \
-            with respect to coefficients."""
+        offset=None,
+    ):
+        """Compute ``mu`` and the derivative of the deviance with respect to coefficients."""
         lin_pred = _safe_lin_pred(X, coef, offset)
         mu = link.inverse(lin_pred)
         d1 = link.inverse_derivative(lin_pred)
         temp = d1 * self.deviance_derivative(y, mu, sample_weight)
+
         if coef.size == X.shape[1] + 1:
             devp = np.concatenate(([temp.sum()], temp @ X))
         else:
             devp = temp @ X  # same as X.T @ temp
+
         return mu, devp
 
     def eta_mu_deviance(
         self,
         link: Link,
         factor: float,
-        cur_eta: np.ndarray,
-        X_dot_d: np.ndarray,
-        y: np.ndarray,
-        sample_weight: np.ndarray,
-    ):
-        """
-        Compute ``eta``, ``mu`` and the deviance.
-
-        Compute:
-        * the linear predictor, ``eta``, as ``cur_eta + factor * X_dot_d``;
-        * the link-function-transformed prediction, ``mu``;
-        * the deviance.
+        cur_eta,
+        X_dot_d,
+        y,
+        sample_weight,
+    ) -> tuple[np.ndarray, np.ndarray, float]:
+        """Compute ``eta``, ``mu`` and the deviance.
 
         Returns
         -------
         numpy.ndarray, shape (X.shape[0],)
-            The linear predictor, ``eta``.
+            The linear predictor, ``eta``, as ``cur_eta + factor * X_dot_d``.
         numpy.ndarray, shape (X.shape[0],)
             The link-function-transformed prediction, ``mu``.
         float
@@ -355,24 +317,25 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         # avoiding allocating new arrays for every line search loop
         eta_out = np.empty_like(cur_eta)
         mu_out = np.empty_like(cur_eta)
+
         deviance = self._eta_mu_deviance(
             link, factor, cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out
         )
+
         return eta_out, mu_out, deviance
 
     def _eta_mu_deviance(
         self,
         link: Link,
         factor: float,
-        cur_eta: np.ndarray,
-        X_dot_d: np.ndarray,
-        y: np.ndarray,
-        sample_weight: np.ndarray,
-        eta_out: np.ndarray,
-        mu_out: np.ndarray,
-    ):
-        """
-        Update ``eta`` and ``mu`` and compute the deviance.
+        cur_eta,
+        X_dot_d,
+        y,
+        sample_weight,
+        eta_out,
+        mu_out,
+    ) -> float:
+        """Update ``eta`` and ``mu`` and compute the deviance.
 
         This is a default implementation that should work for all valid
         distributions and link functions. To implement a custom optimized
@@ -382,6 +345,7 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         Returns
         -------
         float
+            The deviance.
         """
         eta_out[:] = cur_eta + factor * X_dot_d
         mu_out[:] = link.inverse(eta_out)
@@ -390,17 +354,16 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
     def rowwise_gradient_hessian(
         self,
         link: Link,
-        coef: np.ndarray,
+        coef,
         dispersion,
         X: Union[MatrixBase, StandardizedMatrix],
-        y: np.ndarray,
-        sample_weight: np.ndarray,
-        eta: np.ndarray,
-        mu: np.ndarray,
-        offset: np.ndarray = None,
+        y,
+        sample_weight,
+        eta,
+        mu,
+        offset=None,
     ):
-        """
-        Compute the gradient and negative Hessian of the log likelihood row-wise.
+        """Compute the gradient and negative Hessian of the log likelihood row-wise.
 
         Returns
         -------
@@ -411,6 +374,7 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
         """
         gradient_rows = np.empty_like(mu)
         hessian_rows = np.empty_like(mu)
+
         self._rowwise_gradient_hessian(
             link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
         )
@@ -422,8 +386,7 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
     def _rowwise_gradient_hessian(
         self, link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
     ):
-        """
-        Update ``gradient_rows`` and ``hessian_rows`` in place.
+        """Update ``gradient_rows`` and ``hessian_rows`` in place.
 
         This is a default implementation that should work for all valid
         distributions and link functions. To implement a custom optimized
@@ -551,10 +514,6 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
 
         method = {'pearson', 'deviance'}, optional (default='pearson')
             Whether to base the estimate on the Pearson residuals or the deviance.
-
-        Returns
-        -------
-        float
         """
         y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
 
@@ -580,24 +539,27 @@ class TweedieDistribution(ExponentialDispersionModel):
 
     A Tweedie distribution with mean :math:`\mu = \mathrm{E}(Y)` is uniquely
     defined by its mean-variance relationship
-    :math:`\mathrm{var}(Y) \propto \mu^{\mathrm{power}}`.
+    :math:`\mathrm{var}(Y) \propto \mu^{\mathrm{p}}`.
 
     Special cases are:
 
-    ====== ================
-    Power  Distribution
-    ====== ================
-    0      Normal
-    1      Poisson
-    (1, 2) Compound Poisson
-    2      Gamma
-    3      Inverse Gaussian
-    ====== ================
+    ====== ================ ============
+    Power  Distribution     Support
+    ====== ================ ============
+    0      Normal           ``(-∞, +∞)``
+    1      Poisson          ``[0, +∞)``
+    (1, 2) Compound Poisson ``[0, +∞)``
+    2      Gamma            ``(0, +∞)``
+    3      Inverse Gaussian ``(0, +∞)``
+    ====== ================ ============
+
+    See the documentation of the superclass,
+    :class:`~glum.ExponentialDispersionModel`, for details.
 
     Parameters
     ----------
     power : float, optional (default=0)
-        The variance power of the `unit_variance`
+        The variance power of the ``unit_variance``
         :math:`v(\mu) = \mu^{\mathrm{power}}`. For
         :math:`0 < \mathrm{power} < 1`, no distribution exists.
     """
@@ -612,9 +574,11 @@ class TweedieDistribution(ExponentialDispersionModel):
     def __eq__(self, other):  # noqa D
         return isinstance(other, TweedieDistribution) and (self.power == other.power)
 
+    def __tweedie_repr__(self):  # noqa D
+        return self.__class__(self.power)
+
     @property
-    def lower_bound(self) -> float:
-        """Return the lowest value of ``y`` allowed."""
+    def lower_bound(self) -> float:  # noqa D
         if self.power <= 0:
             return -np.inf
         if self.power >= 1:
@@ -622,8 +586,7 @@ class TweedieDistribution(ExponentialDispersionModel):
         raise ValueError
 
     @property
-    def include_lower_bound(self) -> bool:
-        """Return whether ``lower_bound`` is allowed as a value of ``y``."""
+    def include_lower_bound(self) -> bool:  # noqa D
         if self.power <= 0:
             return False
         if (self.power >= 1) and (self.power < 2):
@@ -639,97 +602,66 @@ class TweedieDistribution(ExponentialDispersionModel):
 
     @power.setter
     def power(self, power):
-        if not isinstance(power, (int, float)):
-            raise TypeError(f"power must be an int or float, input was {power}")
+
+        if not isinstance(power, (int, float, np.number)):
+            raise TypeError(f"The power parameter must be numeric; got {power}.")
         if (power > 0) and (power < 1):
-            raise ValueError("For 0<power<1, no distribution exists.")
+            raise ValueError("For `0 < p < 1`, no distribution exists.")
 
         # Prevents upcasting when working with 32-bit data
         self._power = power if isinstance(power, int) else np.float32(power)
 
-    def unit_variance(self, mu: np.ndarray) -> np.ndarray:
-        """Compute the unit variance of a Tweedie distribution ``v(mu) = mu^power``.
-
-        Parameters
-        ----------
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        Returns
-        -------
-        numpy.ndarray, shape (n_samples,)
-        """
+    def unit_variance(self, mu):  # noqa D
         p = self.power  # noqa: F841
         return numexpr.evaluate("mu ** p")
 
-    def unit_variance_derivative(self, mu: np.ndarray) -> np.ndarray:
-        r"""Compute the derivative of the unit variance of a Tweedie distribution.
-
-        Equation: :math:`v(\mu) = p \times \mu^{(p-1)}`.
-
-        Parameters
-        ----------
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        Returns
-        -------
-        numpy.ndarray, shape (n_samples,)
-        """
+    def unit_variance_derivative(self, mu):  # noqa D
         p = self.power  # noqa: F841
         return numexpr.evaluate("p * mu ** (p - 1)")
 
-    def deviance(self, y, mu, sample_weight=None) -> float:
-        """Compute the deviance.
+    def deviance(self, y, mu, sample_weight=None) -> float:  # noqa D
 
-        Parameters
-        ----------
-        y : array-like, shape (n_samples,)
-            Target values.
-
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        sample_weight : array-like, shape (n_samples,), optional (default=1)
-            Sample weights.
-        """
-        p = self.power
         y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
         sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
 
         # NOTE: the dispersion parameter is only necessary to convey
         # type information on account of a bug in Cython
 
-        if p == 0:
+        if self.power == 0:
             return normal_deviance(y, sample_weight, mu, dispersion=1.0)
-        if p == 1:
+        if self.power == 1:
             return poisson_deviance(y, sample_weight, mu, dispersion=1.0)
-        elif p == 2:
+        elif self.power == 2:
             return gamma_deviance(y, sample_weight, mu, dispersion=1.0)
+        elif self.power == 3:
+            return inv_gaussian_deviance(y, sample_weight, mu, dispersion=1.0)
         else:
-            return tweedie_deviance(y, sample_weight, mu, p=float(p))
+            return tweedie_deviance(y, sample_weight, mu, p=float(self.power))
 
-    def unit_deviance(self, y, mu):
-        """Get the deviance of each observation."""
-        p = self.power
-        if p == 0:  # Normal distribution
+    def unit_deviance(self, y, mu):  # noqa D
+
+        if self.power == 0:  # normal distribution
             return (y - mu) ** 2
-        if p == 1:  # Poisson distribution
+        if self.power == 1:  # Poisson distribution
             return 2 * (special.xlogy(y, y / mu) - y + mu)
-        elif p == 2:  # Gamma distribution
+        elif self.power == 2:  # Gamma distribution
             return 2 * (np.log(mu / y) + y / mu - 1)
+        elif self.power == 3:  # inverse Gaussian distribution
+            return ((y / mu - 1) ** 2) / y
         else:
-            mu1mp = mu ** (1 - p)
+            mu1mp = mu ** (1 - self.power)
             return 2 * (
-                (np.maximum(y, 0) ** (2 - p)) / ((1 - p) * (2 - p))
-                - y * mu1mp / (1 - p)
-                + mu * mu1mp / (2 - p)
+                (np.maximum(y, 0) ** (2 - self.power))
+                / ((1 - self.power) * (2 - self.power))
+                - y * mu1mp / (1 - self.power)
+                + mu * mu1mp / (2 - self.power)
             )
 
     def _rowwise_gradient_hessian(
         self, link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
     ):
         f = None
+
         if self.power == 0 and isinstance(link, IdentityLink):
             f = normal_identity_rowwise_gradient_hessian
         elif self.power == 1 and isinstance(link, LogLink):
@@ -738,6 +670,8 @@ class TweedieDistribution(ExponentialDispersionModel):
             f = gamma_log_rowwise_gradient_hessian
         elif 1 < self.power < 2 and isinstance(link, LogLink):
             f = partial(tweedie_log_rowwise_gradient_hessian, p=self.power)
+        elif self.power == 3:
+            f = partial(inv_gaussian_log_rowwise_gradient_hessian, p=self.power)
 
         if f is not None:
             return f(y, sample_weight, eta, mu, gradient_rows, hessian_rows)
@@ -758,6 +692,7 @@ class TweedieDistribution(ExponentialDispersionModel):
         mu_out: np.ndarray,
     ):
         f = None
+
         if self.power == 0 and isinstance(link, IdentityLink):
             f = normal_identity_eta_mu_deviance
         elif self.power == 1 and isinstance(link, LogLink):
@@ -766,6 +701,8 @@ class TweedieDistribution(ExponentialDispersionModel):
             f = gamma_log_eta_mu_deviance
         elif 1 < self.power < 2 and isinstance(link, LogLink):
             f = partial(tweedie_log_eta_mu_deviance, p=self.power)
+        elif self.power == 3 and isinstance(link, LogLink):
+            f = partial(inv_gaussian_log_eta_mu_deviance, p=self.power)
 
         if f is not None:
             return f(cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out, factor)
@@ -777,7 +714,7 @@ class TweedieDistribution(ExponentialDispersionModel):
     def log_likelihood(self, y, mu, sample_weight=None, dispersion=None) -> float:
         r"""Compute the log likelihood.
 
-        For ``1 < power < 2``, we use the series approximation by Dunn and Smyth
+        For ``1 < p < 2``, we use the series approximation by Dunn and Smyth
         (2005) to compute the normalization term.
 
         Parameters
@@ -813,33 +750,14 @@ class TweedieDistribution(ExponentialDispersionModel):
             return tweedie_log_likelihood(
                 y, sample_weight, mu, float(p), float(dispersion)
             )
+        elif p == 3:
+            return inv_gaussian_log_likelihood(y, sample_weight, mu, float(dispersion))
         else:
             raise NotImplementedError
 
-    def dispersion(self, y, mu, sample_weight=None, ddof=1, method="pearson") -> float:
-        r"""Estimate the dispersion parameter :math:`\phi`.
-
-        Parameters
-        ----------
-        y : array-like, shape (n_samples,)
-            Target values.
-
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        sample_weight : array-like, shape (n_samples,), optional (default=None)
-            Weights or exposure to which variance is inversely proportional.
-
-        ddof : int, optional (default=1)
-            Degrees of freedom consumed by the model for ``mu``.
-
-        method = {'pearson', 'deviance'}, optional (default='pearson')
-            Whether to base the estimate on the Pearson residuals or the deviance.
-
-        Returns
-        -------
-        float
-        """
+    def dispersion(  # noqa D
+        self, y, mu, sample_weight=None, ddof=1, method="pearson"
+    ) -> float:
         p = self.power  # noqa: F841
         y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
 
@@ -856,38 +774,13 @@ class TweedieDistribution(ExponentialDispersionModel):
         )
 
 
-class NormalDistribution(TweedieDistribution):
-    """Class for the Normal (a.k.a. Gaussian) distribution."""
+class NormalDistribution(ExponentialDispersionModel):
+    """Class for the normal (a.k.a. Gaussian) distribution.
 
-    def __init__(self):
-        super().__init__(power=0)
+    The normal distribution models outcomes ``y`` in ``(-∞, +∞)``.
 
-
-class PoissonDistribution(TweedieDistribution):
-    """Class for the scaled Poisson distribution."""
-
-    def __init__(self):
-        super().__init__(power=1)
-
-
-class GammaDistribution(TweedieDistribution):
-    """Class for the Gamma distribution."""
-
-    def __init__(self):
-        super().__init__(power=2)
-
-
-class InverseGaussianDistribution(TweedieDistribution):
-    """Class for the scaled Inverse Gaussian distribution."""
-
-    def __init__(self):
-        super().__init__(power=3)
-
-
-class GeneralizedHyperbolicSecant(ExponentialDispersionModel):
-    """A class for the Generalized Hyperbolic Secant (GHS) distribution.
-
-    The GHS distribution is for targets ``y`` in ``(-∞, +∞)``.
+    See the documentation of the superclass,
+    :class:`~glum.ExponentialDispersionModel`, for details.
     """
 
     lower_bound = -np.inf
@@ -898,57 +791,470 @@ class GeneralizedHyperbolicSecant(ExponentialDispersionModel):
     def __eq__(self, other):  # noqa D
         return isinstance(other, self.__class__)
 
-    def unit_variance(self, mu: np.ndarray) -> np.ndarray:
-        """Get the unit-level expected variance.
+    def __tweedie_repr__(self):  # noqa D
+        return TweedieDistribution(0)
 
-        See superclass documentation.
+    def unit_variance(self, mu) -> np.ndarray:  # noqa D
+        return 1 if np.isscalar(mu) else np.ones_like(mu)
+
+    def unit_variance_derivative(self, mu) -> np.ndarray:  # noqa D
+        return 0 if np.isscalar(mu) else np.zeros_like(mu)
+
+    def deviance(self, y, mu, sample_weight=None) -> float:  # noqa D
+
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+        sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
+
+        # NOTE: the dispersion parameter is only necessary to convey
+        # type information on account of a bug in Cython
+
+        return normal_deviance(y, sample_weight, mu, dispersion=1.0)
+
+    def unit_deviance(self, y, mu):  # noqa D
+        return (y - mu) ** 2
+
+    def _rowwise_gradient_hessian(
+        self, link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
+    ):
+        if isinstance(link, IdentityLink):
+            return normal_identity_rowwise_gradient_hessian(
+                y, sample_weight, eta, mu, gradient_rows, hessian_rows
+            )
+
+        return super()._rowwise_gradient_hessian(
+            link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
+        )
+
+    def _eta_mu_deviance(
+        self,
+        link: Link,
+        factor: float,
+        cur_eta,
+        X_dot_d,
+        y,
+        sample_weight,
+        eta_out,
+        mu_out,
+    ):
+        if isinstance(link, IdentityLink):
+            return normal_identity_eta_mu_deviance(
+                cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out, factor
+            )
+
+        return super()._eta_mu_deviance(
+            link, factor, cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out
+        )
+
+    def log_likelihood(self, y, mu, sample_weight=None, dispersion=None) -> float:
+        r"""Compute the log likelihood.
 
         Parameters
         ----------
-        mu : array-like or float
+        y : array-like, shape (n_samples,)
+            Target values.
 
-        Returns
-        -------
-        array-like
+        mu : array-like, shape (n_samples,)
+            Predicted mean.
+
+        sample_weight : array-like, shape (n_samples,), optional (default=1)
+            Sample weights.
+
+        dispersion : float, optional (default=None)
+            Dispersion parameter :math:`\phi`. Estimated if ``None``.
         """
-        return 1 + mu**2
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+        sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
 
-    def unit_variance_derivative(self, mu: np.ndarray) -> np.ndarray:
-        """Get the derivative of the unit variance.
+        if dispersion is None:
+            dispersion = self.dispersion(y, mu, sample_weight)
 
-        See superclass documentation.
+        return normal_log_likelihood(y, sample_weight, mu, float(dispersion))
+
+    def dispersion(  # noqa D
+        self, y, mu, sample_weight=None, ddof=1, method="pearson"
+    ) -> float:
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+
+        if method == "pearson":
+            formula = "(y - mu) ** 2"
+            if sample_weight is None:
+                return numexpr.evaluate(formula).sum() / (len(y) - ddof)
+            else:
+                formula = f"sample_weight * {formula}"
+                return numexpr.evaluate(formula).sum() / (sample_weight.sum() - ddof)
+
+        return super().dispersion(
+            y, mu, sample_weight=sample_weight, ddof=ddof, method=method
+        )
+
+
+class PoissonDistribution(ExponentialDispersionModel):
+    """Class for the scaled Poisson distribution.
+
+    The Poisson distribution models discrete outcomes ``y`` in ``[0, +∞)``.
+
+    See the documentation of the superclass,
+    :class:`~glum.ExponentialDispersionModel`, for details.
+    """
+
+    lower_bound = 0
+    upper_bound = np.inf
+    include_lower_bound = True
+    include_upper_bound = False
+
+    def __eq__(self, other):  # noqa D
+        return isinstance(other, self.__class__)
+
+    def __tweedie_repr__(self):  # noqa D
+        return TweedieDistribution(1)
+
+    def unit_variance(self, mu) -> np.ndarray:  # noqa D
+        return mu
+
+    def unit_variance_derivative(self, mu) -> np.ndarray:  # noqa D
+        return 1.0 if np.isscalar(mu) else np.ones_like(mu)
+
+    def deviance(self, y, mu, sample_weight=None) -> float:  # noqa D
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+        sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
+
+        # NOTE: the dispersion parameter is only necessary to convey
+        # type information on account of a bug in Cython
+
+        return poisson_deviance(y, sample_weight, mu, dispersion=1.0)
+
+    def unit_deviance(self, y, mu):
+        """Compute the unit deviance."""
+        return 2 * (special.xlogy(y, y / mu) - y + mu)
+
+    def _rowwise_gradient_hessian(
+        self, link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
+    ):
+        if isinstance(link, LogLink):
+            return poisson_log_rowwise_gradient_hessian(
+                y, sample_weight, eta, mu, gradient_rows, hessian_rows
+            )
+
+        return super()._rowwise_gradient_hessian(
+            link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
+        )
+
+    def _eta_mu_deviance(
+        self,
+        link: Link,
+        factor: float,
+        cur_eta,
+        X_dot_d,
+        y,
+        sample_weight,
+        eta_out,
+        mu_out,
+    ):
+        if isinstance(link, LogLink):
+            return poisson_log_eta_mu_deviance(
+                cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out, factor
+            )
+
+        return super()._eta_mu_deviance(
+            link, factor, cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out
+        )
+
+    def log_likelihood(self, y, mu, sample_weight=None, dispersion=None) -> float:
+        r"""Compute the log likelihood.
 
         Parameters
         ----------
-        mu : array-like or float
+        y : array-like, shape (n_samples,)
+            Target values.
 
-        Returns
-        -------
-        array-like
+        mu : array-like, shape (n_samples,)
+            Predicted mean.
+
+        sample_weight : array-like, shape (n_samples,), optional (default=1)
+            Sample weights.
+
+        dispersion : float, optional (default=None)
+            Dispersion parameter :math:`\phi`. Estimated if ``None``.
         """
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+        sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
+
+        # NOTE: the dispersion parameter is only necessary to convey
+        # type information on account of a bug in Cython
+
+        return poisson_log_likelihood(y, sample_weight, mu, 1.0)
+
+    def dispersion(  # noqa D
+        self, y, mu, sample_weight=None, ddof=1, method="pearson"
+    ) -> float:
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+
+        if method == "pearson":
+            formula = "((y - mu) ** 2) / mu"
+            if sample_weight is None:
+                return numexpr.evaluate(formula).sum() / (len(y) - ddof)
+            else:
+                formula = f"sample_weight * {formula}"
+                return numexpr.evaluate(formula).sum() / (sample_weight.sum() - ddof)
+
+        return super().dispersion(
+            y, mu, sample_weight=sample_weight, ddof=ddof, method=method
+        )
+
+
+class GammaDistribution(ExponentialDispersionModel):
+    """Class for the gamma distribution.
+
+    The gamma distribution models outcomes ``y`` in ``(0, +∞)``.
+
+    See the documentation of the superclass,
+    :class:`~glum.ExponentialDispersionModel`, for details.
+    """
+
+    lower_bound = 0
+    upper_bound = np.inf
+    include_lower_bound = False
+    include_upper_bound = False
+
+    def __eq__(self, other):  # noqa D
+        return isinstance(other, self.__class__)
+
+    def __tweedie_repr__(self):  # noqa D
+        return TweedieDistribution(2)
+
+    def unit_variance(self, mu) -> np.ndarray:  # noqa D
+        return mu**2
+
+    def unit_variance_derivative(self, mu) -> np.ndarray:  # noqa D
         return 2 * mu
 
-    def unit_deviance(self, y: np.ndarray, mu: np.ndarray) -> np.ndarray:
-        """Get the unit-level deviance.
+    def deviance(self, y, mu, sample_weight=None) -> float:  # noqa D
 
-        See superclass documentation.
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+        sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
+
+        # NOTE: the dispersion parameter is only necessary to convey
+        # type information on account of a bug in Cython
+
+        return gamma_deviance(y, sample_weight, mu, dispersion=1.0)
+
+    def unit_deviance(self, y, mu):  # noqa D
+        return 2 * (np.log(mu / y) + y / mu - 1)
+
+    def _rowwise_gradient_hessian(
+        self, link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
+    ):
+        if isinstance(link, LogLink):
+            return gamma_log_rowwise_gradient_hessian(
+                y, sample_weight, eta, mu, gradient_rows, hessian_rows
+            )
+
+        return super()._rowwise_gradient_hessian(
+            link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
+        )
+
+    def _eta_mu_deviance(
+        self,
+        link: Link,
+        factor: float,
+        cur_eta,
+        X_dot_d,
+        y,
+        sample_weight,
+        eta_out,
+        mu_out,
+    ):
+        if isinstance(link, LogLink):
+            return gamma_log_eta_mu_deviance(
+                cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out, factor
+            )
+
+        return super()._eta_mu_deviance(
+            link, factor, cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out
+        )
+
+    def log_likelihood(self, y, mu, sample_weight=None, dispersion=None) -> float:
+        r"""Compute the log likelihood.
 
         Parameters
         ----------
-        y : array-like
-        mu : array-like
+        y : array-like, shape (n_samples,)
+            Target values.
 
-        Returns
-        -------
-        array-like
+        mu : array-like, shape (n_samples,)
+            Predicted mean.
+
+        sample_weight : array-like, shape (n_samples,), optional (default=1)
+            Sample weights.
+
+        dispersion : float, optional (default=None)
+            Dispersion parameter :math:`\phi`. Estimated if ``None``.
         """
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+        sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
+
+        if dispersion is None:
+            dispersion = self.dispersion(y, mu, sample_weight)
+
+        return gamma_log_likelihood(y, sample_weight, mu, float(dispersion))
+
+    def dispersion(  # noqa D
+        self, y, mu, sample_weight=None, ddof=1, method="pearson"
+    ) -> float:
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+
+        if method == "pearson":
+            formula = "((y - mu) ** 2) / (mu ** 2)"
+            if sample_weight is None:
+                return numexpr.evaluate(formula).sum() / (len(y) - ddof)
+            else:
+                formula = f"sample_weight * {formula}"
+                return numexpr.evaluate(formula).sum() / (sample_weight.sum() - ddof)
+
+        return super().dispersion(
+            y, mu, sample_weight=sample_weight, ddof=ddof, method=method
+        )
+
+
+class InverseGaussianDistribution(ExponentialDispersionModel):
+    """Class for the inverse Gaussian distribution.
+
+    The inverse Gaussian distribution models outcomes ``y`` in ``(0, +∞)``.
+
+    See the documentation of the superclass,
+    :class:`~glum.ExponentialDispersionModel`, for details.
+    """
+
+    lower_bound = 0
+    upper_bound = np.inf
+    include_lower_bound = False
+    include_upper_bound = False
+
+    def __eq__(self, other):  # noqa D
+        return isinstance(other, self.__class__)
+
+    def __tweedie_repr__(self):  # noqa D
+        return TweedieDistribution(3)
+
+    def unit_variance(self, mu) -> np.ndarray:  # noqa D
+        return mu**3
+
+    def unit_variance_derivative(self, mu) -> np.ndarray:  # noqa D
+        return 3 * (mu**2)
+
+    def deviance(self, y, mu, sample_weight=None) -> float:  # noqa D
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+        sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
+
+        return tweedie_deviance(y, sample_weight, mu, p=3.0)
+
+    def unit_deviance(self, y, mu):  # noqa D
+        return numexpr.evaluate("y / (mu**2) + 1 / y - 2 / mu")
+
+    def _rowwise_gradient_hessian(
+        self, link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
+    ):
+        return super()._rowwise_gradient_hessian(
+            link, y, sample_weight, eta, mu, gradient_rows, hessian_rows
+        )
+
+    def _eta_mu_deviance(
+        self,
+        link: Link,
+        factor: float,
+        cur_eta,
+        X_dot_d,
+        y,
+        sample_weight,
+        eta_out,
+        mu_out,
+    ):
+        if isinstance(link, LogLink):
+            return tweedie_log_eta_mu_deviance(
+                cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out, factor, p=3.0
+            )
+
+        return super()._eta_mu_deviance(
+            link, factor, cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out
+        )
+
+    def log_likelihood(self, y, mu, sample_weight=None, dispersion=None) -> float:
+        r"""Compute the log likelihood.
+
+        Parameters
+        ----------
+        y : array-like, shape (n_samples,)
+            Target values.
+
+        mu : array-like, shape (n_samples,)
+            Predicted mean.
+
+        sample_weight : array-like, shape (n_samples,), optional (default=1)
+            Sample weights.
+
+        dispersion : float, optional (default=None)
+            Dispersion parameter :math:`\phi`. Estimated if ``None``.
+        """
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+        sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
+
+        if dispersion is None:
+            dispersion = self.dispersion(y, mu, sample_weight)
+
+        return tweedie_log_likelihood(y, sample_weight, mu, 3.0, float(dispersion))
+
+    def dispersion(  # noqa D
+        self, y, mu, sample_weight=None, ddof=1, method="pearson"
+    ) -> float:
+        y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
+
+        if method == "pearson":
+            formula = "((y - mu) ** 2) / (mu ** 3)"
+            if sample_weight is None:
+                return numexpr.evaluate(formula).sum() / (len(y) - ddof)
+            else:
+                formula = f"sample_weight * {formula}"
+                return numexpr.evaluate(formula).sum() / (sample_weight.sum() - ddof)
+
+        return super().dispersion(
+            y, mu, sample_weight=sample_weight, ddof=ddof, method=method
+        )
+
+
+class GeneralizedHyperbolicSecant(ExponentialDispersionModel):
+    """A class for the Generalized Hyperbolic Secant (GHS) distribution.
+
+    The GHS distribution models outcomes ``y`` in ``(-∞, +∞)``.
+
+    See the documentation of the superclass,
+    :class:`~glum.ExponentialDispersionModel`, for details.
+    """
+
+    lower_bound = -np.inf
+    upper_bound = np.inf
+    include_lower_bound = False
+    include_upper_bound = False
+
+    def __eq__(self, other):  # noqa D
+        return isinstance(other, self.__class__)
+
+    def unit_variance(self, mu) -> np.ndarray:  # noqa D
+        return 1 + mu**2
+
+    def unit_variance_derivative(self, mu) -> np.ndarray:  # noqa D
+        return 2 * mu
+
+    def unit_deviance(self, y, mu) -> np.ndarray:  # noqa D
         return 2 * y * (np.arctan(y) - np.arctan(mu)) + np.log((1 + mu**2) / (1 + y**2))
 
 
 class BinomialDistribution(ExponentialDispersionModel):
     """A class for the Binomial distribution.
 
-    The Binomial distribution is for targets ``y`` in ``[0, 1]``.
+    The Binomial distribution models outcomes ``y`` in ``[0, 1]``.
+
+    See the documentation of the superclass,
+    :class:`~glum.ExponentialDispersionModel`, for details.
     """
 
     lower_bound = 0
@@ -959,50 +1265,13 @@ class BinomialDistribution(ExponentialDispersionModel):
     def __eq__(self, other):  # noqa D
         return isinstance(other, self.__class__)
 
-    def unit_variance(self, mu: np.ndarray) -> np.ndarray:
-        """Get the unit-level expected variance.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu : array-like
-
-        Returns
-        -------
-        array-like
-        """
+    def unit_variance(self, mu):  # noqa D
         return mu * (1 - mu)
 
-    def unit_variance_derivative(self, mu):
-        """Get the derivative of the unit variance.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu : array-like or float
-
-        Returns
-        -------
-        array-like
-        """
+    def unit_variance_derivative(self, mu):  # noqa D
         return 1 - 2 * mu
 
-    def unit_deviance(self, y: np.ndarray, mu: np.ndarray) -> np.ndarray:
-        """Get the unit-level deviance.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        y : array-like
-        mu : array-like
-
-        Returns
-        -------
-        array-like
-        """
+    def unit_deviance(self, y, mu):  # noqa D
         # see Wooldridge and Papke (1996) for the fractional case
         return -2 * (special.xlogy(y, mu) + special.xlogy(1 - y, 1 - mu))
 
@@ -1021,17 +1290,18 @@ class BinomialDistribution(ExponentialDispersionModel):
         self,
         link: Link,
         factor: float,
-        cur_eta: np.ndarray,
-        X_dot_d: np.ndarray,
-        y: np.ndarray,
-        sample_weight: np.ndarray,
-        eta_out: np.ndarray,
-        mu_out: np.ndarray,
+        cur_eta,
+        X_dot_d,
+        y,
+        sample_weight,
+        eta_out,
+        mu_out,
     ):
         if isinstance(link, LogitLink):
             return binomial_logit_eta_mu_deviance(
                 cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out, factor
             )
+
         return super()._eta_mu_deviance(
             link, factor, cur_eta, X_dot_d, y, sample_weight, eta_out, mu_out
         )
@@ -1056,30 +1326,9 @@ class BinomialDistribution(ExponentialDispersionModel):
         ll = special.xlogy(y, mu) + special.xlogy(1 - y, 1 - mu)
         return np.sum(ll) if sample_weight is None else np.dot(ll, sample_weight)
 
-    def dispersion(self, y, mu, sample_weight=None, ddof=1, method="pearson") -> float:
-        r"""Estimate the dispersion parameter :math:`\phi`.
-
-        Parameters
-        ----------
-        y : array-like, shape (n_samples,)
-            Target values.
-
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        sample_weight : array-like, shape (n_samples,), optional (default=None)
-            Weights or exposure to which variance is inversely proportional.
-
-        ddof : int, optional (default=1)
-            Degrees of freedom consumed by the model for ``mu``.
-
-        method = {'pearson', 'deviance'}, optional (default='pearson')
-            Whether to base the estimate on the Pearson residuals or the deviance.
-
-        Returns
-        -------
-        float
-        """
+    def dispersion(  # noqa D
+        self, y, mu, sample_weight=None, ddof=1, method="pearson"
+    ) -> float:
         y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
 
         if method == "pearson":
@@ -1098,14 +1347,14 @@ class BinomialDistribution(ExponentialDispersionModel):
 class NegativeBinomialDistribution(ExponentialDispersionModel):
     r"""A class for the Negative Binomial distribution.
 
-    A Negative Binomial distribution with mean :math:`\mu = \mathrm{E}(Y)` is uniquely
-    defined by its mean-variance relationship
+    A negative binomial distribution with mean :math:`\mu = \mathrm{E}(Y)` is
+    uniquely defined by its mean-variance relationship
     :math:`\mathrm{var}(Y) \propto \mu + \theta * \mu^2`.
 
     Parameters
     ----------
     theta : float, optional (default=1.0)
-        The dispersion parameter from `unit_variance`
+        The dispersion parameter from the ``unit_variance``
         :math:`v(\mu) = \mu + \theta * \mu^2`. For
         :math:`\theta <= 0`, no distribution exists.
 
@@ -1132,74 +1381,34 @@ class NegativeBinomialDistribution(ExponentialDispersionModel):
 
     @property
     def theta(self) -> float:
-        """Return the Negative Binomial theta parameter."""
+        """Return the negative binomial theta parameter."""
         return self._theta
 
     @theta.setter
     def theta(self, theta):
+
         if not isinstance(theta, (int, float)):
-            raise TypeError(f"theta must be an int or float, input was {theta}")
+            raise TypeError(f"Theta must be numeric; got {theta}.")
         if not theta > 0:
-            raise ValueError(
-                f"theta must be strictly positive number, input was {theta}"
-            )
+            raise ValueError(f"Theta must be strictly positive; got was {theta}.")
 
         # Prevents upcasting when working with 32-bit data
-        self._theta = np.float32(theta)
+        self._theta = theta if isinstance(theta, int) else np.float32(theta)
 
-    def unit_variance(self, mu: np.ndarray) -> np.ndarray:
-        """Compute the unit variance of a Negative Binomial distribution
-        ``v(mu) = mu + theta * mu^2``.
-
-        Parameters
-        ----------
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        Returns
-        -------
-        numpy.ndarray, shape (n_samples,)
-        """
+    def unit_variance(self, mu):  # noqa D
         return mu + self.theta * mu**2
 
-    def unit_variance_derivative(self, mu: np.ndarray) -> np.ndarray:
-        r"""Compute the derivative of the unit variance of a Negative Binomial distribution.
-
-        Equation: :math:`v(\mu) = 1 + 2 \times \theta \times \mu`.
-
-        Parameters
-        ----------
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        Returns
-        -------
-        numpy.ndarray, shape (n_samples,)
-        """
+    def unit_variance_derivative(self, mu):  # noqa D
         return 1 + 2 * self.theta * mu
 
-    def deviance(self, y, mu, sample_weight=None) -> float:
-        """Compute the deviance.
-
-        Parameters
-        ----------
-        y : array-like, shape (n_samples,)
-            Target values.
-
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        sample_weight : array-like, shape (n_samples,), optional (default=1)
-            Sample weights.
-        """
+    def deviance(self, y, mu, sample_weight=None) -> float:  # noqa D
         theta = self.theta
         y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
         sample_weight = np.ones_like(y) if sample_weight is None else sample_weight
 
         return negative_binomial_deviance(y, sample_weight, mu, theta=float(theta))
 
-    def unit_deviance(self, y: np.ndarray, mu: np.ndarray) -> np.ndarray:
-        """Get the deviance of each observation."""
+    def unit_deviance(self, y, mu):  # noqa D
         theta = self.theta
 
         r = 1.0 / theta
@@ -1221,12 +1430,12 @@ class NegativeBinomialDistribution(ExponentialDispersionModel):
         self,
         link: Link,
         factor: float,
-        cur_eta: np.ndarray,
-        X_dot_d: np.ndarray,
-        y: np.ndarray,
-        sample_weight: np.ndarray,
-        eta_out: np.ndarray,
-        mu_out: np.ndarray,
+        cur_eta,
+        X_dot_d,
+        y,
+        sample_weight,
+        eta_out,
+        mu_out,
     ):
         if isinstance(link, LogLink):
             return negative_binomial_log_eta_mu_deviance(
@@ -1266,30 +1475,9 @@ class NegativeBinomialDistribution(ExponentialDispersionModel):
 
         return negative_binomial_log_likelihood(y, sample_weight, mu, float(theta), 1.0)
 
-    def dispersion(self, y, mu, sample_weight=None, ddof=1, method="pearson") -> float:
-        r"""Estimate the dispersion parameter :math:`\phi`.
-
-        Parameters
-        ----------
-        y : array-like, shape (n_samples,)
-            Target values.
-
-        mu : array-like, shape (n_samples,)
-            Predicted mean.
-
-        sample_weight : array-like, shape (n_samples,), optional (default=None)
-            Weights or exposure to which variance is inversely proportional.
-
-        ddof : int, optional (default=1)
-            Degrees of freedom consumed by the model for ``mu``.
-
-        method = {'pearson', 'deviance'}, optional (default='pearson')
-            Whether to base the estimate on the Pearson residuals or the deviance.
-
-        Returns
-        -------
-        float
-        """
+    def dispersion(  # noqa D
+        self, y, mu, sample_weight=None, ddof=1, method="pearson"
+    ) -> float:
         theta = self.theta  # noqa: F841
         y, mu, sample_weight = _as_float_arrays(y, mu, sample_weight)
 
@@ -1307,8 +1495,8 @@ class NegativeBinomialDistribution(ExponentialDispersionModel):
 
 
 def guess_intercept(
-    y: np.ndarray,
-    sample_weight: np.ndarray,
+    y,
+    sample_weight,
     link: Link,
     distribution: ExponentialDispersionModel,
     eta: Union[np.ndarray, float] = None,
@@ -1327,51 +1515,77 @@ def guess_intercept(
     avg_y = np.average(y, weights=sample_weight)
 
     if isinstance(link, IdentityLink):
-        # This is only correct for normal. For other distributions, answer is unknown,
-        # but assume that we want sum(y) = sum(mu)
+
+        # This is only correct for the normal. For other distributions, the
+        # answer is unknown, but we assume that we want `sum(y) = sum(mu)`
+
         if eta is None:
             return avg_y
+
         avg_eta = eta if np.isscalar(eta) else np.average(eta, weights=sample_weight)
+
         return avg_y - avg_eta
+
     elif isinstance(link, LogLink):
+
         # This is only correct for Tweedie
+
         log_avg_y = np.log(avg_y)
+
         assert np.isfinite(log_avg_y).all()
 
         if eta is None:
             return log_avg_y
+
         mu = np.exp(eta)
+
         if isinstance(distribution, TweedieDistribution):
             p = distribution.power
+        elif isinstance(distribution, NormalDistribution):
+            p = 0
+        elif isinstance(distribution, PoissonDistribution):
+            p = 1
+        elif isinstance(distribution, GammaDistribution):
+            p = 2
+        elif isinstance(distribution, InverseGaussianDistribution):
+            p = 3
         else:
             p = 1  # Like Poisson
+
         if np.isscalar(mu):
             first = np.log(y.dot(sample_weight) * mu ** (1 - p))
             second = np.log(sample_weight.sum() * mu ** (2 - p))
         else:
             first = np.log((y * mu ** (1 - p)).dot(sample_weight))
             second = np.log((mu ** (2 - p)).dot(sample_weight))
+
         return first - second
+
     elif isinstance(link, LogitLink):
+
         log_odds = np.log(avg_y) - np.log(1 - avg_y)
+
         if eta is None:
             return log_odds
+
         avg_eta = eta if np.isscalar(eta) else np.average(eta, weights=sample_weight)
+
         return log_odds - avg_eta
+
     else:
+
         return link.link(y.dot(sample_weight))
 
 
 def get_one_over_variance(
     distribution: ExponentialDispersionModel,
     link: Link,
-    mu: np.ndarray,
-    eta: np.ndarray,
-    dispersion,
-    sample_weight: np.ndarray,
+    mu,
+    eta,
+    dispersion: float,
+    sample_weight,
 ):
-    """
-    Get one over the variance.
+    """Get one over the variance.
 
     For Tweedie: ``sigma_inv = sample_weight / (mu ** p)`` during optimization,
     because ``phi = 1``.

--- a/src/glum/_distribution.py
+++ b/src/glum/_distribution.py
@@ -99,10 +99,12 @@ class ExponentialDispersionModel(metaclass=ABCMeta):
 
         return lb_op(x, self.lower_bound) & ub_op(x, self.upper_bound)
 
-    def to_tweedie(self):
+    def to_tweedie(self, safe=True):
         """Return the Tweedie representation of a distribution if it exists."""
         if hasattr(self, "__tweedie_repr__"):
             return self.__tweedie_repr__()
+        if safe:
+            raise ValueError("This distribution has no Tweedie representation.")
         return None
 
     @abstractmethod

--- a/src/glum/_functions.pyx
+++ b/src/glum/_functions.pyx
@@ -277,7 +277,7 @@ def inv_gaussian_log_rowwise_gradient_hessian(
         inv_mu2 = inv_mu ** 2
 
         gradient_rows_out[i] = 2 * weights[i] * (inv_mu - y[i] * inv_mu2)
-        hessian_rows_out[i] = 2 * weights[i] * (2 * y[i] * inv_mu2 - inv_mu)
+        hessian_rows_out[i] = 2 * weights[i] * (inv_mu - 2 * y[i] * inv_mu2)
 
 def inv_gaussian_log_likelihood(
     const_floating1d y,

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -3673,7 +3673,7 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
             raise NotImplementedError(
                 "The family instance does not define a `log_likelihood` method, so "
                 "information criteria cannot be computed. Compatible families include "
-                "the binomial, negative binomial and Tweedie (power<2 or power=3)."
+                "the binomial, negative binomial and Tweedie (power<=2 or power=3)."
             )
 
         ddof = np.sum(np.abs(self.coef_) > np.finfo(self.coef_.dtype).eps)

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -494,23 +494,18 @@ def get_family(
 
 def get_link(link: Union[str, Link], family: ExponentialDispersionModel) -> Link:
     """
-    For the Tweedie distribution, this code follows actuarial best practices regarding
-    link functions. Note that these links are sometimes not canonical:
-        - identity for normal (``p=0``);
+    For the Tweedie distribution, this code follows actuarial best practices
+    regarding link functions. Note that these links are sometimes not canonical:
+        - identity for normal (``p = 0``);
         - no convention for ``p < 0``, so let's leave it as identity;
         - log otherwise.
     """
     if isinstance(link, Link):
         return link
     if link == "auto":
-        if isinstance(family, TweedieDistribution):
-            if family.power <= 0:
+        if tweedie_representation := family.to_tweedie():
+            if tweedie_representation.power <= 0:
                 return IdentityLink()
-            if family.power < 1:
-                raise ValueError(
-                    "For 0 < p < 1, no Tweedie distribution exists. "
-                    "Please choose a different distribution."
-                )
             return LogLink()
         if isinstance(family, GeneralizedHyperbolicSecant):
             return IdentityLink()
@@ -3669,25 +3664,12 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
         [3] Park, M.Y., 2006. Generalized linear models with regularization;
         Stanford Universty.
         """
-
-        # we require that the log_likelihood be defined
-        model_err_str = (
-            "The computation of the information criteria has only "
-            + "been defined for models with a Binomial likelihood, Negative "
-            + "Binomial likelihood or a Tweedie likelihood with power <= 2."
-        )
-        if not isinstance(
-            self.family_instance,
-            (BinomialDistribution, TweedieDistribution, NegativeBinomialDistribution),
-        ):
-            raise NotImplementedError(model_err_str)
-
-        # the log_likelihood has not been implemented for the InverseGaussianDistribution
-        if (
-            isinstance(self.family_instance, TweedieDistribution)
-            and self.family_instance.power > 2
-        ):
-            raise NotImplementedError(model_err_str)
+        if not hasattr(self.family_instance, "log_likelihood"):
+            raise NotImplementedError(
+                "The family instance does not define a `log_likelihood` method, so "
+                "information criteria cannot be computed. Compatible families include "
+                "the binomial, negative binomial and Tweedie (power<2 or power=3)."
+            )
 
         ddof = np.sum(np.abs(self.coef_) > np.finfo(self.coef_.dtype).eps)
         k_params = ddof + self.fit_intercept
@@ -3695,9 +3677,8 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
 
         if nobs != self._num_obs:
             raise ValueError(
-                "The same dataset that was used for training should "
-                + "also be used for the computation of information "
-                + "criteria"
+                "The same dataset that was used for training should also be used for "
+                "the computation of information criteria."
             )
 
         mu = self.predict(X, context=context)
@@ -3705,6 +3686,7 @@ class GeneralizedLinearRegressor(GeneralizedLinearRegressorBase):
 
         aic = -2 * ll + 2 * k_params
         bic = -2 * ll + np.log(nobs) * k_params
+
         if nobs > k_params + 1:
             aicc = aic + 2 * k_params * (k_params + 1) / (nobs - k_params - 1)
         else:

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -504,7 +504,7 @@ def get_link(link: Union[str, Link], family: ExponentialDispersionModel) -> Link
         return link
 
     if (link is None) or (link == "auto"):
-        if tweedie_representation := family.to_tweedie():
+        if tweedie_representation := family.to_tweedie(safe=False):
             if tweedie_representation.power <= 0:
                 return IdentityLink()
             return LogLink()

--- a/src/glum/_link.py
+++ b/src/glum/_link.py
@@ -177,7 +177,7 @@ class IdentityLink(Link):
     def __eq__(self, other):  # noqa D
         return isinstance(other, self.__class__)
 
-    def __tweedie__repr__(self):  # noqa D
+    def __tweedie_repr__(self):  # noqa D
         return TweedieLink(0)
 
     def link(self, mu):  # noqa D
@@ -202,7 +202,7 @@ class LogLink(Link):
     def __eq__(self, other):  # noqa D
         return isinstance(other, self.__class__)
 
-    def __tweedie__repr__(self):  # noqa D
+    def __tweedie_repr__(self):  # noqa D
         return TweedieLink(1)
 
     def link(self, mu):  # noqa D

--- a/src/glum/_link.py
+++ b/src/glum/_link.py
@@ -1,21 +1,20 @@
 import warnings
 from abc import ABCMeta, abstractmethod
+from typing import Callable
 
 import numpy as np
 from scipy import special
 
-from ._util import _asanyarray
-
 
 class Link(metaclass=ABCMeta):
-    """Abstract base class for Link functions."""
+    """Abstract base class for link functions."""
 
     @abstractmethod
     def link(self, mu):
-        """Compute the link function ``g(mu)``.
+        """Compute the link function.
 
-        The link function links the mean, ``mu ≡ E(Y)``, to the linear predictor
-        ``X * w``, i.e. ``g(mu)`` is equal to the linear predictor.
+        The link function ``g`` links the mean, ``mu ≡ E(Y)``, to the linear
+        predictor, ``X * w``, so that ``g(mu)`` is equal to the linear predictor.
 
         Parameters
         ----------
@@ -26,7 +25,7 @@ class Link(metaclass=ABCMeta):
 
     @abstractmethod
     def derivative(self, mu):
-        """Compute the derivative of the link ``g'(mu)``.
+        """Compute the derivative of the link function.
 
         Parameters
         ----------
@@ -37,22 +36,11 @@ class Link(metaclass=ABCMeta):
 
     @abstractmethod
     def inverse(self, lin_pred):
-        """Compute the inverse link function ``h(lin_pred)``.
+        """Compute the inverse link function.
 
-        Gives the inverse relationship between linear predictor,
-        ``lin_pred ≡ X * w``, and the mean, ``mu ≡ E(Y)``, i.e.
-        ``h(lin_pred) = mu``.
-
-        Parameters
-        ----------
-        lin_pred : array-like, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        pass
-
-    @abstractmethod
-    def inverse_derivative(self, lin_pred):
-        """Compute the derivative of the inverse link function ``h'(lin_pred)``.
+        The inverse link function ``h`` gives the inverse relationship between
+        the linear predictor, ``X * w``, and the mean, ``mu ≡ E(Y)``, so that
+        ``h(X * w) = mu``.
 
         Parameters
         ----------
@@ -62,8 +50,8 @@ class Link(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def inverse_derivative2(self, lin_pred):
-        """Compute second derivative of the inverse link function ``h''(lin_pred)``.
+    def inverse_derivative(self, lin_pred):
+        """Compute the derivative of the inverse link function.
 
         Parameters
         ----------
@@ -72,238 +60,26 @@ class Link(metaclass=ABCMeta):
         """
         pass
 
-
-class IdentityLink(Link):
-    """The identity link function ``g(x) = x``."""
-
-    def __eq__(self, other):  # noqa D
-        return isinstance(other, self.__class__)
-
-    def link(self, mu):
-        """Return mu (identity link).
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu: array-like
-        """
-        return _asanyarray(mu)
-
-    def derivative(self, mu):
-        """Get the derivative of the identity link, a vector of ones.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu: array-like
-        """
-        return 1.0 if np.isscalar(mu) else np.ones_like(mu)
-
-    def inverse(self, lin_pred):
-        """Compute the inverse link function ``h(lin_pred)``.
-
-        Gives the inverse relationship between linear predictor and the mean
-        ``mu ≡ E(Y)``, i.e. ``h(linear predictor) = mu``.
-
-        Parameters
-        ----------
-        lin_pred : array-like, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        return _asanyarray(lin_pred)
-
-    def inverse_derivative(self, lin_pred):
-        """Compute the derivative of the inverse link function ``h'(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array-like, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        return 1.0 if np.isscalar(lin_pred) else np.ones_like(lin_pred)
-
+    @abstractmethod
     def inverse_derivative2(self, lin_pred):
-        """Compute second derivative of the inverse link function ``h''(lin_pred)``.
+        """Compute second derivative of the inverse link function.
 
         Parameters
         ----------
         lin_pred : array-like, shape (n_samples,)
             Usually the (fitted) linear predictor.
         """
-        return 0.0 if np.isscalar(lin_pred) else np.zeros_like(lin_pred)
+        pass
+
+    def to_tweedie(self):
+        """Return the Tweedie representation of a link function if it exists."""
+        if hasattr(self, "__tweedie_repr__"):
+            return self.__tweedie_repr__()
+        return None
 
 
-class LogLink(Link):
-    """The log link function ``log(x)``."""
-
-    def __eq__(self, other):  # noqa D
-        return isinstance(other, self.__class__)
-
-    def link(self, mu):
-        """Get the log of ``mu``.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu: array-like
-
-        Returns
-        -------
-        numpy.ndarray
-        """
-        return np.log(_asanyarray(mu))
-
-    def derivative(self, mu):
-        """Get the derivative of the log link, one over ``mu``.
-
-        Parameters
-        ----------
-        mu: array-like
-
-        Returns
-        -------
-        numpy.ndarray
-        """
-        return 1 / _asanyarray(mu)
-
-    def inverse(self, lin_pred):
-        """Get the inverse of the log link, the exponential function.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        lin_pred: array-like
-
-        Returns
-        -------
-        numpy.ndarray
-        """
-        return np.exp(_asanyarray(lin_pred))
-
-    def inverse_derivative(self, lin_pred):
-        """Compute the derivative of the inverse link function ``h'(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array-like, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        return np.exp(_asanyarray(lin_pred))
-
-    def inverse_derivative2(self, lin_pred):
-        """Compute second derivative of the inverse link function ``h''(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array-like, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        return np.exp(_asanyarray(lin_pred))
-
-
-class LogitLink(Link):
-    """The logit link function ``logit(x)``."""
-
-    def __eq__(self, other):  # noqa D
-        return isinstance(other, self.__class__)
-
-    def link(self, mu):
-        """Get the logit function of ``mu``.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu: array-like
-
-        Returns
-        -------
-        numpy.ndarray
-        """
-        return special.logit(_asanyarray(mu))
-
-    def derivative(self, mu):
-        """Get the derivative of the logit link.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu: array-like
-
-        Returns
-        -------
-        array-like
-        """
-        mu = _asanyarray(mu)
-        return 1.0 / (mu * (1 - mu))
-
-    def inverse(self, lin_pred):
-        """Get the inverse of the logit link.
-
-        See superclass documentation.
-
-        Note: since passing a very large value might result in an output of one,
-        this function bounds the output to be between ``[50*eps, 1 - 50*eps]``,
-        where ``eps`` is floating point epsilon.
-
-        Parameters
-        ----------
-        lin_pred: array-like
-
-        Returns
-        -------
-        array-like
-        """
-        inv_logit = special.expit(_asanyarray(lin_pred))
-        eps50 = 50 * np.finfo(inv_logit.dtype).eps
-        if np.any(inv_logit > 1 - eps50) or np.any(inv_logit < eps50):
-            warnings.warn(
-                "Computing sigmoid function gave results too close to 0 or 1. Clipping."
-            )
-            return np.clip(inv_logit, eps50, 1 - eps50)
-        return inv_logit
-
-    def inverse_derivative(self, lin_pred):
-        """Compute the derivative of the inverse link function ``h'(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        ep = special.expit(_asanyarray(lin_pred))
-        return ep * (1.0 - ep)
-
-    def inverse_derivative2(self, lin_pred):
-        """Compute second derivative of the inverse link function ``h''(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        ep = special.expit(_asanyarray(lin_pred))
-        return ep * (1.0 - ep) * (1.0 - 2 * ep)
-
-
-def catch_p(fun):
-    """
-    Decorate ``fun``, ensuring that the given linear predictor is compatible with the \
-    relevant Tweedie power parameter.
-
-    Parameters
-    ----------
-    fun: TweedieLink method
-
-    Returns
-    -------
-    Callable
-    """
+def catch_p(fun) -> Callable:
+    """Ensure that linear predictors are compatible with the Tweedie power parameter."""
 
     def _to_return(*args, **kwargs):
         with np.errstate(invalid="raise"):
@@ -320,94 +96,159 @@ def catch_p(fun):
 
 
 class TweedieLink(Link):
-    """The Tweedie link function ``x^(1-p)`` if ``p≠1`` and ``log(x)`` if ``p=1``."""
+    """The Tweedie link function ``x^(1-p)`` if ``p≠1`` and ``log(x)`` if ``p=1``.
 
-    def __init__(self, p):
-        self.p = p
+    See the documentation of the superclass, :class:`~glum.Link`, for details.
+    """
+
+    def __init__(self, power):
+        self.power = power
 
     def __eq__(self, other):  # noqa D
-        return isinstance(other, self.__class__) and (self.p == other.p)
+        return isinstance(other, self.__class__) and (self.power == other.power)
 
-    def link(self, mu):
-        """Get the Tweedie canonical link.
+    def __tweedie__repr__(self):  # noqa D
+        return self.__class__(self.power)
 
-        See superclass documentation.
+    @property
+    def power(self) -> float:  # noqa D
+        return self._power
 
-        Parameters
-        ----------
-        mu: array-like
-        """
-        if self.p == 0:
-            return _asanyarray(mu)
-        if self.p == 1:
-            return np.log(_asanyarray(mu))
-        return _asanyarray(mu) ** (1 - self.p)
+    @power.setter
+    def power(self, power):
+        if not isinstance(power, (int, float, np.number)):
+            raise TypeError(f"The power parameter must be numeric; got {power}.")
+        if (power > 0) and (power < 1):
+            raise ValueError("For `0<p<1`, no distribution exists.")
 
-    def derivative(self, mu):
-        """Get the derivative of the Tweedie link.
+        # Prevents upcasting when working with 32-bit data
+        self._power = power if isinstance(power, int) else np.float32(power)
 
-        See superclass documentation.
+    def link(self, mu):  # noqa D
+        if self.power == 0:
+            return mu
+        if self.power == 1:
+            return np.log(mu)
+        return mu ** (1 - self.power)
 
-        Parameters
-        ----------
-        mu: array-like
-        """
-        if self.p == 0:
+    def derivative(self, mu):  # noqa D
+        if self.power == 0:
             return 1.0 if np.isscalar(mu) else np.ones_like(mu)
-        if self.p == 1:
-            return 1 / _asanyarray(mu)
-        return (1 - self.p) * _asanyarray(mu) ** (-self.p)
+        if self.power == 1:
+            return 1 / mu
+        return (1 - self.power) * mu ** (-self.power)
 
     @catch_p
-    def inverse(self, lin_pred):
-        """Get the inverse of the Tweedie link.
+    def inverse(self, lin_pred):  # noqa D
+        if self.power == 0:
+            return lin_pred
+        if self.power == 1:
+            return np.exp(lin_pred)
 
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu: array-like
-        """
-        if self.p == 0:
-            return _asanyarray(lin_pred)
-        if self.p == 1:
-            return np.exp(_asanyarray(lin_pred))
-        return _asanyarray(lin_pred) ** (1 / (1 - self.p))
+        return lin_pred ** (1 / (1 - self.power))
 
     @catch_p
-    def inverse_derivative(self, lin_pred):
-        """Compute the derivative of the inverse Tweedie link function ``h'(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array-like, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        if self.p == 0:
+    def inverse_derivative(self, lin_pred):  # noqa D
+        if self.power == 0:
             return 1.0 if np.isscalar(lin_pred) else np.ones_like(lin_pred)
-        if self.p == 1:
-            return np.exp(_asanyarray(lin_pred))
-        return (1 / (1 - self.p)) * _asanyarray(lin_pred) ** (self.p / (1 - self.p))
+        if self.power == 1:
+            return np.exp(lin_pred)
+
+        return (1 / (1 - self.power)) * lin_pred ** (self.power / (1 - self.power))
 
     @catch_p
-    def inverse_derivative2(self, lin_pred):
-        """Compute second derivative of the inverse Tweedie link function \
-            ``h''(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        if self.p == 0:
+    def inverse_derivative2(self, lin_pred):  # noqa D
+        if self.power == 0:
             return 0.0 if np.isscalar(lin_pred) else np.zeros_like(lin_pred)
-        if self.p == 1:
-            return np.exp(_asanyarray(lin_pred))
+        if self.power == 1:
+            return np.exp(lin_pred)
 
-        result = _asanyarray(lin_pred) ** ((2 * self.p - 1) / (1 - self.p))
-        result *= self.p / (1 - self.p) ** 2
+        result = lin_pred ** ((2 * self.power - 1) / (1 - self.power))
+        result *= self.power / (1 - self.power) ** 2
 
         return result
+
+
+class IdentityLink(Link):
+    """The identity link function."""
+
+    def __eq__(self, other):  # noqa D
+        return isinstance(other, self.__class__)
+
+    def __tweedie__repr__(self):  # noqa D
+        return TweedieLink(0)
+
+    def link(self, mu):  # noqa D
+        return mu
+
+    def derivative(self, mu):  # noqa D
+        return 1 if np.isscalar(mu) else np.ones_like(mu)
+
+    def inverse(self, lin_pred):  # noqa D
+        return lin_pred
+
+    def inverse_derivative(self, lin_pred):  # noqa D
+        return 1.0 if np.isscalar(lin_pred) else np.ones_like(lin_pred)
+
+    def inverse_derivative2(self, lin_pred):  # noqa D
+        return 0.0 if np.isscalar(lin_pred) else np.zeros_like(lin_pred)
+
+
+class LogLink(Link):
+    """The log link function ``log(x)``."""
+
+    def __eq__(self, other):  # noqa D
+        return isinstance(other, self.__class__)
+
+    def __tweedie__repr__(self):  # noqa D
+        return TweedieLink(1)
+
+    def link(self, mu):  # noqa D
+        return np.log(mu)
+
+    def derivative(self, mu):  # noqa D
+        return 1 / mu
+
+    def inverse(self, lin_pred):  # noqa D
+        return np.exp(lin_pred)
+
+    def inverse_derivative(self, lin_pred):  # noqa D
+        return np.exp(lin_pred)
+
+    def inverse_derivative2(self, lin_pred):  # noqa D
+        return np.exp(lin_pred)
+
+
+class LogitLink(Link):
+    """The logit link function ``logit(x)``."""
+
+    def __eq__(self, other):  # noqa D
+        return isinstance(other, self.__class__)
+
+    def link(self, mu):  # noqa D
+        return special.logit(mu)
+
+    def derivative(self, mu):  # noqa D
+        return 1.0 / (mu * (1 - mu))
+
+    def inverse(self, lin_pred):  # noqa D
+
+        inv_logit = special.expit(lin_pred)
+        eps50 = 50 * np.finfo(inv_logit.dtype).eps
+
+        if np.any(inv_logit > 1 - eps50) or np.any(inv_logit < eps50):
+            warnings.warn("Sigmoid function too close to 0 or 1. Clipping.")
+            return np.clip(inv_logit, eps50, 1 - eps50)
+
+        return inv_logit
+
+    def inverse_derivative(self, lin_pred):  # noqa D
+        ep = special.expit(lin_pred)
+        return ep * (1.0 - ep)
+
+    def inverse_derivative2(self, lin_pred):  # noqa D
+        ep = special.expit(lin_pred)
+        return ep * (1.0 - ep) * (1.0 - 2 * ep)
 
 
 class CloglogLink(Link):
@@ -416,84 +257,27 @@ class CloglogLink(Link):
     def __eq__(self, other):  # noqa D
         return isinstance(other, self.__class__)
 
-    def link(self, mu):
-        """Get the logit function of ``mu``.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu: array-like
-
-        Returns
-        -------
-        numpy.ndarray
-        """
-        mu = _asanyarray(mu)
+    def link(self, mu):  # noqa D
         return np.log(-np.log1p(-mu))
 
-    def derivative(self, mu):
-        """Get the derivative of the cloglog link.
-
-        See superclass documentation.
-
-        Parameters
-        ----------
-        mu: array-like
-
-        Returns
-        -------
-        array-like
-        """
-        mu = _asanyarray(mu)
+    def derivative(self, mu):  # noqa D
         return 1.0 / ((mu - 1) * (np.log1p(-mu)))
 
-    def inverse(self, lin_pred):
-        """Get the inverse of the cloglog link.
+    def inverse(self, lin_pred):  # noqa D
 
-        See superclass documentation.
-
-        Note: since passing a very large value might result in an output of one,
-        this function bounds the output to be between ``[50*eps, 1 - 50*eps]``,
-        where ``eps`` is floating point epsilon.
-
-        Parameters
-        ----------
-        lin_pred: array-like
-
-        Returns
-        -------
-        array-like
-        """
-        lin_pred = _asanyarray(lin_pred)
+        lin_pred = lin_pred
         inv_cloglog = -np.expm1(-np.exp(lin_pred))
         eps50 = 50 * np.finfo(inv_cloglog.dtype).eps
+
         if np.any(inv_cloglog > 1 - eps50) or np.any(inv_cloglog < eps50):
-            warnings.warn(
-                "Computing sigmoid function gave results too close to 0 or 1. Clipping."
-            )
+            warnings.warn("Sigmoid function too close to 0 or 1. Clipping.")
             return np.clip(inv_cloglog, eps50, 1 - eps50)
+
         return inv_cloglog
 
-    def inverse_derivative(self, lin_pred):
-        """Compute the derivative of the inverse link function ``h'(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        lin_pred = _asanyarray(lin_pred)
+    def inverse_derivative(self, lin_pred):  # noqa D
         return np.exp(lin_pred - np.exp(lin_pred))
 
-    def inverse_derivative2(self, lin_pred):
-        """Compute second derivative of the inverse link function ``h''(lin_pred)``.
-
-        Parameters
-        ----------
-        lin_pred : array, shape (n_samples,)
-            Usually the (fitted) linear predictor.
-        """
-        lin_pred = _asanyarray(lin_pred)
+    def inverse_derivative2(self, lin_pred):  # noqa D
         # TODO: check if numerical stability can be improved
         return np.exp(np.exp(lin_pred) - lin_pred) * np.expm1(lin_pred)

--- a/src/glum/_link.py
+++ b/src/glum/_link.py
@@ -71,10 +71,12 @@ class Link(metaclass=ABCMeta):
         """
         pass
 
-    def to_tweedie(self):
+    def to_tweedie(self, safe=True):
         """Return the Tweedie representation of a link function if it exists."""
         if hasattr(self, "__tweedie_repr__"):
             return self.__tweedie_repr__()
+        if safe:
+            raise ValueError("This link function has no Tweedie representation.")
         return None
 
 
@@ -87,8 +89,9 @@ def catch_p(fun) -> Callable:
                 result = fun(*args, **kwargs)
             except FloatingPointError as e:
                 raise ValueError(
-                    f"Your linear predictors are not supported for p={args[0].p}. For "
-                    + "negative linear predictors, consider using a log link instead."
+                    "Your linear predictors are not supported for power "
+                    f"{args[0].power}. For negative linear predictors, consider using "
+                    "a log link instead."
                 ) from e
         return result
 
@@ -144,7 +147,6 @@ class TweedieLink(Link):
             return lin_pred
         if self.power == 1:
             return np.exp(lin_pred)
-
         return lin_pred ** (1 / (1 - self.power))
 
     @catch_p

--- a/tests/glm/test_distribution.py
+++ b/tests/glm/test_distribution.py
@@ -56,9 +56,9 @@ def test_family_bounds(family, expected):
 def test_tweedie_distribution_power():
     with pytest.raises(ValueError, match="no distribution exists"):
         TweedieDistribution(power=0.5)
-    with pytest.raises(TypeError, match="must be an int or float"):
+    with pytest.raises(TypeError, match="must be numeric"):
         TweedieDistribution(power=1j)
-    with pytest.raises(TypeError, match="must be an int or float"):
+    with pytest.raises(TypeError, match="must be numeric"):
         dist = TweedieDistribution()
         dist.power = 1j
 
@@ -89,11 +89,11 @@ def test_tweedie_distribution_parsing():
 
 
 def test_negative_binomial_distribution_alpha():
-    with pytest.raises(ValueError, match="must be strictly positive number"):
+    with pytest.raises(ValueError, match="must be strictly positive"):
         NegativeBinomialDistribution(theta=-0.5)
-    with pytest.raises(TypeError, match="must be an int or float"):
+    with pytest.raises(TypeError, match="must be numeric"):
         NegativeBinomialDistribution(theta=1j)
-    with pytest.raises(TypeError, match="must be an int or float"):
+    with pytest.raises(TypeError, match="must be numeric"):
         dist = NegativeBinomialDistribution()
         dist.theta = 1j
 
@@ -120,8 +120,11 @@ def test_negative_binomial_distribution_parsing():
 
 def test_equality():
     assert TweedieDistribution(1) == TweedieDistribution(1)
-    assert TweedieDistribution(1) == PoissonDistribution()
-    assert TweedieDistribution(2) == GammaDistribution()
+    assert TweedieDistribution(0) != NormalDistribution()
+    assert TweedieDistribution(1) != PoissonDistribution()
+    assert TweedieDistribution(2) != GammaDistribution()
+    assert GammaDistribution() == GammaDistribution()
+    assert NormalDistribution() == NormalDistribution()
     assert PoissonDistribution() == PoissonDistribution()
     assert TweedieDistribution(1) != TweedieDistribution(1.5)
     assert TweedieDistribution(1) != BinomialDistribution()

--- a/tests/glm/test_distribution.py
+++ b/tests/glm/test_distribution.py
@@ -119,19 +119,24 @@ def test_negative_binomial_distribution_parsing():
 
 
 def test_equality():
-    assert TweedieDistribution(1) == TweedieDistribution(1)
-    assert TweedieDistribution(0) != NormalDistribution()
-    assert TweedieDistribution(1) != PoissonDistribution()
-    assert TweedieDistribution(2) != GammaDistribution()
+    assert BinomialDistribution() == BinomialDistribution()
     assert GammaDistribution() == GammaDistribution()
+    assert NegativeBinomialDistribution(1) != BinomialDistribution()
+    assert NegativeBinomialDistribution(1) != NegativeBinomialDistribution(1.5)
+    assert NegativeBinomialDistribution(1) == NegativeBinomialDistribution(1)
     assert NormalDistribution() == NormalDistribution()
     assert PoissonDistribution() == PoissonDistribution()
-    assert TweedieDistribution(1) != TweedieDistribution(1.5)
+    assert TweedieDistribution(0) != NormalDistribution()
+    assert TweedieDistribution(0) == NormalDistribution().to_tweedie()
     assert TweedieDistribution(1) != BinomialDistribution()
-    assert BinomialDistribution() == BinomialDistribution()
-    assert NegativeBinomialDistribution(1) == NegativeBinomialDistribution(1)
-    assert NegativeBinomialDistribution(1) != NegativeBinomialDistribution(1.5)
-    assert NegativeBinomialDistribution(1) != BinomialDistribution()
+    assert TweedieDistribution(1) != PoissonDistribution()
+    assert TweedieDistribution(1) == PoissonDistribution().to_tweedie()
+    assert TweedieDistribution(1) != TweedieDistribution(1.5)
+    assert TweedieDistribution(1) == TweedieDistribution(1)
+    assert TweedieDistribution(2) != GammaDistribution()
+    assert TweedieDistribution(2) == GammaDistribution().to_tweedie()
+    assert TweedieDistribution(3) != InverseGaussianDistribution()
+    assert TweedieDistribution(3) == InverseGaussianDistribution().to_tweedie()
 
 
 @pytest.mark.parametrize(

--- a/tests/glm/test_link.py
+++ b/tests/glm/test_link.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from glum._link import CloglogLink, Link, LogitLink, LogLink, TweedieLink
+from glum._link import CloglogLink, IdentityLink, Link, LogitLink, LogLink, TweedieLink
 
 
 @pytest.mark.parametrize("link", Link.__subclasses__())
@@ -34,9 +34,13 @@ def test_link_properties(link):
 
 
 def test_equality():
+    assert IdentityLink() == IdentityLink()
+    assert LogitLink() == LogitLink()
+    assert LogLink() == LogLink()
+    assert TweedieLink(0) != IdentityLink()
+    assert TweedieLink(0) == IdentityLink().to_tweedie()
+    assert TweedieLink(1.5) != LogitLink()
+    assert TweedieLink(1.5) != TweedieLink(2.5)
     assert TweedieLink(1.5) == TweedieLink(1.5)
     assert TweedieLink(1) != LogLink()
-    assert LogLink() == LogLink()
-    assert TweedieLink(1.5) != TweedieLink(2.5)
-    assert TweedieLink(1.5) != LogitLink()
-    assert LogitLink() == LogitLink()
+    assert TweedieLink(1) == LogLink().to_tweedie()


### PR DESCRIPTION
This PR restructures the distributions to avoid diamond inheritance -- i.e. the gamma, inverse Gaussian, normal and Poisson distributions no longer inherit from the Tweedie distribution. Because it is often convenient to test whether a distribution belongs to the Tweedie family, I added a `to_tweedie` method to the base class, which allows users to recover the Tweedie representation of a family if it exists. (I added an equivalent method to `Link`.)

Because it is a breaking change, the base branch is `glum_v3`.

Some free riders:

- `ExponentialDispersionModel.in_y_range` has been cleaned up.
- The documentation of the different distributions has been cleaned up and simplified.
- Excessively restrictive type hints have been removed. A few new hints have been added.
- Cython functions for the inverse Gaussian distribution have been added.
- The parsing of Tweedie links in `get_family` has been aligned on `get_family`.

