### PR TITLE
scikit-learn-compliant error message when the number of input features is different between the fit and predict methods.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -110,6 +110,10 @@ Changelog
 2.5.1 - 2023-05-19
 ------------------
 
+**Other changes:**
+
+- Better error message when the number of input features is different between the fit and predict methods.
+
 **Bug fix:**
 
 - We fixed a bug in the computation of :meth:`~glum.distribution.NegativeBinomialDistribution.log_likelihood`. Previously, this method just returned ``None``.

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1357,6 +1357,12 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
             drop_first=getattr(self, "drop_first", False),
         )
 
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"X has {X.shape[1]} features, but {self.__class__.__name__} "
+                f"is expecting {self.n_features_in_} features as input."
+            )
+
         if alpha_index is None:
             xb = X @ self.coef_ + self.intercept_
             if offset is not None:


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry

Fixes #847 
