### PR TITLE
Rename argument for SKL compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - { os: ubuntu-latest, environment: 'py39' }
           - { os: ubuntu-latest, environment: 'py310' }
           - { os: ubuntu-latest, environment: 'py311' }
           - { os: ubuntu-latest, environment: 'py312' }
-          - { os: ubuntu-latest, environment: 'oldies' }
           - { os: windows-latest, environment: 'py312' }
           - { os: macos-latest, environment: 'py312' }
+          - { os: ubuntu-latest, environment: 'oldies' }
+          - { os: ubuntu-latest, environment: 'nightly' }
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -41,6 +41,9 @@ jobs:
         uses: prefix-dev/setup-pixi@992a3081e2f87829e0fff9fb29f4fe6a5d1e80a2
         with:
           environments: ${{ matrix.environment }}
+      - name: Install nightlies
+        if: matrix.NOTE == 'Nightly Builds'
+        run: pixi run -e ${{ matrix.environment }} install-nightlies
       - name: Install repository
         run: pixi run -e ${{ matrix.environment }} postinstall
       - name: Run pytest

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -72,7 +72,7 @@ from ._util import (
     _safe_toarray,
 )
 
-if version.parse(skl.__version__) < version.parse("1.6"):
+if version.parse(skl.__version__).release < (1, 6):
     keyword_finiteness = "force_all_finite"
 else:
     keyword_finiteness = "ensure_all_finite"


### PR DESCRIPTION
The development version doesn't count as 1.6 or newer, as it turns out.

This PR also adds the nightly tests to CI to avoid a repeat.

Closes #819.
