### PR TITLE
Fix `test_formula` for pandas 3.0 nightly

### DIFF
--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -1716,7 +1716,9 @@ def test_column_with_stddev_zero():
 
     model = GeneralizedLinearRegressor(
         family="poisson", fit_intercept=False, scale_predictors=False
-    ).fit(X, y)  # noqa: F841
+    ).fit(
+        X, y
+    )  # noqa: F841
     model = GeneralizedLinearRegressor(family="poisson").fit(X, y)  # noqa: F841
 
 

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -1716,9 +1716,7 @@ def test_column_with_stddev_zero():
 
     model = GeneralizedLinearRegressor(
         family="poisson", fit_intercept=False, scale_predictors=False
-    ).fit(
-        X, y
-    )  # noqa: F841
+    ).fit(X, y)  # noqa: F841
     model = GeneralizedLinearRegressor(family="poisson").fit(X, y)  # noqa: F841
 
 
@@ -3028,12 +3026,18 @@ def test_formula(get_mixed_data, formula, drop_first, fit_intercept):
     if fit_intercept:
         # full rank check must consider presence of intercept
         y_ext, X_ext = formulaic.model_matrix(
-            formula, data, ensure_full_rank=drop_first
+            formula,
+            data,
+            ensure_full_rank=drop_first,
+            materializer=formulaic.materializers.PandasMaterializer,
         )
         X_ext = X_ext.drop(columns="Intercept")
     else:
         y_ext, X_ext = formulaic.model_matrix(
-            formula + "-1", data, ensure_full_rank=drop_first
+            formula + "-1",
+            data,
+            ensure_full_rank=drop_first,
+            materializer=formulaic.materializers.PandasMaterializer,
         )
     y_ext = y_ext.iloc[:, 0]
 


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

This change should fix the `formulaic.errors.FormulaMaterializerNotFoundError: No materializer has been registered for input type 'pandas.DataFrame'. Available input types are: set().` errors in the nightlies run. The underlying cause is that the current version of formulaic has some issues with pandas 3.0, and `model_matrix` does not work without selecting a materializer explicitly.

IMO being explicit is not a bad idea anyway, so we can fix the test instead of waiting for a formulaic update.