### PR TITLE
Exclude metaprogrammed methods from docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,23 @@ extensions = [
     "sphinx.ext.mathjax",
 ]
 
+autodoc_default_options = {
+    "exclude-members": (
+        "set_fit_request, "
+        "set_fit_predict_request, "
+        "set_fit_transform_request, "
+        "set_partial_fit_request, "
+        "set_predict_request, "
+        "set_predict_proba_request, "
+        "set_predict_log_proba_request, "
+        "set_decision_function_request, "
+        "set_score_request, "
+        "set_split_request, "
+        "set_transform_request, "
+        "set_inverse_transform_request"
+    )
+}
+
 autodoc_typehints = "description"
 
 templates_path = ["_templates"]

--- a/docs/dev
+++ b/docs/dev
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Running this script will rebuild the documentation every time you change one
-# of the sources. 
+# of the sources.
 
 # In Firefox, install the Live Reload extension and set up a rule for:
 # Host URL: http://localhost:8000/*


### PR DESCRIPTION
Scikit-learn has been generating metadata-routing methods programmatically, which show up in our documentation.