### PR TITLE
Drop SciPy from nightly CI

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -35,7 +35,6 @@ cmd = """
     PRE_WHEELS="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS pandas
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS scikit-learn
-    && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS scipy
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i https://pypi.fury.io/arrow-nightlies/ pyarrow
     && pip install --no-use-pep517 --no-deps git+https://github.com/Quantco/tabmat
 """

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1791,7 +1791,7 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
     ) -> WaldTestResult:
         """
         Perform a Wald test for the hypothesis that the coefficients of the
-        features in ``terms`` are equal to the values in ``terms``.
+        features in ``terms`` are equal to the values in ``values``.
         """
 
         if isinstance(terms, str):


### PR DESCRIPTION
Closes #853.

Is there a reason for which we aren't testing against nightly NumPy?