### PR TITLE
Accept `None` more generally

### DIFF
--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -2144,14 +2144,14 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 https://github.com/scikit-learn/scikit-learn/pull/9405.
                 """
             )
-        if self.solver not in {
+        if self.solver not in [
             None,
             "auto",
             "irls-ls",
             "lbfgs",
             "irls-cd",
             "trust-constr",
-        }:
+        ]:
             raise ValueError(
                 "GeneralizedLinearRegressor supports only solvers"
                 " 'auto', 'irls-ls', 'lbfgs', 'irls-cd' and 'trust-constr'; "
@@ -2182,7 +2182,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             raise TypeError(
                 f"The argument warm_start must be bool; got {self.warm_start}."
             )
-        if self.selection not in {"cyclic", "random"}:
+        if self.selection not in ["cyclic", "random"]:
             raise ValueError(
                 "The argument selection must be 'cyclic' or 'random'; "
                 f"got {self.selection}."
@@ -2200,14 +2200,14 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 "scale_predictors=True is not supported when fit_intercept=False."
             )
         if ((self.lower_bounds is not None) or (self.upper_bounds is not None)) and (
-            self.solver not in {None, "auto", "irls-cd"}
+            self.solver not in [None, "auto", "irls-cd"]
         ):
             raise ValueError(
                 "Only the 'cd' solver is supported when bounds are set; "
                 f"got {self.solver}."
             )
         if ((self.A_ineq is not None) or (self.b_ineq is not None)) and (
-            self.solver not in {None, "auto", "trust-constr"}
+            self.solver not in [None, "auto", "trust-constr"]
         ):
             raise ValueError(
                 "Only the 'trust-constr' solver supports inequality constraints; "

--- a/src/glum/_glm_cv.py
+++ b/src/glum/_glm_cv.py
@@ -290,8 +290,8 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
         P2="identity",
         fit_intercept=True,
         family: Union[str, ExponentialDispersionModel] = "normal",
-        link: Union[str, Link] = "auto",
-        solver="auto",
+        link: Optional[Union[str, Link]] = "auto",
+        solver: Optional[str] = "auto",
         max_iter=100,
         gradient_tol: Optional[float] = None,
         step_size_tol: Optional[float] = None,
@@ -525,12 +525,11 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
             ):
                 assert isinstance(self._link_instance, LogLink)
 
-            _dtype = [np.float64, np.float32]
             start_params = initialize_start_params(
                 self.start_params,
                 n_cols=X.shape[1],
                 fit_intercept=self.fit_intercept,
-                _dtype=_dtype,
+                dtype=[np.float64, np.float32],
             )
 
             P1_no_alpha = setup_p1(P1, X, X.dtype, 1, l1)
@@ -690,7 +689,7 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
             self.start_params,
             n_cols=X.shape[1],
             fit_intercept=self.fit_intercept,
-            _dtype=X.dtype,
+            dtype=X.dtype,
         )
 
         coef = self._get_start_coef(


### PR DESCRIPTION
For some reason, Glum requires many arguments to be strings where `None` would have been a more obvious default. This PR tweaks the code to accept `None` as well, though it doesn't change the default values.

It also removes the leading underscores from `_dtype` and `_stype`. Not sure why they were ever there.