### PR TITLE
Fix breakage caused by scikit-learn API changes

### DIFF
--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -2466,7 +2466,10 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 )
 
         if y is None:
-            raise ValueError("y cannot be None when not using a two-sided formula.")
+            raise ValueError(
+                f"Unless using a two-sided formula, {self.__class__.__name__} "
+                "requires y to be passed, but the target y is None."
+            )
 
         if not _is_contiguous(X):
             if self.copy_X is not None and not self.copy_X:

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -27,6 +27,7 @@ import pandas as pd
 import scipy.sparse as sps
 import scipy.sparse.linalg as splinalg
 import sklearn as skl
+import sklearn.utils.validation
 import tabmat as tm
 from formulaic import Formula, FormulaSpec
 from formulaic.parser import DefaultFormulaParser
@@ -42,6 +43,17 @@ from sklearn.utils.validation import (
     check_is_fitted,
     column_or_1d,
 )
+
+if hasattr(sklearn.utils.validation, "validate_data"):
+    validate_data = sklearn.utils.validation.validate_data
+else:
+    validate_data = BaseEstimator._validate_data
+
+if hasattr(sklearn.utils.validation, "_check_n_features"):
+    _check_n_features = sklearn.utils.validation._check_n_features
+else:
+    _check_n_features = BaseEstimator._check_n_features
+
 
 from ._distribution import (
     BinomialDistribution,
@@ -2506,9 +2518,10 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
                 drop_first=getattr(self, "drop_first", False),
                 **{keyword_finiteness: force_all_finite},
             )
-            self._check_n_features(X, reset=True)
+            _check_n_features(self, X, reset=True)
         else:
-            X, y = self._validate_data(
+            X, y = validate_data(
+                self,
                 X,
                 y,
                 ensure_2d=True,


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

Fixes the daily run failure in #830 

Some of it is caused by our using `sklearn.BaseEstimator`'s private methods, which have been refactored in https://github.com/scikit-learn/scikit-learn/pull/29696. The proposed solution is not super nice, but we have to make sure that glum works with both old and new versions of scikit-learn.
