### PR TITLE
Update wheels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MarcAntoineSchmidtQC @jtilly @lbittarello
+* @MarcAntoineSchmidtQC @jtilly @lbittarello @stanmart

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,14 +12,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-20.04, windows-2022, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_ARCHS_MACOS: x86_64 arm64
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@06375d89d211a1232ef63355742e9e2e564bc7f7
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
       - uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,13 @@ test-requires = ["pytest", "pytest-xdist"]
 
 [tool.cibuildwheel.macos]
 before-build = [
-  "conda create -n build 'llvm-openmp=11'",
+  "/Users/runner/micromamba-bin/micromamba create -y -p $MAMBA_ROOT_PREFIX/envs/build -c conda-forge 'llvm-openmp=11'",
 ]
 
 [tool.cibuildwheel.macos.environment]
-LDFLAGS="-Wl,-rpath,$CONDA/envs/build/lib -L$CONDA/envs/build/lib"
-CFLAGS="-I$CONDA/envs/build/include"
-CXXFLAGS="-I$CONDA/envs/build/include"
+LDFLAGS="-Wl,-rpath,$MAMBA_ROOT_PREFIX/envs/build/lib -L$MAMBA_ROOT_PREFIX/envs/build/lib"
+CFLAGS="-I$MAMBA_ROOT_PREFIX/envs/build/include"
+CXXFLAGS="-I$MAMBA_ROOT_PREFIX/envs/build/include"
 CXX="/usr/bin/clang++"
 CC="/usr/bin/clang"
 MACOSX_DEPLOYMENT_TARGET="10.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,12 @@ skip = [
   "cp36*",
   "cp37*",
   "cp38*",
-  "cp313-*",
 ]
 test-requires = ["pytest", "pytest-xdist"]
 
 [tool.cibuildwheel.macos]
 before-build = [
-  "bash build_tools/prepare_macos_wheel.sh",
+  "conda create -n build 'llvm-openmp=11'",
 ]
 
 [tool.cibuildwheel.macos.environment]


### PR DESCRIPTION
Remove skip on python 3.13 for the wheel, and update the macos wheel to use apple silicon natively.

<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
