### PR TITLE
Skip numpy in nightly

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -38,7 +38,7 @@ jobs:
           micromamba install -y c-compiler cxx-compiler 'cython!=3.0.4' jemalloc-local libgomp mako xsimd
 
           PRE_WHEELS="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
-          for pkg in numpy pandas scikit-learn scipy; do
+          for pkg in pandas scikit-learn scipy; do
             echo "Installing $pkg nightly"
             micromamba remove -y --force $pkg
             pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS $pkg


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

I suggest to skip testing the nightly build with numpy 2.0 until we figure out how to fix the current errors. This will make the CI pass again for many PR that had nothing to do with numpy but were still failing the nightly job.