### PR TITLE
Use regularized models in `test_glm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # glum
 
 [![CI](https://github.com/Quantco/glm_benchmarks/workflows/CI/badge.svg)](https://github.com/Quantco/glum/actions)
+[![Daily runs](https://github.com/Quantco/glum/actions/workflows/daily.yml/badge.svg)](https://github.com/Quantco/glum/actions/workflows/daily.yml)
 [![Docs](https://readthedocs.org/projects/pip/badge/?version=latest&style=flat)](https://glum.readthedocs.io/)
 [![Conda-forge](https://img.shields.io/conda/vn/conda-forge/glum?logoColor=white&logo=conda-forge)](https://anaconda.org/conda-forge/glum)
 [![PypiVersion](https://img.shields.io/pypi/v/glum.svg?logo=pypi&logoColor=white)](https://pypi.org/project/glum)

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -47,7 +47,7 @@ from glum._link import IdentityLink, Link, LogitLink, LogLink
 GLM_SOLVERS = ["irls-ls", "lbfgs", "irls-cd", "trust-constr"]
 
 estimators = [
-    (GeneralizedLinearRegressor, {}),
+    (GeneralizedLinearRegressor, {"alpha": 1.0}),
     (GeneralizedLinearRegressorCV, {"n_alphas": 2}),
 ]
 


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

With the change to a default `alpha=0` in glum 3 many of our tests are now using unregularized models. This might cause issues (#863) when e.g. scikit-learn decides to add singular matrices to`sklearn.utils.check_estimator`'s checks. This PR changes the default model in  `tests/test_glm.py` to the old, regularized default.

I also added a badge for ~~nightlies~~ daily tests to the readme so that it's a bit more obvious when the nightlies are failing.
