### PR TITLE
Change MRO

### DIFF
--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -713,7 +713,7 @@ def _group_sum(groups: np.ndarray, data: tm.MatrixBase):
 
 
 # TODO: abc
-class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
+class GeneralizedLinearRegressorBase(RegressorMixin, BaseEstimator):
     """
     Base class for :class:`GeneralizedLinearRegressor` and
     :class:`GeneralizedLinearRegressorCV`.


### PR DESCRIPTION
Closes #878.

In CI against the latest scikit-learn version, we're seeing

```
FAILED tests/glm/test_glm.py::test_check_estimator[GeneralizedLinearRegressor-kwargs0] - AssertionError: GeneralizedLinearRegressor is inheriting from mixins in the wrong order. In general, in mixin inheritance, more specialized mixins must come before more general ones. This means, for instance, `BaseEstimator` should be on the right side of most other mixins. You need to change the order so that:
RegressorMixin comes before/left side of BaseEstimator
FAILED tests/glm/test_glm.py::test_check_estimator[GeneralizedLinearRegressorCV-kwargs1] - AssertionError: GeneralizedLinearRegressorCV is inheriting from mixins in the wrong order. In general, in mixin inheritance, more specialized mixins must come before more general ones. This means, for instance, `BaseEstimator` should be on the right side of most other mixins. You need to change the order so that:
RegressorMixin comes before/left side of BaseEstimator
```

This check was introduced with https://github.com/scikit-learn/scikit-learn/pull/30234.

Was there are reason we ordered things they way we did or is this safe to change?