### PR TITLE
Make `y` optional in GeneralizedLinearRegressorCV when using a formula

### DIFF
--- a/src/glum/_glm_cv.py
+++ b/src/glum/_glm_cv.py
@@ -422,7 +422,7 @@ class GeneralizedLinearRegressorCV(GeneralizedLinearRegressorBase):
     def fit(
         self,
         X: ArrayLike,
-        y: ArrayLike,
+        y: Optional[ArrayLike] = None,
         sample_weight: Optional[ArrayLike] = None,
         offset: Optional[ArrayLike] = None,
         *,


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

`GeneralizedLinearRegressorCV` was already prepared to handle formulas in glum 3.0, but the function signature was missed. This PR fixes it and adds a test to make sure it does not happen again.