### PR TITLE
Add wheel and setuptools to host-requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   tools:
     python: mambaforge-4.10
   commands:
-    - mamba install -c conda-forge -c nodefaults pixi==0.22.0
+    - mamba install -c conda-forge -c nodefaults pixi==0.39.4
     - pixi run -e docs postinstall
     - pixi run readthedocs
 sphinx:

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,4 +1,4 @@
-version: 5
+version: 6
 environments:
   benchmark:
     channels:
@@ -353,6 +353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py313h90d716c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py313hf2da073_1.conda
@@ -487,6 +488,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_23.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py313ha7868ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
@@ -851,6 +853,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py313h90d716c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
@@ -999,6 +1002,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_23.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py313ha7868ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
@@ -5207,35 +5211,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
 packages:
-- kind: conda
-  name: _libavif_api
-  version: 1.1.1
-  build: h57928b3_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_2.conda
   sha256: b99b8948a170ff721ea958ee04a4431797070e85dd6942cb27b73ac3102e5145
   md5: 76cf1f62c9a62d6b8f44339483e0f016
   size: 9286
   timestamp: 1730268773319
-- kind: conda
-  name: _libgcc_mutex
-  version: '0.1'
-  build: conda_forge
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
   license: None
   size: 2562
   timestamp: 1578324546067
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_gnu
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   build_number: 16
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   md5: 73aaf86a425cc6e73fcf236a5a46396d
   depends:
@@ -5247,13 +5235,19 @@ packages:
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_gnu
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+  build_number: 2
+  sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
+  md5: 562b26ba2e19059551a811e72ab7f793
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5744
+  timestamp: 1650742457817
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
   build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
   sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
   md5: 37e16618af5c4851a3f3d66dd0e11141
   depends:
@@ -5266,29 +5260,7 @@ packages:
   license_family: BSD
   size: 49468
   timestamp: 1718213032772
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_kmp_llvm
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
-  sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
-  md5: 562b26ba2e19059551a811e72ab7f793
-  depends:
-  - _libgcc_mutex 0.1 conda_forge
-  - llvm-openmp >=9.0.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5744
-  timestamp: 1650742457817
-- kind: conda
-  name: alabaster
-  version: 1.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_0.conda
   sha256: a9e1092725561d9bff12d3a4d3bb46c43d3d0db3cbb2c63c9025d1c77e84840c
   md5: 7d78a232029458d0077ede6cda30ed0c
   depends:
@@ -5297,12 +5269,7 @@ packages:
   license_family: BSD
   size: 18522
   timestamp: 1722035895436
-- kind: conda
-  name: alsa-lib
-  version: 1.2.13
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.13-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.13-hb9d3cd8_0.conda
   sha256: f507b58f77eabc0cc133723cb7fc45c053d551f234df85e70fb3ede082b0cd53
   md5: ae1370588aa6a5157c34c73e9bbb36a0
   depends:
@@ -5312,13 +5279,7 @@ packages:
   license_family: GPL
   size: 560238
   timestamp: 1731489643707
-- kind: conda
-  name: altair
-  version: 5.5.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/altair-5.5.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/altair-5.5.0-pyhd8ed1ab_0.conda
   sha256: de9d4f1211b6f818b9c5b42b641ca7b729e92a265d442f5a471cb9a83d7e10dd
   md5: a36e83a3ca4416a393be9d023f1f9c8d
   depends:
@@ -5333,13 +5294,7 @@ packages:
   license_family: BSD
   size: 495342
   timestamp: 1732408526911
-- kind: conda
-  name: anyio
-  version: 4.6.2.post1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
   sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
   md5: 688697ec5e9588bdded167d19577625b
   depends:
@@ -5355,27 +5310,7 @@ packages:
   license_family: MIT
   size: 109864
   timestamp: 1728935803440
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: h7bae524_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
-  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
-  md5: 7adba36492a1bb22d98ffffe4f6fc6de
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2235747
-  timestamp: 1718551382432
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: hac33072_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   md5: 346722a0be40f6edc53f12640d301338
   depends:
@@ -5385,12 +5320,17 @@ packages:
   license_family: BSD
   size: 2706396
   timestamp: 1718551242397
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
+  md5: 7adba36492a1bb22d98ffffe4f6fc6de
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2235747
+  timestamp: 1718551382432
+- conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
   sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
   md5: 3d7c14285d3eb3239a76ff79063f27a5
   depends:
@@ -5401,13 +5341,7 @@ packages:
   license_family: BSD
   size: 1958151
   timestamp: 1718551737234
-- kind: conda
-  name: appnope
-  version: 0.1.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
   sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
   md5: cc4834a9ee7cc49ce8d25177c47b10d8
   depends:
@@ -5416,13 +5350,7 @@ packages:
   license_family: BSD
   size: 10241
   timestamp: 1707233195627
-- kind: conda
-  name: argon2-cffi
-  version: 23.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
   md5: 3afef1f55a1366b4d3b6a0d92e2235e4
   depends:
@@ -5435,13 +5363,20 @@ packages:
   license_family: MIT
   size: 18602
   timestamp: 1692818472638
-- kind: conda
-  name: argon2-cffi-bindings
-  version: 21.2.0
-  build: py312h024a12e_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py312h024a12e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py312h66e93f0_5.conda
+  sha256: 3cbc3b026f5c3f26de696ead10607db8d80cbb003d87669ac3b02e884f711978
+  md5: 1505fc57c305c0a3174ea7aae0a0db25
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  size: 34847
+  timestamp: 1725356749774
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py312h024a12e_5.conda
   sha256: 0e32ddd41f273f505956254d81ffadaf982ed1cb7dfd70d9251a8c5b705c7267
   md5: 6ccaeafe1a52b0d0e7ebfbf53a374649
   depends:
@@ -5454,13 +5389,7 @@ packages:
   license_family: MIT
   size: 32838
   timestamp: 1725356954187
-- kind: conda
-  name: argon2-cffi-bindings
-  version: 21.2.0
-  build: py312h4389bb4_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py312h4389bb4_5.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py312h4389bb4_5.conda
   sha256: 8764a8a9416d90264c7d36526de77240a454d0ee140841db545bdd5825ebd6f1
   md5: 53943e7ecba6b3e3744b292dc3fb4ae2
   depends:
@@ -5474,32 +5403,7 @@ packages:
   license_family: MIT
   size: 34399
   timestamp: 1725357069475
-- kind: conda
-  name: argon2-cffi-bindings
-  version: 21.2.0
-  build: py312h66e93f0_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py312h66e93f0_5.conda
-  sha256: 3cbc3b026f5c3f26de696ead10607db8d80cbb003d87669ac3b02e884f711978
-  md5: 1505fc57c305c0a3174ea7aae0a0db25
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cffi >=1.0.1
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 34847
-  timestamp: 1725356749774
-- kind: conda
-  name: arrow
-  version: 1.3.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
   sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
   md5: b77d8c2313158e6e461ca0efb1c2c508
   depends:
@@ -5510,13 +5414,7 @@ packages:
   license_family: Apache
   size: 100096
   timestamp: 1696129131844
-- kind: conda
-  name: astor
-  version: 0.8.1
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/astor-0.8.1-pyh9f0ad1d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/astor-0.8.1-pyh9f0ad1d_0.tar.bz2
   sha256: cb4ae0e3055907983f21a24dc2ac47d5a77d7c1dd98b1e21fed06956437e52c7
   md5: 6ae770689be59dc391ef974d2e849b56
   depends:
@@ -5525,13 +5423,7 @@ packages:
   license_family: BSD
   size: 25792
   timestamp: 1593610550883
-- kind: conda
-  name: asttokens
-  version: 2.4.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
   sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
   md5: 5f25798dcefd8252ce5f9dc494d5f571
   depends:
@@ -5541,13 +5433,7 @@ packages:
   license_family: Apache
   size: 28922
   timestamp: 1698341257884
-- kind: conda
-  name: async-lru
-  version: 2.0.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
   sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
   md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
   depends:
@@ -5557,13 +5443,7 @@ packages:
   license_family: MIT
   size: 15342
   timestamp: 1690563152778
-- kind: conda
-  name: attrs
-  version: 24.2.0
-  build: pyh71513ae_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
   sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
   md5: 6732fa52eb8e66e5afeb32db8701a791
   depends:
@@ -5572,13 +5452,7 @@ packages:
   license_family: MIT
   size: 56048
   timestamp: 1722977241383
-- kind: conda
-  name: autograd
-  version: 1.7.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/autograd-1.7.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/autograd-1.7.0-pyhd8ed1ab_0.conda
   sha256: 2640424d10419ebc53cf962b606de81deec33611f9d1f08eee1e23bbd7fc4a96
   md5: 3d0c2341f515348d7fdc4f6d5f448446
   depends:
@@ -5589,13 +5463,7 @@ packages:
   license_family: MIT
   size: 47431
   timestamp: 1724658599538
-- kind: conda
-  name: autograd-gamma
-  version: 0.5.0
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/autograd-gamma-0.5.0-pyh9f0ad1d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/autograd-gamma-0.5.0-pyh9f0ad1d_0.tar.bz2
   sha256: ee6384ca35889fbc2a877ae7140eb90ca66980310640027eb39185ffa84f92bd
   md5: 1d2f3cd0881ead2f033ec5a9d567c6f0
   depends:
@@ -5606,13 +5474,36 @@ packages:
   license_family: MIT
   size: 7767
   timestamp: 1602812490828
-- kind: conda
-  name: aws-c-auth
-  version: 0.8.0
-  build: h6c5491b_10
-  build_number: 10
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+  sha256: d2837a84e6bd7d993a83e79f9e240e1465e375f3d57149ea5b1927c6a4133bcc
+  md5: 409b7ee6d3473cc62bda7280f6ac20d0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 107163
+  timestamp: 1731733534767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+  sha256: 63cb8c25e0a26be4261d4271de525e7e33aefe9d9b001b8abfa5c9ac69c3dab3
+  md5: 17c90d9eb8c6842fd739dc5445ce9962
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92355
+  timestamp: 1731733738919
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
   sha256: f92d43e36d271194f027a49c5bd91c7f3eab0406a83734b0a2fee75e0c914546
   md5: 78eef4154032e557c81bcd12640ee048
   depends:
@@ -5628,54 +5519,19 @@ packages:
   license_family: Apache
   size: 103029
   timestamp: 1731733929676
-- kind: conda
-  name: aws-c-auth
-  version: 0.8.0
-  build: h9b725a8_10
-  build_number: 10
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
-  sha256: 63cb8c25e0a26be4261d4271de525e7e33aefe9d9b001b8abfa5c9ac69c3dab3
-  md5: 17c90d9eb8c6842fd739dc5445ce9962
-  depends:
-  - __osx >=11.0
-  - aws-c-cal >=0.8.0,<0.8.1.0a0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-http >=0.9.1,<0.9.2.0a0
-  - aws-c-io >=0.15.2,<0.15.3.0a0
-  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 92355
-  timestamp: 1731733738919
-- kind: conda
-  name: aws-c-auth
-  version: 0.8.0
-  build: hb88c0a9_10
-  build_number: 10
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
-  sha256: d2837a84e6bd7d993a83e79f9e240e1465e375f3d57149ea5b1927c6a4133bcc
-  md5: 409b7ee6d3473cc62bda7280f6ac20d0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+  sha256: 220a37955c120bf2f565fbd5320a82fc4c8b550b2449294bc0509c296cfcb9fa
+  md5: c54459d686ad9d0502823cacff7e8423
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-c-cal >=0.8.0,<0.8.1.0a0
   - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-http >=0.9.1,<0.9.2.0a0
-  - aws-c-io >=0.15.2,<0.15.3.0a0
-  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
   - libgcc >=13
+  - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 107163
-  timestamp: 1731733534767
-- kind: conda
-  name: aws-c-cal
-  version: 0.8.0
-  build: h5d7ee29_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+  size: 47477
+  timestamp: 1731678510949
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
   sha256: 2a8c09b33400cf2b7d658e63fd5a6f9b6e9626458f6213b904592fc15220bc92
   md5: 92734dad83d22314205ba73b679710d2
   depends:
@@ -5686,13 +5542,7 @@ packages:
   license_family: Apache
   size: 39966
   timestamp: 1731678721786
-- kind: conda
-  name: aws-c-cal
-  version: 0.8.0
-  build: hb414858_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
   sha256: d2327c924931550a05ab902b4aedbcf5105b581839bade4db7fba6e73dd63214
   md5: fd898cb8119bf3ad009762df2d8068b0
   depends:
@@ -5705,30 +5555,26 @@ packages:
   license_family: Apache
   size: 46852
   timestamp: 1731679007675
-- kind: conda
-  name: aws-c-cal
-  version: 0.8.0
-  build: hecf86a2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
-  sha256: 220a37955c120bf2f565fbd5320a82fc4c8b550b2449294bc0509c296cfcb9fa
-  md5: c54459d686ad9d0502823cacff7e8423
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+  sha256: 90bd2ff40b65acb62f11e2500ee7b7e85ac77d2e332429002f4c1da949bec27f
+  md5: ff3653946d34a6a6ba10babb139d96ef
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
   - libgcc >=13
-  - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 47477
-  timestamp: 1731678510949
-- kind: conda
-  name: aws-c-common
-  version: 0.10.3
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+  size: 237137
+  timestamp: 1731567278052
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+  sha256: bb2c1038726d31ffd2d35a5764f80bcd670b6a1c753aadfd261aecb9f88db6d8
+  md5: 4150339e3b08db33fe4c436340b1d7f6
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 221524
+  timestamp: 1731567512057
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
   sha256: 27c094c554a84389f0f2430e7397a1b33d558b035bbaf188877f635dbb9b26e6
   md5: 49b50b5f5074259e9a62c0c271a24d98
   depends:
@@ -5739,42 +5585,18 @@ packages:
   license_family: Apache
   size: 234894
   timestamp: 1731567453718
-- kind: conda
-  name: aws-c-common
-  version: 0.10.3
-  build: h5505292_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
-  sha256: bb2c1038726d31ffd2d35a5764f80bcd670b6a1c753aadfd261aecb9f88db6d8
-  md5: 4150339e3b08db33fe4c436340b1d7f6
-  depends:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 221524
-  timestamp: 1731567512057
-- kind: conda
-  name: aws-c-common
-  version: 0.10.3
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
-  sha256: 90bd2ff40b65acb62f11e2500ee7b7e85ac77d2e332429002f4c1da949bec27f
-  md5: ff3653946d34a6a6ba10babb139d96ef
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+  sha256: 210ba4fff1c9500fe02de1dae311ce723bfa313a2d21b72accd745f736f56fce
+  md5: 257f4ae92fe11bd8436315c86468c39b
   depends:
   - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
   - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 237137
-  timestamp: 1731567278052
-- kind: conda
-  name: aws-c-compression
-  version: 0.3.0
-  build: h5d7ee29_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+  size: 19034
+  timestamp: 1731678703956
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
   sha256: a52ea62bf08aed3af079e16d1738f3d2a7fcdd1d260289ae27ae96298e15d12a
   md5: 15566c36b0cf5f314e3bee7f7cc796b5
   depends:
@@ -5784,13 +5606,7 @@ packages:
   license_family: Apache
   size: 18204
   timestamp: 1731678916439
-- kind: conda
-  name: aws-c-compression
-  version: 0.3.0
-  build: hb414858_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
   sha256: 2f8c79b24a1396ed2754379bfbe1595b50e7cf306962060b80084b46b682887f
   md5: beb319c4aeb7de9f6cacf533ebbae94c
   depends:
@@ -5802,49 +5618,7 @@ packages:
   license_family: Apache
   size: 22528
   timestamp: 1731679090015
-- kind: conda
-  name: aws-c-compression
-  version: 0.3.0
-  build: hf42f96a_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
-  sha256: 210ba4fff1c9500fe02de1dae311ce723bfa313a2d21b72accd745f736f56fce
-  md5: 257f4ae92fe11bd8436315c86468c39b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - libgcc >=13
-  license: Apache-2.0
-  license_family: Apache
-  size: 19034
-  timestamp: 1731678703956
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.5.0
-  build: h13ead76_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
-  sha256: 386965fab5f0bed4a6109cdba32579f16bee1b0f76ce1db840ce6f7070188f9f
-  md5: 55a901b6d4fb9ce1bc8328925b229f0b
-  depends:
-  - __osx >=11.0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-io >=0.15.2,<0.15.3.0a0
-  - aws-checksums >=0.2.2,<0.2.3.0a0
-  - libcxx >=18
-  license: Apache-2.0
-  license_family: Apache
-  size: 47528
-  timestamp: 1731714690911
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.5.0
-  build: h1ffe551_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
   sha256: 3b780d6483baa889e8df5aa66ab3c439a9c81331cf2a4799e373f4174768ddd9
   md5: 7cce4dfab184f4bbdfc160789251b3c5
   depends:
@@ -5858,13 +5632,20 @@ packages:
   license_family: Apache
   size: 53500
   timestamp: 1731714597524
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.5.0
-  build: hab6af6e_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+  sha256: 386965fab5f0bed4a6109cdba32579f16bee1b0f76ce1db840ce6f7070188f9f
+  md5: 55a901b6d4fb9ce1bc8328925b229f0b
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 47528
+  timestamp: 1731714690911
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
   sha256: 39fe165d6616e09d25c07a85560ec414a0b0b19c1880e0df52283196cf44896f
   md5: 1e81f2ecfb25d4a84b4d8fa6067924e5
   depends:
@@ -5878,13 +5659,7 @@ packages:
   license_family: Apache
   size: 54641
   timestamp: 1731714676039
-- kind: conda
-  name: aws-c-http
-  version: 0.9.1
-  build: hab05fe4_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
   sha256: 90a325b6f5371dd2203b643de646967fe57a4bcbbee8c91086abbf9dd733d59a
   md5: fb409f7053fa3dbbdf6eb41045a87795
   depends:
@@ -5898,13 +5673,20 @@ packages:
   license_family: Apache
   size: 196945
   timestamp: 1731714483279
-- kind: conda
-  name: aws-c-http
-  version: 0.9.1
-  build: hab0f966_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+  sha256: fca9ed0f0895bab9bf737c8d8a3314556cb893d45c40f0656f21a93502db3089
+  md5: d880c40b8fc7d07374c036f93f1359d2
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 153315
+  timestamp: 1731714621306
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
   sha256: 81c93d2b8c951c18509ff1359505d01740f77865c9bef46c457607f0ca8c76ad
   md5: e715a008f534917e93ed2238546b68b0
   depends:
@@ -5919,49 +5701,7 @@ packages:
   license_family: Apache
   size: 182315
   timestamp: 1731714924335
-- kind: conda
-  name: aws-c-http
-  version: 0.9.1
-  build: hf483d09_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
-  sha256: fca9ed0f0895bab9bf737c8d8a3314556cb893d45c40f0656f21a93502db3089
-  md5: d880c40b8fc7d07374c036f93f1359d2
-  depends:
-  - __osx >=11.0
-  - aws-c-cal >=0.8.0,<0.8.1.0a0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-compression >=0.3.0,<0.3.1.0a0
-  - aws-c-io >=0.15.2,<0.15.3.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 153315
-  timestamp: 1731714621306
-- kind: conda
-  name: aws-c-io
-  version: 0.15.2
-  build: h39f8ad8_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
-  sha256: b14e32f024f6be1610dccfdb6371e101cba204d24f37c2a63d9b6380ac74ac17
-  md5: 3b49f1dd8f20bead8b222828cfdad585
-  depends:
-  - __osx >=11.0
-  - aws-c-cal >=0.8.0,<0.8.1.0a0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 137610
-  timestamp: 1731702839896
-- kind: conda
-  name: aws-c-io
-  version: 0.15.2
-  build: hdeadb07_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
   sha256: 1636136a5d882b4aaa13ea8b7de8cf07038a6878872e3c434df9daf478cee594
   md5: 461a1eaa075fd391add91bcffc9de0c1
   depends:
@@ -5974,13 +5714,18 @@ packages:
   license_family: Apache
   size: 159368
   timestamp: 1731702542973
-- kind: conda
-  name: aws-c-io
-  version: 0.15.2
-  build: hef77f12_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+  sha256: b14e32f024f6be1610dccfdb6371e101cba204d24f37c2a63d9b6380ac74ac17
+  md5: 3b49f1dd8f20bead8b222828cfdad585
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137610
+  timestamp: 1731702839896
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
   sha256: 8c02308ad64dcccb85ea55b6fdfb6b6de4b5710a564d24faf64655c4029f4008
   md5: ac3ab925a1345a6957d5d217fd2d9469
   depends:
@@ -5993,31 +5738,7 @@ packages:
   license_family: Apache
   size: 160495
   timestamp: 1731702920182
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.11.0
-  build: h68a0d7e_8
-  build_number: 8
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
-  sha256: 837c24c105624e16ace94b4b566ffe45231ff275339c523571ebd45946926156
-  md5: 9e3ac70d27e7591b1310a690768cfe27
-  depends:
-  - __osx >=11.0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-http >=0.9.1,<0.9.2.0a0
-  - aws-c-io >=0.15.2,<0.15.3.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 134573
-  timestamp: 1731734281038
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.11.0
-  build: h7bd072d_8
-  build_number: 8
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
   sha256: 51d3d87a47c642096e2ce389a169aec2e26958042e9130857552a12d65a19045
   md5: 0e9d67838114c0dbd267a9311268b331
   depends:
@@ -6030,13 +5751,19 @@ packages:
   license_family: Apache
   size: 194447
   timestamp: 1731734668760
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.11.0
-  build: hbfeb708_8
-  build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+  sha256: 837c24c105624e16ace94b4b566ffe45231ff275339c523571ebd45946926156
+  md5: 9e3ac70d27e7591b1310a690768cfe27
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 134573
+  timestamp: 1731734281038
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
   sha256: c1462d6b1de9bdaf6b3233e70cdf2e49b481da9bdf91c0c3f5fcf5ed55f3ca18
   md5: e125209fbb06e56a208a75f8aae48c00
   depends:
@@ -6050,12 +5777,7 @@ packages:
   license_family: Apache
   size: 186691
   timestamp: 1731735208782
-- kind: conda
-  name: aws-c-s3
-  version: 0.7.2
-  build: h3a84f74_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.2-h3a84f74_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.2-h3a84f74_0.conda
   sha256: c0ae38eb1f878157323afdd002229e9eeb739f622e028447330805c030c50a9f
   md5: a5f883ce16928e898856b5bd8d1bee57
   depends:
@@ -6072,12 +5794,22 @@ packages:
   license_family: Apache
   size: 113549
   timestamp: 1732679091663
-- kind: conda
-  name: aws-c-s3
-  version: 0.7.2
-  build: h6108ab3_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.2-h6108ab3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.2-h840aca7_0.conda
+  sha256: 30e4bed9d008fb79f5e84ecbea0f21030ad5d60cb5c55a962df90721aa98fc42
+  md5: 63100ff62fdff4a6afcea38841036027
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97042
+  timestamp: 1732679268030
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.2-h6108ab3_0.conda
   sha256: b85c36390bfde675fd7fcebfd44bd60d09919d2c7fd2c983d9a5504db3cef6c3
   md5: dd13817144d595f8309f08cd61578fba
   depends:
@@ -6094,33 +5826,18 @@ packages:
   license_family: Apache
   size: 108777
   timestamp: 1732679249162
-- kind: conda
-  name: aws-c-s3
-  version: 0.7.2
-  build: h840aca7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.2-h840aca7_0.conda
-  sha256: 30e4bed9d008fb79f5e84ecbea0f21030ad5d60cb5c55a962df90721aa98fc42
-  md5: 63100ff62fdff4a6afcea38841036027
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+  sha256: f6e38c79b124c34edb048c28ec58fdfc4ea8f7a218dc493195afbada48ba063b
+  md5: bbdd20fb1994a9f0ba98078fcb6c12ab
   depends:
-  - __osx >=11.0
-  - aws-c-auth >=0.8.0,<0.8.1.0a0
-  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - __glibc >=2.17,<3.0.a0
   - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-http >=0.9.1,<0.9.2.0a0
-  - aws-c-io >=0.15.2,<0.15.3.0a0
-  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 97042
-  timestamp: 1732679268030
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.2.1
-  build: h5d7ee29_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+  size: 55738
+  timestamp: 1731687063424
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
   sha256: ed3b272b9a345142e62f0cf9ab2a9fa909c92e09691f6a06e98ff500a1f8a303
   md5: 0f1e5bc57d4567c9d9bec8d8982828ed
   depends:
@@ -6130,13 +5847,7 @@ packages:
   license_family: Apache
   size: 50276
   timestamp: 1731687215375
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.2.1
-  build: hb414858_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
   sha256: 6130e79950efe49460dcedc8a4845a274ed572e55667b66c815dc771f63f9eca
   md5: 0e3318644bfcc9c42cbde728d7bb8e08
   depends:
@@ -6148,30 +5859,18 @@ packages:
   license_family: Apache
   size: 55188
   timestamp: 1731687352327
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.2.1
-  build: hf42f96a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
-  sha256: f6e38c79b124c34edb048c28ec58fdfc4ea8f7a218dc493195afbada48ba063b
-  md5: bbdd20fb1994a9f0ba98078fcb6c12ab
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+  sha256: da802ace5448481c968cfec7e7a4f79f686f42df9de8e3f78c09a925c2882a79
+  md5: d908d43d87429be24edfb20e96543c20
   depends:
   - __glibc >=2.17,<3.0.a0
   - aws-c-common >=0.10.3,<0.10.4.0a0
   - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 55738
-  timestamp: 1731687063424
-- kind: conda
-  name: aws-checksums
-  version: 0.2.2
-  build: h5d7ee29_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+  size: 72744
+  timestamp: 1731687193373
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
   sha256: eb7ebe309b33a04329b3e51a7f10bb407815389dc37cc047f7d41f9c91f0d1b0
   md5: db1ed95988a8fe6c1ce0d94abdfc8e72
   depends:
@@ -6181,13 +5880,7 @@ packages:
   license_family: Apache
   size: 70184
   timestamp: 1731687342560
-- kind: conda
-  name: aws-checksums
-  version: 0.2.2
-  build: hb414858_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
   sha256: f7d0c5c9bd65cca937ed53425800d7376e89bdac9f82fcef44698e6707784cae
   md5: 0cb03655a7cf5b4ad9e0cd8d5a18b21d
   depends:
@@ -6199,29 +5892,7 @@ packages:
   license_family: Apache
   size: 91905
   timestamp: 1731687613902
-- kind: conda
-  name: aws-checksums
-  version: 0.2.2
-  build: hf42f96a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
-  sha256: da802ace5448481c968cfec7e7a4f79f686f42df9de8e3f78c09a925c2882a79
-  md5: d908d43d87429be24edfb20e96543c20
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - libgcc >=13
-  license: Apache-2.0
-  license_family: Apache
-  size: 72744
-  timestamp: 1731687193373
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.29.6
-  build: h0e61686_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.6-h0e61686_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.6-h0e61686_0.conda
   sha256: b821d0125f8fcb589b880bf3a5e0e1667e285b3006ceb19d96e6d92d049ab787
   md5: 651a6500e5fded51bb7572f4eebcfd7b
   depends:
@@ -6241,12 +5912,26 @@ packages:
   license_family: Apache
   size: 355169
   timestamp: 1732769507038
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.29.6
-  build: h2d7cec8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.6-h2d7cec8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.6-h8bcca62_0.conda
+  sha256: b6d2ff238a712137afd9b46842235b32a04cac580734873bf86876da6e71dd03
+  md5: 8e49f5e86a3e39699b24035fa6d1ad40
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.2,<0.7.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 236490
+  timestamp: 1732769764315
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.6-h2d7cec8_0.conda
   sha256: 171f1096285af8ba584940420762f083a3476728ced00f0d84fc5984856b52e3
   md5: a08b5df4fe1f5b8247ed98e0f25391e0
   depends:
@@ -6266,82 +5951,7 @@ packages:
   license_family: Apache
   size: 261909
   timestamp: 1732769680432
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.29.6
-  build: h8bcca62_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.6-h8bcca62_0.conda
-  sha256: b6d2ff238a712137afd9b46842235b32a04cac580734873bf86876da6e71dd03
-  md5: 8e49f5e86a3e39699b24035fa6d1ad40
-  depends:
-  - __osx >=11.0
-  - aws-c-auth >=0.8.0,<0.8.1.0a0
-  - aws-c-cal >=0.8.0,<0.8.1.0a0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
-  - aws-c-http >=0.9.1,<0.9.2.0a0
-  - aws-c-io >=0.15.2,<0.15.3.0a0
-  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
-  - aws-c-s3 >=0.7.2,<0.7.3.0a0
-  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
-  - libcxx >=18
-  license: Apache-2.0
-  license_family: Apache
-  size: 236490
-  timestamp: 1732769764315
-- kind: conda
-  name: aws-sdk-cpp
-  version: 1.11.449
-  build: h0ed5b37_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h0ed5b37_4.conda
-  sha256: 0057120a9a651d5a50f9fbd4a6404a5aec22885f298ec4da61a1bc1468891f0e
-  md5: da1b9b48262754a5ecf1cf494bb6c4d9
-  depends:
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
-  - aws-checksums >=0.2.2,<0.2.3.0a0
-  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 2845768
-  timestamp: 1732813377812
-- kind: conda
-  name: aws-sdk-cpp
-  version: 1.11.449
-  build: h3b64406_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h3b64406_4.conda
-  sha256: 10ce9c203d31229432421a841d8d135d3e942637571aae4bb2d3c7d5242e7f05
-  md5: f9e46a4bb5a04cbca08355f166ce87c8
-  depends:
-  - __osx >=11.0
-  - aws-c-common >=0.10.3,<0.10.4.0a0
-  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
-  - aws-checksums >=0.2.2,<0.2.3.0a0
-  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libcxx >=18
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.4.0,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2722689
-  timestamp: 1732812825640
-- kind: conda
-  name: aws-sdk-cpp
-  version: 1.11.449
-  build: h5558e3c_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h5558e3c_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h5558e3c_4.conda
   sha256: 4881f7b4f5e3c797332cffb990df246a422346b220a9c16014f274beb2a276f5
   md5: ba7abdc93b0ade11d774b47aaab84737
   depends:
@@ -6359,12 +5969,40 @@ packages:
   license_family: Apache
   size: 2945541
   timestamp: 1732812288219
-- kind: conda
-  name: azure-core-cpp
-  version: 1.14.0
-  build: h5cfcd09_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h3b64406_4.conda
+  sha256: 10ce9c203d31229432421a841d8d135d3e942637571aae4bb2d3c7d5242e7f05
+  md5: f9e46a4bb5a04cbca08355f166ce87c8
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2722689
+  timestamp: 1732812825640
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h0ed5b37_4.conda
+  sha256: 0057120a9a651d5a50f9fbd4a6404a5aec22885f298ec4da61a1bc1468891f0e
+  md5: da1b9b48262754a5ecf1cf494bb6c4d9
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 2845768
+  timestamp: 1732813377812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
   sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
   md5: 0a8838771cc2e985cd295e01ae83baf1
   depends:
@@ -6377,12 +6015,7 @@ packages:
   license_family: MIT
   size: 345117
   timestamp: 1728053909574
-- kind: conda
-  name: azure-core-cpp
-  version: 1.14.0
-  build: hd50102c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
   sha256: f5b91329ed59ffc0be8747784c6e4cc7e56250c54032883a83bc11808ef6a87e
   md5: f093a11dcf3cdcca010b20a818fcc6dc
   depends:
@@ -6394,12 +6027,7 @@ packages:
   license_family: MIT
   size: 294299
   timestamp: 1728054014060
-- kind: conda
-  name: azure-identity-cpp
-  version: 1.10.0
-  build: h113e628_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
   sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
   md5: 73f73f60854f325a55f1d31459f2ab73
   depends:
@@ -6412,12 +6040,7 @@ packages:
   license_family: MIT
   size: 232351
   timestamp: 1728486729511
-- kind: conda
-  name: azure-identity-cpp
-  version: 1.10.0
-  build: hc602bab_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
   sha256: bde446b916fff5150606f8ed3e6058ffc55a3aa72381e46f1ab346590b1ae40a
   md5: d7b71593a937459f2d4b67e1a4727dc2
   depends:
@@ -6429,13 +6052,7 @@ packages:
   license_family: MIT
   size: 166907
   timestamp: 1728486882502
-- kind: conda
-  name: azure-storage-blobs-cpp
-  version: 12.13.0
-  build: h3cf044e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
   sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
   md5: 7eb66060455c7a47d9dcdbfa9f46579b
   depends:
@@ -6448,13 +6065,7 @@ packages:
   license_family: MIT
   size: 549342
   timestamp: 1728578123088
-- kind: conda
-  name: azure-storage-blobs-cpp
-  version: 12.13.0
-  build: h7585a09_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
   sha256: 08d52d130addc0fb55d5ba10d9fa483e39be25d69bac7f4c676c2c3069207590
   md5: 704238ef05d46144dae2e6b5853df8bc
   depends:
@@ -6466,13 +6077,7 @@ packages:
   license_family: MIT
   size: 438636
   timestamp: 1728578216193
-- kind: conda
-  name: azure-storage-common-cpp
-  version: 12.8.0
-  build: h736e048_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
   sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
   md5: 13de36be8de3ae3f05ba127631599213
   depends:
@@ -6486,13 +6091,7 @@ packages:
   license_family: MIT
   size: 149312
   timestamp: 1728563338704
-- kind: conda
-  name: azure-storage-common-cpp
-  version: 12.8.0
-  build: h9ca1f76_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
   sha256: 77ab04e8fe5636a2de9c718f72a43645f7502cd208868c8a91ffba385547d585
   md5: 7a187cd7b1445afc80253bb186a607cc
   depends:
@@ -6505,13 +6104,7 @@ packages:
   license_family: MIT
   size: 121278
   timestamp: 1728563418777
-- kind: conda
-  name: azure-storage-files-datalake-cpp
-  version: 12.12.0
-  build: ha633028_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
   sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
   md5: 7c1980f89dd41b097549782121a73490
   depends:
@@ -6525,13 +6118,7 @@ packages:
   license_family: MIT
   size: 287366
   timestamp: 1728729530295
-- kind: conda
-  name: azure-storage-files-datalake-cpp
-  version: 12.12.0
-  build: hcdd55da_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
   sha256: f48523f8aa0b5b80f45a92f0556b388dd96f44ac2dc2f44a01d08c1822eec97d
   md5: c49fbc5233fcbaa86391162ff1adef38
   depends:
@@ -6544,13 +6131,7 @@ packages:
   license_family: MIT
   size: 196032
   timestamp: 1728729672889
-- kind: conda
-  name: babel
-  version: 2.16.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_0.conda
   sha256: fce1d78e42665bb26d3f2b45ce9cacf0d9dbe4c1b2db3879a384eadee53c6231
   md5: 6d4e9ecca8d88977147e109fc7053184
   depends:
@@ -6560,13 +6141,7 @@ packages:
   license_family: BSD
   size: 6525614
   timestamp: 1730878929589
-- kind: conda
-  name: beautifulsoup4
-  version: 4.12.3
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
   sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
   md5: 332493000404d8411859539a5a630865
   depends:
@@ -6576,13 +6151,7 @@ packages:
   license_family: MIT
   size: 118200
   timestamp: 1705564819537
-- kind: conda
-  name: binutils
-  version: '2.43'
-  build: h4852527_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_2.conda
   sha256: 92be0f8ccd501ceeb3c782e2182e6ea04dca46799038176de40a57bca45512c5
   md5: 348619f90eee04901f4a70615efff35b
   depends:
@@ -6591,13 +6160,7 @@ packages:
   license_family: GPL
   size: 33876
   timestamp: 1729655402186
-- kind: conda
-  name: binutils_impl_linux-64
-  version: '2.43'
-  build: h4bf12b8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_2.conda
   sha256: 267e78990247369b13234bda270f31beb56a600b4851a8244e31dd9ad85b3b17
   md5: cf0c5521ac2a20dfa6c662a4009eeef6
   depends:
@@ -6607,13 +6170,7 @@ packages:
   license_family: GPL
   size: 5682777
   timestamp: 1729655371045
-- kind: conda
-  name: binutils_linux-64
-  version: '2.43'
-  build: h4852527_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_2.conda
   sha256: df52bd8b8b2a20a0c529d9ad08aaf66093ac318aa8a33d270f18274341a77062
   md5: 18aba879ddf1f8f28145ca6fcb873d8c
   depends:
@@ -6622,13 +6179,8 @@ packages:
   license_family: GPL
   size: 34945
   timestamp: 1729655404893
-- kind: conda
-  name: blas
-  version: '2.125'
-  build: mkl
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blas-2.125-mkl.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.125-mkl.conda
   sha256: 23695a43c8ca9d0674f69b03c1d35820eea75bc3d05cd60acb0152da2664c1a9
   md5: 8a0ffaaae2bccf691cffdde83cb0f1a5
   depends:
@@ -6648,13 +6200,8 @@ packages:
   license_family: BSD
   size: 15741
   timestamp: 1729643046419
-- kind: conda
-  name: blas
-  version: '2.125'
-  build: mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/blas-2.125-mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/blas-2.125-mkl.conda
   sha256: f9cf3f5d6146d1977e12379679132dd5f038af7a4c88248434cdff2c214fc2f2
   md5: 186eeb4e8ba0a5944775e04f241fc02a
   depends:
@@ -6672,13 +6219,8 @@ packages:
   license_family: BSD
   size: 18541
   timestamp: 1729643687453
-- kind: conda
-  name: blas-devel
-  version: 3.9.0
-  build: 25_linux64_mkl
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-25_linux64_mkl.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-25_linux64_mkl.conda
   sha256: 41cf2c23fc526cb4195ef986fa983096207b8d24a7c817a4a5214016c76ddf2b
   md5: cb60caae3cb30988431d7107691bd587
   depends:
@@ -6692,13 +6234,8 @@ packages:
   license_family: BSD
   size: 15418
   timestamp: 1729642936896
-- kind: conda
-  name: blas-devel
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/blas-devel-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/blas-devel-3.9.0-25_win64_mkl.conda
   sha256: 23e69f638d7a0d9dafa3f044b66314cac500b8362863da639cc311184b12b8b7
   md5: b3c40599e865dac087085b596fbbf4ad
   depends:
@@ -6712,13 +6249,7 @@ packages:
   license_family: BSD
   size: 17628
   timestamp: 1729643634509
-- kind: conda
-  name: bleach
-  version: 6.2.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
   sha256: 01be7fb5163e7c31356a18c259ddc19a5431b8b974dc65e2427b88c2d30034f3
   md5: 461bcfab8e65c166e297222ae919a2d4
   depends:
@@ -6728,13 +6259,7 @@ packages:
   license_family: Apache
   size: 132652
   timestamp: 1730286301829
-- kind: conda
-  name: blis
-  version: 0.9.0
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/blis-0.9.0-h2466b09_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/blis-0.9.0-h2466b09_2.conda
   sha256: 329988d3b81b9faa35edb97d49e7b68ca34c67443d8d72cc13c4d75ea276137e
   md5: 26d6a32bfcfa79dc82e913ed747f25c7
   depends:
@@ -6745,12 +6270,21 @@ packages:
   license_family: BSD
   size: 3250841
   timestamp: 1713880162189
-- kind: conda
-  name: blosc
-  version: 1.21.6
-  build: h5499902_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+  md5: 54fe76ab3d0189acaef95156874db7f9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48842
+  timestamp: 1719266029046
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
   sha256: 5a1e635a371449a750b776cab64ad83f5218b58b3f137ebd33ad3ec17f1ce92e
   md5: e94ca7aec8544f700d45b24aff2dd4d7
   depends:
@@ -6764,12 +6298,7 @@ packages:
   license_family: BSD
   size: 33201
   timestamp: 1719266149627
-- kind: conda
-  name: blosc
-  version: 1.21.6
-  build: h85f69ea_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
   sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
   md5: 2390269374fded230fcbca8332a4adc0
   depends:
@@ -6784,32 +6313,7 @@ packages:
   license_family: BSD
   size: 50135
   timestamp: 1719266616208
-- kind: conda
-  name: blosc
-  version: 1.21.6
-  build: hef167b5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
-  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
-  md5: 54fe76ab3d0189acaef95156874db7f9
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.0,<1.3.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 48842
-  timestamp: 1719266029046
-- kind: conda
-  name: bokeh
-  version: 3.6.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.1-pyhd8ed1ab_0.conda
   sha256: f917c7c60ac9c8066fb389432876fe381d2068758a87d0a06e79428c46091ee4
   md5: e88d74bb7b9b89d4c9764286ceb94cc9
   depends:
@@ -6827,13 +6331,7 @@ packages:
   license_family: BSD
   size: 4520636
   timestamp: 1730964473035
-- kind: conda
-  name: branca
-  version: 0.7.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
   sha256: 9f7df349cb5a8852804d5bb1f5f49e3076a55ac7229b9c114bb5f7461f497ba7
   md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
   depends:
@@ -6843,13 +6341,32 @@ packages:
   license_family: MIT
   size: 28923
   timestamp: 1714071906758
-- kind: conda
-  name: brotli
-  version: 1.1.0
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
+  md5: 98514fe74548d768907ce7a13f680e8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_2
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19264
+  timestamp: 1725267697072
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
+  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 hd74edd7_2
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 19588
+  timestamp: 1725268044856
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
   sha256: d8fd7d1b446706776117d2dcad1c0289b9f5e1521cb13405173bad38568dd252
   md5: 378f1c9421775dfe644731cb121c8979
   depends:
@@ -6863,50 +6380,30 @@ packages:
   license_family: MIT
   size: 19697
   timestamp: 1725268293988
-- kind: conda
-  name: brotli
-  version: 1.1.0
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
-  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
-  md5: 98514fe74548d768907ce7a13f680e8f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
+  md5: c63b5e52939e795ba8d26e35d767a843
   depends:
   - __glibc >=2.17,<3.0.a0
-  - brotli-bin 1.1.0 hb9d3cd8_2
   - libbrotlidec 1.1.0 hb9d3cd8_2
   - libbrotlienc 1.1.0 hb9d3cd8_2
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 19264
-  timestamp: 1725267697072
-- kind: conda
-  name: brotli
-  version: 1.1.0
-  build: hd74edd7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
-  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
-  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  size: 18881
+  timestamp: 1725267688731
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
+  md5: b8512db2145dc3ae8d86cdc21a8d421e
   depends:
   - __osx >=11.0
-  - brotli-bin 1.1.0 hd74edd7_2
   - libbrotlidec 1.1.0 hd74edd7_2
   - libbrotlienc 1.1.0 hd74edd7_2
   license: MIT
   license_family: MIT
-  size: 19588
-  timestamp: 1725268044856
-- kind: conda
-  name: brotli-bin
-  version: 1.1.0
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+  size: 16772
+  timestamp: 1725268026061
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
   sha256: f3bf2893613540ac256c68f211861c4de618d96291719e32178d894114ac2bc2
   md5: d22534a9be5771fc58eb7564947f669d
   depends:
@@ -6919,69 +6416,7 @@ packages:
   license_family: MIT
   size: 20837
   timestamp: 1725268270219
-- kind: conda
-  name: brotli-bin
-  version: 1.1.0
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
-  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
-  md5: c63b5e52939e795ba8d26e35d767a843
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libbrotlidec 1.1.0 hb9d3cd8_2
-  - libbrotlienc 1.1.0 hb9d3cd8_2
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 18881
-  timestamp: 1725267688731
-- kind: conda
-  name: brotli-bin
-  version: 1.1.0
-  build: hd74edd7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
-  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
-  md5: b8512db2145dc3ae8d86cdc21a8d421e
-  depends:
-  - __osx >=11.0
-  - libbrotlidec 1.1.0 hd74edd7_2
-  - libbrotlienc 1.1.0 hd74edd7_2
-  license: MIT
-  license_family: MIT
-  size: 16772
-  timestamp: 1725268026061
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py312h275cf98_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py312h275cf98_2.conda
-  sha256: f83baa6f6bcba7b73f6921d5c1aa95ffc5d8b246ade933ade79250de0a4c9c4c
-  md5: a99aec1ac46794a5fb1cd3cf5d2b6110
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libbrotlicommon 1.1.0 h2466b09_2
-  license: MIT
-  license_family: MIT
-  size: 321874
-  timestamp: 1725268491976
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py312h2ec8cdc_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
   sha256: f2a59ccd20b4816dea9a2a5cb917eb69728271dbf1aeab4e1b7e609330a50b6f
   md5: b0b867af6fc74b2a0aa206da29c0f3cf
   depends:
@@ -6996,13 +6431,7 @@ packages:
   license_family: MIT
   size: 349867
   timestamp: 1725267732089
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py312hde4cb15_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hde4cb15_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hde4cb15_2.conda
   sha256: 254b411fa78ccc226f42daf606772972466f93e9bc6895eabb4cfda22f5178af
   md5: a83c2ef76ccb11bc2349f4f17696b15d
   depends:
@@ -7017,13 +6446,7 @@ packages:
   license_family: MIT
   size: 339360
   timestamp: 1725268143995
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py313h3579c5c_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py313h3579c5c_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py313h3579c5c_2.conda
   sha256: b0a66572f44570ee7cc960e223ca8600d26bb20cfb76f16b95adf13ec4ee3362
   md5: f3bee63c7b5d041d841aff05785c28b7
   depends:
@@ -7038,13 +6461,22 @@ packages:
   license_family: MIT
   size: 339067
   timestamp: 1725268603536
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py313h5813708_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py313h5813708_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py312h275cf98_2.conda
+  sha256: f83baa6f6bcba7b73f6921d5c1aa95ffc5d8b246ade933ade79250de0a4c9c4c
+  md5: a99aec1ac46794a5fb1cd3cf5d2b6110
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 321874
+  timestamp: 1725268491976
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py313h5813708_2.conda
   sha256: e89803147849d429f1ba3eec880b487c2cc4cac48a221079001a2ab1216f3709
   md5: c1a5d95bf18940d2b1d12f7bf2fb589b
   depends:
@@ -7059,13 +6491,26 @@ packages:
   license_family: MIT
   size: 322309
   timestamp: 1725268431915
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h2466b09_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
   sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
   md5: 276e7ffe9ffe39688abc665ef0f45596
   depends:
@@ -7076,44 +6521,26 @@ packages:
   license_family: BSD
   size: 54927
   timestamp: 1720974860185
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h4bc722e_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
-  md5: 62ee74e96c5ebb0af99386de58cf9553
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+  sha256: 732571ba6286dbccbf4c6450078a581b7a5620204faf876ff0ef282d77a6bfa8
+  md5: ee228789a85f961d14567252a03e725f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 252783
-  timestamp: 1720974456583
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h99b78c6_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
-  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 204857
+  timestamp: 1732447031823
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+  sha256: 6dfa83cbd9acc8671d439fe9c745a5716faf6cbadf2f1e18c841bcf86cbba5f2
+  md5: fb72102e8a8f9bcd38e40af09ff41c42
   depends:
   - __osx >=11.0
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 122909
-  timestamp: 1720974522888
-- kind: conda
-  name: c-ares
-  version: 1.34.3
-  build: h2466b09_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_1.conda
+  license: MIT
+  license_family: MIT
+  size: 179318
+  timestamp: 1732447193278
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_1.conda
   sha256: 535b9dd013b8726b5147ca202f509308960ef0d050bce4872e16c0d76962147c
   md5: f8413bb7fb62f7bdc2545c9a06937790
   depends:
@@ -7124,44 +6551,7 @@ packages:
   license_family: MIT
   size: 192376
   timestamp: 1732447407728
-- kind: conda
-  name: c-ares
-  version: 1.34.3
-  build: h5505292_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
-  sha256: 6dfa83cbd9acc8671d439fe9c745a5716faf6cbadf2f1e18c841bcf86cbba5f2
-  md5: fb72102e8a8f9bcd38e40af09ff41c42
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 179318
-  timestamp: 1732447193278
-- kind: conda
-  name: c-ares
-  version: 1.34.3
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
-  sha256: 732571ba6286dbccbf4c6450078a581b7a5620204faf876ff0ef282d77a6bfa8
-  md5: ee228789a85f961d14567252a03e725f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 204857
-  timestamp: 1732447031823
-- kind: conda
-  name: c-compiler
-  version: 1.8.0
-  build: h2b85faf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_1.conda
   sha256: 009fced27be14e5ac750a04111a07eda79d73f80009300c1538cb83d5da71879
   md5: fa7b3bf2965b9d74a81a0702d9bb49ee
   depends:
@@ -7172,28 +6562,7 @@ packages:
   license_family: BSD
   size: 6085
   timestamp: 1728985300402
-- kind: conda
-  name: c-compiler
-  version: 1.8.0
-  build: hcfcfb64_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.8.0-hcfcfb64_1.conda
-  sha256: 3fc7b2ceb03cc024e5f91f70fb576da71ff9cec787f3c481f3372d311ecc04f3
-  md5: 33c106164044a19c4e8d13277ae97c3f
-  depends:
-  - vs2019_win-64
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6513
-  timestamp: 1728985389589
-- kind: conda
-  name: c-compiler
-  version: 1.8.0
-  build: hf48404e_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.8.0-hf48404e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.8.0-hf48404e_1.conda
   sha256: 64245f90755c314f61d48b38fc7b82270b709f88204789895f7c4b2b84204992
   md5: 429476dcb80c4f9087cd8ac1fa2183d1
   depends:
@@ -7205,47 +6574,35 @@ packages:
   license_family: BSD
   size: 6220
   timestamp: 1728985386241
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: h56e8100_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
-  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
-  md5: 4c4fd67c18619be5aa65dc5b6c72e490
-  license: ISC
-  size: 158773
-  timestamp: 1725019107649
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hbcca054_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.8.0-hcfcfb64_1.conda
+  sha256: 3fc7b2ceb03cc024e5f91f70fb576da71ff9cec787f3c481f3372d311ecc04f3
+  md5: 33c106164044a19c4e8d13277ae97c3f
+  depends:
+  - vs2019_win-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6513
+  timestamp: 1728985389589
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
   sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
   md5: c27d1c142233b5bc9ca570c6e2e0c244
   license: ISC
   size: 159003
   timestamp: 1725018903918
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hf0a4a13_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
   sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
   md5: 40dec13fd8348dbe303e57be74bd3d35
   license: ISC
   size: 158482
   timestamp: 1725019034582
-- kind: conda
-  name: cached-property
-  version: 1.5.2
-  build: hd8ed1ab_1
-  build_number: 1
-  subdir: noarch
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
   sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
   md5: 9b347a7ec10940d3f7941ff6c460b551
   depends:
@@ -7254,14 +6611,7 @@ packages:
   license_family: BSD
   size: 4134
   timestamp: 1615209571450
-- kind: conda
-  name: cached_property
-  version: 1.5.2
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
   sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
   md5: 576d629e47797577ab0f1b351297ef4a
   depends:
@@ -7270,13 +6620,7 @@ packages:
   license_family: BSD
   size: 11065
   timestamp: 1615209567874
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: hebfffa5_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
   sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
   md5: fceaedf1cdbcb02df9699a0d9b005292
   depends:
@@ -7301,13 +6645,7 @@ packages:
   license: LGPL-2.1-only or MPL-1.1
   size: 983604
   timestamp: 1721138900054
-- kind: conda
-  name: cctools
-  version: '1010.6'
-  build: hf67d63f_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-hf67d63f_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-hf67d63f_2.conda
   sha256: 5cd748e93968df7a3575f5cd051fb387ca0b1753537374e8c9270d44315186d2
   md5: 409225e7241a0099a81ce5fc0f3576d8
   depends:
@@ -7318,13 +6656,7 @@ packages:
   license_family: Other
   size: 21118
   timestamp: 1732552617055
-- kind: conda
-  name: cctools_osx-arm64
-  version: '1010.6'
-  build: h623e0ac_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h623e0ac_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h623e0ac_2.conda
   sha256: 1293ba9599964813cd5b7de3ef5b2a34f8c728f04f030add1d2daaa770563651
   md5: c667893c4bda0bd15dea9ae36e943c94
   depends:
@@ -7343,13 +6675,7 @@ packages:
   license_family: Other
   size: 1101877
   timestamp: 1732552573870
-- kind: conda
-  name: certifi
-  version: 2024.8.30
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
   sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
   md5: 12f7d00853807b0531775e9be891cb11
   depends:
@@ -7357,12 +6683,7 @@ packages:
   license: ISC
   size: 163752
   timestamp: 1725278204397
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py312h06ac9bb_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
   sha256: cba6ea83c4b0b4f5b5dc59cb19830519b28f95d7ebef7c9c5cf1c14843621457
   md5: a861504bbea4161a9170b85d4d2be840
   depends:
@@ -7376,12 +6697,7 @@ packages:
   license_family: MIT
   size: 294403
   timestamp: 1725560714366
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py312h0fad829_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py312h0fad829_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py312h0fad829_0.conda
   sha256: 8d91a0d01358b5c3f20297c6c536c5d24ccd3e0c2ddd37f9d0593d0f0070226f
   md5: 19a5456f72f505881ba493979777b24e
   depends:
@@ -7395,50 +6711,7 @@ packages:
   license_family: MIT
   size: 281206
   timestamp: 1725560813378
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py312h4389bb4_0.conda
-  sha256: ac007bf5fd56d13e16d95eea036433012f2e079dc015505c8a79efebbad1fcbc
-  md5: 08310c1a22ef957d537e547f8d484f92
-  depends:
-  - pycparser
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 288142
-  timestamp: 1725560896359
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py313ha7868ed_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py313ha7868ed_0.conda
-  sha256: b19f581fe423858f1f477c52e10978be324c55ebf2e418308d30d013f4a476ff
-  md5: 519a29d7ac273f8c165efc0af099da42
-  depends:
-  - pycparser
-  - python >=3.13.0rc1,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 291828
-  timestamp: 1725561211547
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py313hc845a76_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py313hc845a76_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py313hc845a76_0.conda
   sha256: 50650dfa70ccf12b9c4a117d7ef0b41895815bb7328d830d667a6ba3525b60e8
   md5: 6d24d5587a8615db33c961a4ca0a8034
   depends:
@@ -7452,13 +6725,35 @@ packages:
   license_family: MIT
   size: 282115
   timestamp: 1725560759157
-- kind: conda
-  name: cfgv
-  version: 3.3.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py312h4389bb4_0.conda
+  sha256: ac007bf5fd56d13e16d95eea036433012f2e079dc015505c8a79efebbad1fcbc
+  md5: 08310c1a22ef957d537e547f8d484f92
+  depends:
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 288142
+  timestamp: 1725560896359
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py313ha7868ed_0.conda
+  sha256: b19f581fe423858f1f477c52e10978be324c55ebf2e418308d30d013f4a476ff
+  md5: 519a29d7ac273f8c165efc0af099da42
+  depends:
+  - pycparser
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 291828
+  timestamp: 1725561211547
+- conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
   sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
   md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
   depends:
@@ -7467,13 +6762,7 @@ packages:
   license_family: MIT
   size: 10788
   timestamp: 1629909423398
-- kind: conda
-  name: charset-normalizer
-  version: 3.4.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
   sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
   md5: a374efa97290b8799046df7c5ca17164
   depends:
@@ -7482,13 +6771,7 @@ packages:
   license_family: MIT
   size: 47314
   timestamp: 1728479405343
-- kind: conda
-  name: clang
-  version: 17.0.6
-  build: default_h360f5da_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17.0.6-default_h360f5da_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17.0.6-default_h360f5da_7.conda
   sha256: 3caeb933e74561c834074ef1617aa721c10e6b08c1fed9d5180c82a9ba18b5f2
   md5: c98bdbd4985530fac68ea4831d053ba1
   depends:
@@ -7497,13 +6780,7 @@ packages:
   license_family: Apache
   size: 24105
   timestamp: 1725505775351
-- kind: conda
-  name: clang-17
-  version: 17.0.6
-  build: default_h146c034_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17-17.0.6-default_h146c034_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17-17.0.6-default_h146c034_7.conda
   sha256: f9e40e5402ab78543553e7bc0437dfeed42d43f486395b66dd55ea0fd819b789
   md5: 585064b6856cb3e719343e3362ea828b
   depends:
@@ -7520,13 +6797,7 @@ packages:
   license_family: Apache
   size: 715930
   timestamp: 1725505694198
-- kind: conda
-  name: clang_impl_osx-arm64
-  version: 17.0.6
-  build: he47c785_23
-  build_number: 23
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-17.0.6-he47c785_23.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-17.0.6-he47c785_23.conda
   sha256: 7a5999645f66f12f8ff9f07ead73d3552f79fff09675487ec1f4f087569587e1
   md5: 519e4d9eb59dd0a1484e509dcc789217
   depends:
@@ -7539,13 +6810,7 @@ packages:
   license_family: BSD
   size: 17965
   timestamp: 1731984992637
-- kind: conda
-  name: clang_osx-arm64
-  version: 17.0.6
-  build: h07b0088_23
-  build_number: 23
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-17.0.6-h07b0088_23.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-17.0.6-h07b0088_23.conda
   sha256: ccafb62b45d71f646f0ca925fc7342d093fe5ea17ceeb15b84f1c277fc716295
   md5: cf5bbfc8b558c41d2a4ba17f5cabb48c
   depends:
@@ -7554,13 +6819,7 @@ packages:
   license_family: BSD
   size: 21177
   timestamp: 1731984996665
-- kind: conda
-  name: clangxx
-  version: 17.0.6
-  build: default_h360f5da_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-17.0.6-default_h360f5da_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-17.0.6-default_h360f5da_7.conda
   sha256: 73a87fe4a31494cdc5d74aacf9d08f560e4468795547f06290ee6a7bb128f61c
   md5: 0bb5cea65ab3457812707537603a3619
   depends:
@@ -7570,13 +6829,7 @@ packages:
   license_family: Apache
   size: 24168
   timestamp: 1725505786435
-- kind: conda
-  name: clangxx_impl_osx-arm64
-  version: 17.0.6
-  build: h50f59cd_23
-  build_number: 23
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-17.0.6-h50f59cd_23.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-17.0.6-h50f59cd_23.conda
   sha256: 7b975e2a1e141769ba4bc45792d145c68a72923465355d3f83ad60450529e01f
   md5: d086b99e198e21b3b29d2847cade1fce
   depends:
@@ -7588,13 +6841,7 @@ packages:
   license_family: BSD
   size: 18005
   timestamp: 1731985015782
-- kind: conda
-  name: clangxx_osx-arm64
-  version: 17.0.6
-  build: h07b0088_23
-  build_number: 23
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-17.0.6-h07b0088_23.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-17.0.6-h07b0088_23.conda
   sha256: 58c65adb2e03209ec1dcd926c3256a3a188d6cfa23a89b7fcaa6c9ff56a0f364
   md5: 743758f55670a6a9a0c93010cd497801
   depends:
@@ -7604,13 +6851,7 @@ packages:
   license_family: BSD
   size: 19581
   timestamp: 1731985020343
-- kind: conda
-  name: click
-  version: 8.1.7
-  build: unix_pyh707e725_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
   sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
   md5: f3ad426304898027fc619827ff428eca
   depends:
@@ -7620,13 +6861,7 @@ packages:
   license_family: BSD
   size: 84437
   timestamp: 1692311973840
-- kind: conda
-  name: click
-  version: 8.1.7
-  build: win_pyh7428d3b_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
   sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
   md5: 3549ecbceb6cd77b91a105511b7d0786
   depends:
@@ -7637,14 +6872,7 @@ packages:
   license_family: BSD
   size: 85051
   timestamp: 1692312207348
-- kind: conda
-  name: cloudpickle
-  version: 3.1.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
   sha256: 5a33d0d3ef33121c546eaf78b3dac2141fc4d30bbaeb3959bbc66fcd5e99ced6
   md5: c88ca2bb7099167912e3b26463fff079
   depends:
@@ -7653,13 +6881,7 @@ packages:
   license_family: BSD
   size: 25952
   timestamp: 1729059365471
-- kind: conda
-  name: colorama
-  version: 0.4.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   md5: 3faab06a954c2a04039983f2c4a50d99
   depends:
@@ -7668,13 +6890,7 @@ packages:
   license_family: BSD
   size: 25170
   timestamp: 1666700778190
-- kind: conda
-  name: comm
-  version: 0.2.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
   sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
   md5: 948d84721b578d426294e17a02e24cbb
   depends:
@@ -7684,13 +6900,7 @@ packages:
   license_family: BSD
   size: 12134
   timestamp: 1710320435158
-- kind: conda
-  name: compiler-rt
-  version: 17.0.6
-  build: h856b3c1_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-17.0.6-h856b3c1_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-17.0.6-h856b3c1_2.conda
   sha256: 91f4a6b80b7802432146a399944c20410e058dfb57ca6d738c0affb79cbdebbb
   md5: 2d00ff8e98c163de45a7c85774094012
   depends:
@@ -7702,14 +6912,7 @@ packages:
   license_family: APACHE
   size: 94878
   timestamp: 1725251190741
-- kind: conda
-  name: compiler-rt_osx-arm64
-  version: 17.0.6
-  build: h832e737_2
-  build_number: 2
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-17.0.6-h832e737_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-17.0.6-h832e737_2.conda
   sha256: 74d63f7f91a9482262d80490fafd39275121f4cb273f293e7d9fe91934837666
   md5: 58fd1fa30d8b0795f33a7e79893b11cc
   depends:
@@ -7721,12 +6924,7 @@ packages:
   license_family: APACHE
   size: 10369238
   timestamp: 1725251155195
-- kind: conda
-  name: contourpy
-  version: 1.3.1
-  build: py312h68727a3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py312h68727a3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py312h68727a3_0.conda
   sha256: e977af50b844b5b8cfec358131a4e923f0aa718e8334321cf8d84f5093576259
   md5: f5fbba0394ee45e9a64a73c2a994126a
   depends:
@@ -7740,12 +6938,7 @@ packages:
   license_family: BSD
   size: 276332
   timestamp: 1731428454756
-- kind: conda
-  name: contourpy
-  version: 1.3.1
-  build: py312hb23fbb9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py312hb23fbb9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py312hb23fbb9_0.conda
   sha256: fa1f8505f45eac22f25c48cd46809da0d26bcb028c37517b3474bacddd029b0a
   md5: f4408290387836e05ac267cd7ec80c5c
   depends:
@@ -7759,12 +6952,7 @@ packages:
   license_family: BSD
   size: 245638
   timestamp: 1731428781337
-- kind: conda
-  name: contourpy
-  version: 1.3.1
-  build: py312hd5eb7cc_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py312hd5eb7cc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py312hd5eb7cc_0.conda
   sha256: b5643ea0dd0bf57e1847679f5985feb649289de872b85c3db900f4110ac83cdd
   md5: 83f7a2ec652abd37a178e35493dfd029
   depends:
@@ -7778,13 +6966,8 @@ packages:
   license_family: BSD
   size: 216484
   timestamp: 1731428831843
-- kind: conda
-  name: cpython
-  version: 3.12.7
-  build: py312hd8ed1ab_0
-  subdir: noarch
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.7-py312hd8ed1ab_0.conda
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.7-py312hd8ed1ab_0.conda
   sha256: 9bbd08c83cc9c3142755b96dc5f3e0f0370d7afdb773c8285359b31e7ce96f0a
   md5: f0d1309310498284ab13c9fd73db4781
   depends:
@@ -7793,14 +6976,8 @@ packages:
   license: Python-2.0
   size: 44632
   timestamp: 1728057282977
-- kind: conda
-  name: cpython
-  version: 3.13.0
-  build: py313hd8ed1ab_101
-  build_number: 101
-  subdir: noarch
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.0-py313hd8ed1ab_101.conda
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.0-py313hd8ed1ab_101.conda
   sha256: 0b696b05a466ec034b549136a104b2a298d3820135c454f69f7ca8b9093a5255
   md5: cf35258c45ef74c804a6768e178f5c62
   depends:
@@ -7809,29 +6986,7 @@ packages:
   license: Python-2.0
   size: 46121
   timestamp: 1732734523087
-- kind: conda
-  name: cxx-compiler
-  version: 1.8.0
-  build: h18dbf2f_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.8.0-h18dbf2f_1.conda
-  sha256: bcadda695b13087920650adf43a599b66745dfb4bfc3b425169547d76082dcf2
-  md5: a1bc5417ab20b451ee141ca3290df479
-  depends:
-  - c-compiler 1.8.0 hf48404e_1
-  - clangxx_osx-arm64 17.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6261
-  timestamp: 1728985417226
-- kind: conda
-  name: cxx-compiler
-  version: 1.8.0
-  build: h1a2810e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.8.0-h1a2810e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.8.0-h1a2810e_1.conda
   sha256: cca0450bbc0d19044107d0f90fa36126a11b007fbfb62bd2a1949b2bb59a21a4
   md5: 3bb4907086d7187bf01c8bec397ffa5e
   depends:
@@ -7842,13 +6997,17 @@ packages:
   license_family: BSD
   size: 6059
   timestamp: 1728985302835
-- kind: conda
-  name: cxx-compiler
-  version: 1.8.0
-  build: h91493d7_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.8.0-h91493d7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.8.0-h18dbf2f_1.conda
+  sha256: bcadda695b13087920650adf43a599b66745dfb4bfc3b425169547d76082dcf2
+  md5: a1bc5417ab20b451ee141ca3290df479
+  depends:
+  - c-compiler 1.8.0 hf48404e_1
+  - clangxx_osx-arm64 17.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6261
+  timestamp: 1728985417226
+- conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.8.0-h91493d7_1.conda
   sha256: c6065df2e055a0392207f512bfa12d7a0e849f5e1a5435a3db9c60ae20bded9b
   md5: 54d722a127a10b59596b5640d58f7ae6
   depends:
@@ -7857,13 +7016,7 @@ packages:
   license_family: BSD
   size: 6549
   timestamp: 1728985390855
-- kind: conda
-  name: cycler
-  version: 0.12.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   md5: 5cd86562580f274031ede6aa6aa24441
   depends:
@@ -7872,32 +7025,7 @@ packages:
   license_family: BSD
   size: 13458
   timestamp: 1696677888423
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py310h1dbcdd0_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py310h1dbcdd0_3.conda
-  sha256: 8b37461698401664da37abd6cccdc4272cf4ebe88e5ac3e3e4d98a4b0dc7f2bb
-  md5: 6166a7f27aef4beb6e18f3170e8ced35
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2900787
-  timestamp: 1727456294469
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py310h5b1441d_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py310h5b1441d_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py310h5b1441d_3.conda
   sha256: ab2fc6b4b8c203da4cade3c25334342dc9f3ce846a2ae81591c3d09bf7b7ed4d
   md5: f1dd2d9a5c782683c28918f44ba547a8
   depends:
@@ -7910,32 +7038,7 @@ packages:
   license_family: APACHE
   size: 3228660
   timestamp: 1727457045753
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py310he320566_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py310he320566_3.conda
-  sha256: 20ca47c6f7cb8bd09697fe0c6613c9375c1742df3f208b1bd4b35304544ac776
-  md5: a015d7853883ea18f84a67267f9577ff
-  depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2704725
-  timestamp: 1727456915394
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py311h55d416d_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py311h55d416d_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py311h55d416d_3.conda
   sha256: 5e7dccec06123009097a79f6e80e28fc05e111b0fb1b538cd357282cf1123510
   md5: d21db006755203fe890596d3eae992ce
   depends:
@@ -7948,70 +7051,7 @@ packages:
   license_family: APACHE
   size: 3747300
   timestamp: 1727456147402
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py311hdd1c356_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py311hdd1c356_3.conda
-  sha256: c902e0fccdd1b18475064ac8a26531840a93fbaa3f35de242dc73ed6cface02f
-  md5: 5e4dda1863198b9f2f7e3b64e9521719
-  depends:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3232926
-  timestamp: 1727456468927
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py311hf7f79b8_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py311hf7f79b8_3.conda
-  sha256: 8f36a4d7657e266ed9a4c4ca0eebbf95ed236c66c3879544ea22ffb9211b20c3
-  md5: d1cd58d3e69c5d19e539565346b72d0c
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3436546
-  timestamp: 1727456365729
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py312h6018fb9_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py312h6018fb9_3.conda
-  sha256: b1e45f513d777ba081e975f94f661b482e18909db09d7bf87ea4491b477330fc
-  md5: e9f6ccd6150a36dc80085902b091fc32
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3203995
-  timestamp: 1727456880981
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py312h8fd2918_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py312h8fd2918_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py312h8fd2918_3.conda
   sha256: 7a888ddda463a3146949540229c70625fbefb05bcb1352cbff990f205b8392b0
   md5: 21e433caf1bb1e4c95832f8bb731d64c
   depends:
@@ -8024,108 +7064,7 @@ packages:
   license_family: APACHE
   size: 3752086
   timestamp: 1727456382070
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py312hde4cb15_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py312hde4cb15_2.conda
-  sha256: bd50c1d3f13403bbc96c0cd18ae95d492eda85df8ab9febe1719bf01018c6e32
-  md5: bc620580cd4cafd885769a3975c00287
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3395577
-  timestamp: 1725379375750
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py313h7176d0d_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py313h7176d0d_3.conda
-  sha256: bb3e9237bd214cb24b90a4da9989f80feb8273ca9e274daf81dfe51c0434e1f4
-  md5: 7c32361cfc75d532f87561a083c72ab0
-  depends:
-  - python >=3.13.0rc2,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3199318
-  timestamp: 1727456468948
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py313h80254e6_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py313h80254e6_3.conda
-  sha256: dae04c67f18f167ba3b33ddd8e50a62503c4f513ba00ed4334a1954c635a04a5
-  md5: e65f6841c4e3f817d89a051e8f17a9d8
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - python >=3.13.0rc2,<3.14.0a0
-  - python >=3.13.0rc2,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3405225
-  timestamp: 1727456264421
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py39h20637d4_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py39h20637d4_3.conda
-  sha256: 6349d3c0173f63626829db715df325298ba3e5fddae33da603e1b3ad027a0d90
-  md5: 9b269d6d65011f6c6ae61cc5234241e3
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2911719
-  timestamp: 1727456371538
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py39h4279646_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py39h4279646_3.conda
-  sha256: a18c72c2e68602f92aa3eb94155de9460b69492a6c21f91a71d09c79e93166b7
-  md5: c89d5275e2d6545ba01d6e1ce064496e
-  depends:
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2701290
-  timestamp: 1727456803310
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py39hde8bd2b_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py39hde8bd2b_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py39hde8bd2b_3.conda
   sha256: 3397832c7863eb90a58f5c0a072e2d184cd7c415002a3375c30191b9c6eeebf2
   md5: 52637110266d72a26d01d3d81038664e
   depends:
@@ -8138,13 +7077,137 @@ packages:
   license_family: APACHE
   size: 3219968
   timestamp: 1727456598162
-- kind: conda
-  name: cython-lint
-  version: 0.16.6
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cython-lint-0.16.6-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py310h1dbcdd0_3.conda
+  sha256: 8b37461698401664da37abd6cccdc4272cf4ebe88e5ac3e3e4d98a4b0dc7f2bb
+  md5: 6166a7f27aef4beb6e18f3170e8ced35
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2900787
+  timestamp: 1727456294469
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py311hf7f79b8_3.conda
+  sha256: 8f36a4d7657e266ed9a4c4ca0eebbf95ed236c66c3879544ea22ffb9211b20c3
+  md5: d1cd58d3e69c5d19e539565346b72d0c
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3436546
+  timestamp: 1727456365729
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py312hde4cb15_2.conda
+  sha256: bd50c1d3f13403bbc96c0cd18ae95d492eda85df8ab9febe1719bf01018c6e32
+  md5: bc620580cd4cafd885769a3975c00287
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3395577
+  timestamp: 1725379375750
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py313h80254e6_3.conda
+  sha256: dae04c67f18f167ba3b33ddd8e50a62503c4f513ba00ed4334a1954c635a04a5
+  md5: e65f6841c4e3f817d89a051e8f17a9d8
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.13.0rc2,<3.14.0a0
+  - python >=3.13.0rc2,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3405225
+  timestamp: 1727456264421
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py39h20637d4_3.conda
+  sha256: 6349d3c0173f63626829db715df325298ba3e5fddae33da603e1b3ad027a0d90
+  md5: 9b269d6d65011f6c6ae61cc5234241e3
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2911719
+  timestamp: 1727456371538
+- conda: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py310he320566_3.conda
+  sha256: 20ca47c6f7cb8bd09697fe0c6613c9375c1742df3f208b1bd4b35304544ac776
+  md5: a015d7853883ea18f84a67267f9577ff
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2704725
+  timestamp: 1727456915394
+- conda: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py311hdd1c356_3.conda
+  sha256: c902e0fccdd1b18475064ac8a26531840a93fbaa3f35de242dc73ed6cface02f
+  md5: 5e4dda1863198b9f2f7e3b64e9521719
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3232926
+  timestamp: 1727456468927
+- conda: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py312h6018fb9_3.conda
+  sha256: b1e45f513d777ba081e975f94f661b482e18909db09d7bf87ea4491b477330fc
+  md5: e9f6ccd6150a36dc80085902b091fc32
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3203995
+  timestamp: 1727456880981
+- conda: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py313h7176d0d_3.conda
+  sha256: bb3e9237bd214cb24b90a4da9989f80feb8273ca9e274daf81dfe51c0434e1f4
+  md5: 7c32361cfc75d532f87561a083c72ab0
+  depends:
+  - python >=3.13.0rc2,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3199318
+  timestamp: 1727456468948
+- conda: https://conda.anaconda.org/conda-forge/win-64/cython-3.0.11-py39h4279646_3.conda
+  sha256: a18c72c2e68602f92aa3eb94155de9460b69492a6c21f91a71d09c79e93166b7
+  md5: c89d5275e2d6545ba01d6e1ce064496e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2701290
+  timestamp: 1727456803310
+- conda: https://conda.anaconda.org/conda-forge/noarch/cython-lint-0.16.6-pyhff2d567_0.conda
   sha256: b8be28885737768620425c3f256c74017d9811fc086f705f5280b2b7bd59536c
   md5: 2d640ab1e2fd57f59e2cd078bc67d99e
   depends:
@@ -8157,13 +7220,20 @@ packages:
   license_family: MIT
   size: 18042
   timestamp: 1731363284571
-- kind: conda
-  name: cytoolz
-  version: 1.0.0
-  build: py312h024a12e_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py312h024a12e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py312h66e93f0_1.conda
+  sha256: 73ad7e01d83734a1418be3a225c14d7840ad93f21cecb13d75a3ca5ea9a464c8
+  md5: a921e2fe122e7f38417b9b17c7a13343
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 395285
+  timestamp: 1728335183361
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py312h024a12e_1.conda
   sha256: 6ae87213edd6b3ae004251c6a6a47ef7898b22e3650b757197e0ae9debba61f2
   md5: ac4f7cc0fdb7599e866e53277eef8b1e
   depends:
@@ -8176,13 +7246,7 @@ packages:
   license_family: BSD
   size: 339006
   timestamp: 1728335229450
-- kind: conda
-  name: cytoolz
-  version: 1.0.0
-  build: py312h4389bb4_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py312h4389bb4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py312h4389bb4_1.conda
   sha256: 640df307a193ad3b34e97a8c274428247ad613289d612de7f8d775a6087a5aef
   md5: d957d8852eb4b4a4f8b6af1e8a0cc044
   depends:
@@ -8196,33 +7260,7 @@ packages:
   license_family: BSD
   size: 316445
   timestamp: 1728335602220
-- kind: conda
-  name: cytoolz
-  version: 1.0.0
-  build: py312h66e93f0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py312h66e93f0_1.conda
-  sha256: 73ad7e01d83734a1418be3a225c14d7840ad93f21cecb13d75a3ca5ea9a464c8
-  md5: a921e2fe122e7f38417b9b17c7a13343
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - toolz >=0.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 395285
-  timestamp: 1728335183361
-- kind: conda
-  name: dask
-  version: 2024.11.2
-  build: pyhff2d567_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
   sha256: 1f2c226bfb4e3ee24125185b0694ec73431ff95bc55d995abdb38b7a7e1838ca
   md5: 4ea56955c9922ac99c35d0784cffeb96
   depends:
@@ -8243,14 +7281,7 @@ packages:
   license_family: BSD
   size: 7549
   timestamp: 1731971053850
-- kind: conda
-  name: dask-core
-  version: 2024.11.2
-  build: pyhff2d567_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
   sha256: b5e120fbcab57343aedbb312c22df8faa1a8444fb16b4d66879efbd7fd560d53
   md5: ae2be36dab764e655a22f240837cef75
   depends:
@@ -8267,13 +7298,7 @@ packages:
   license_family: BSD
   size: 903030
   timestamp: 1731970891036
-- kind: conda
-  name: dask-expr
-  version: 1.1.19
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
   sha256: 5f2c9e8f49c016a249d07eb46bae5b4085f3750827d12aff8aa0db1be4665165
   md5: 09ea33eb6525cc703ce1d39c88378320
   depends:
@@ -8285,13 +7310,7 @@ packages:
   license_family: BSD
   size: 185913
   timestamp: 1731515130979
-- kind: conda
-  name: dask-glm
-  version: 0.3.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.3.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.3.2-pyhd8ed1ab_0.conda
   sha256: 1cbab7ad5d8d80759455670eafc0ff804bce8e4794a46e32ea326115c3eeb009
   md5: 42a1a2e934536afac341b100d41b928c
   depends:
@@ -8306,13 +7325,7 @@ packages:
   license_family: BSD
   size: 17941
   timestamp: 1701346417566
-- kind: conda
-  name: dask-ml
-  version: 2024.4.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2024.4.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2024.4.4-pyhd8ed1ab_0.conda
   sha256: af9b810e3f4c0af06fdeaa6c76332bb768ff078832d3bc62ead022dd935d20ad
   md5: 5fc5ed918fa9a9f63001c06bdf21d53e
   depends:
@@ -8331,24 +7344,23 @@ packages:
   license_family: BSD
   size: 113405
   timestamp: 1718637675033
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hb547adb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 760229
+  timestamp: 1685695754230
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
   sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
   md5: 5a74cdee497e6b65173e10d94582fae6
   license: BSD-2-Clause
   license_family: BSD
   size: 316394
   timestamp: 1685695959391
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
   sha256: 2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4
   md5: ed2c27bda330e3f0ab41577cf8b9b585
   depends:
@@ -8359,44 +7371,7 @@ packages:
   license_family: BSD
   size: 618643
   timestamp: 1685696352968
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
-  md5: 418c6ca5929a611cbd69204907a83995
-  depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 760229
-  timestamp: 1685695754230
-- kind: conda
-  name: debugpy
-  version: 1.8.9
-  build: py312h275cf98_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py312h275cf98_0.conda
-  sha256: 5a6b8e7d6cef17eb0e39c3a4261eeba293901445f4d5ddf8eae09ca775058acb
-  md5: 1300cbe0243cd21d23212fb654c4d434
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 3518631
-  timestamp: 1732237024268
-- kind: conda
-  name: debugpy
-  version: 1.8.9
-  build: py312h2ec8cdc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py312h2ec8cdc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py312h2ec8cdc_0.conda
   sha256: cf79cac70773567382910fcaf7b10bb0f5242d159f8dd93296d8451cd542af9a
   md5: c522fd70ca7a0c2fe1a861dd13987a57
   depends:
@@ -8409,12 +7384,7 @@ packages:
   license_family: MIT
   size: 2605093
   timestamp: 1732236790708
-- kind: conda
-  name: debugpy
-  version: 1.8.9
-  build: py312hd8f9ff3_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py312hd8f9ff3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py312hd8f9ff3_0.conda
   sha256: d588943ac0392300f31115d9852a2ff4213ec22856c382ef56f5650576523ec6
   md5: 51085e5bb7f21019186cc88fd9a03164
   depends:
@@ -8427,30 +7397,7 @@ packages:
   license_family: MIT
   size: 2512030
   timestamp: 1732236996277
-- kind: conda
-  name: debugpy
-  version: 1.8.9
-  build: py313h5813708_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py313h5813708_0.conda
-  sha256: 74227d356330e99abc1232646dc630ab16430af6bc9ac7e9d84a1c9a5b150dae
-  md5: 704d3bf8daa734a973f995ce0e8a3ad2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 3692639
-  timestamp: 1732237246646
-- kind: conda
-  name: debugpy
-  version: 1.8.9
-  build: py313h928ef07_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py313h928ef07_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py313h928ef07_0.conda
   sha256: 721ddcbb75533946ea3589ee3914bbe4257b0abce192e6cb2e6aeaae7412d3cf
   md5: 609660b6a74d79e6b4d3e0d4d8e7e921
   depends:
@@ -8463,13 +7410,33 @@ packages:
   license_family: MIT
   size: 2563094
   timestamp: 1732236906355
-- kind: conda
-  name: decorator
-  version: 5.1.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py312h275cf98_0.conda
+  sha256: 5a6b8e7d6cef17eb0e39c3a4261eeba293901445f4d5ddf8eae09ca775058acb
+  md5: 1300cbe0243cd21d23212fb654c4d434
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3518631
+  timestamp: 1732237024268
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py313h5813708_0.conda
+  sha256: 74227d356330e99abc1232646dc630ab16430af6bc9ac7e9d84a1c9a5b150dae
+  md5: 704d3bf8daa734a973f995ce0e8a3ad2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3692639
+  timestamp: 1732237246646
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
   sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
   md5: 43afe5ab04e35e17ba28649471dd7364
   depends:
@@ -8478,13 +7445,7 @@ packages:
   license_family: BSD
   size: 12072
   timestamp: 1641555714315
-- kind: conda
-  name: defusedxml
-  version: 0.7.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
   sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
   md5: 961b3a227b437d82ad7054484cfa71b2
   depends:
@@ -8493,13 +7454,7 @@ packages:
   license_family: PSF
   size: 24062
   timestamp: 1615232388757
-- kind: conda
-  name: distlib
-  version: 0.3.9
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_0.conda
   sha256: 300b2e714f59403df0560174f5ef6c19db8b4a3b74a7244862cf771f07dee8fb
   md5: fe521c1608280cc2803ebd26dc252212
   depends:
@@ -8508,14 +7463,7 @@ packages:
   license_family: APACHE
   size: 276214
   timestamp: 1728557312342
-- kind: conda
-  name: distributed
-  version: 2024.11.2
-  build: pyhff2d567_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
   sha256: 67b4ef42db9f0fcfa2fb6274bd4ee530769bb84649cbb07da2b7d0a85f4cdfe2
   md5: 171408408370e59126dc3e39352c6218
   depends:
@@ -8542,13 +7490,7 @@ packages:
   license_family: BSD
   size: 802347
   timestamp: 1731970957315
-- kind: conda
-  name: docutils
-  version: 0.21.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
   sha256: 362bfe3afaac18298c48c0c6a935641544077ce5105a42a2d8ebe750ad07c574
   md5: e8cd5d629f65bdf0f3bb312cde14659e
   depends:
@@ -8556,13 +7498,7 @@ packages:
   license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
   size: 403226
   timestamp: 1713930478970
-- kind: conda
-  name: entrypoints
-  version: '0.4'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
   sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
   md5: 3cf04868fee0a029769bd41f4b2fbf2d
   depends:
@@ -8571,13 +7507,7 @@ packages:
   license_family: MIT
   size: 9199
   timestamp: 1643888357950
-- kind: conda
-  name: exceptiongroup
-  version: 1.2.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
   sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
   md5: d02ae936e42063ca46af6cdad2dbd1e0
   depends:
@@ -8585,13 +7515,7 @@ packages:
   license: MIT and PSF-2.0
   size: 20418
   timestamp: 1720869435725
-- kind: conda
-  name: execnet
-  version: 2.1.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
   sha256: 564bc012d73ca29964e7acca18d60b2fa8d20eea6d258d98cfc24df5167beaf0
   md5: 15dda3cdbf330abfe9f555d22f66db46
   depends:
@@ -8600,13 +7524,7 @@ packages:
   license_family: MIT
   size: 38883
   timestamp: 1712591929944
-- kind: conda
-  name: executing
-  version: 2.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
   sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
   md5: d0441db20c827c11721889a241df1220
   depends:
@@ -8615,13 +7533,7 @@ packages:
   license_family: MIT
   size: 28337
   timestamp: 1725214501850
-- kind: conda
-  name: filelock
-  version: 3.16.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
   sha256: 1da766da9dba05091af87977922fe60dc7464091a9ccffb3765d403189d39be4
   md5: 916f8ec5dd4128cd5f207a3c4c07b2c6
   depends:
@@ -8629,13 +7541,7 @@ packages:
   license: Unlicense
   size: 17357
   timestamp: 1726613593584
-- kind: conda
-  name: folium
-  version: 0.18.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.18.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.18.0-pyhd8ed1ab_0.conda
   sha256: b0692047888db2875cbdb3280aec69e9d88c229adf830c4f88357796d35ce006
   md5: 26a1457f3e698dc0c9e656874cc6b623
   depends:
@@ -8649,66 +7555,35 @@ packages:
   license_family: MIT
   size: 79126
   timestamp: 1729664648900
-- kind: conda
-  name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  build: hab24e00_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
   license: BSD-3-Clause
   license_family: BSD
   size: 397370
   timestamp: 1566932522327
-- kind: conda
-  name: font-ttf-inconsolata
-  version: '3.000'
-  build: h77eed37_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
   md5: 34893075a5c9e55cdafac56607368fc6
   license: OFL-1.1
   license_family: Other
   size: 96530
   timestamp: 1620479909603
-- kind: conda
-  name: font-ttf-source-code-pro
-  version: '2.038'
-  build: h77eed37_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
   md5: 4d59c254e01d9cde7957100457e2d5fb
   license: OFL-1.1
   license_family: Other
   size: 700814
   timestamp: 1620479612257
-- kind: conda
-  name: font-ttf-ubuntu
-  version: '0.83'
-  build: h77eed37_3
-  build_number: 3
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
   md5: 49023d73832ef61042f6a237cb2687e7
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
   license_family: Other
   size: 1620504
   timestamp: 1727511233259
-- kind: conda
-  name: fontconfig
-  version: 2.15.0
-  build: h7e30c49_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
   sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
   md5: 8f5b0b297b59e1ac160ad4beec99dbee
   depends:
@@ -8722,13 +7597,7 @@ packages:
   license_family: MIT
   size: 265599
   timestamp: 1730283881107
-- kind: conda
-  name: fonts-conda-ecosystem
-  version: '1'
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
   md5: fee5683a3f04bd15cbd8318b096a27ab
   depends:
@@ -8737,13 +7606,7 @@ packages:
   license_family: BSD
   size: 3667
   timestamp: 1566974674465
-- kind: conda
-  name: fonts-conda-forge
-  version: '1'
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
   md5: f766549260d6815b0c52253f1fb1bb29
   depends:
@@ -8755,12 +7618,7 @@ packages:
   license_family: BSD
   size: 4102
   timestamp: 1566932280397
-- kind: conda
-  name: fonttools
-  version: 4.55.0
-  build: py312h178313f_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.0-py312h178313f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.0-py312h178313f_0.conda
   sha256: 2a8d4fe8968828584057f8b07f3e102e326d8ec08d0e30e4ecc21f35031239a0
   md5: f404f4fb99ccaea68b00c1cc64fc1e68
   depends:
@@ -8775,12 +7633,22 @@ packages:
   license_family: MIT
   size: 2843090
   timestamp: 1731643626471
-- kind: conda
-  name: fonttools
-  version: 4.55.0
-  build: py312h31fea79_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.0-py312h31fea79_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.0-py312h998013c_0.conda
+  sha256: 427d75267cfeee820498efeea59477790f7e28cdbe0f18a8484f23dae9a85cce
+  md5: b009bb8037e769ff4fd6439642268ecb
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2752240
+  timestamp: 1731643678207
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.0-py312h31fea79_0.conda
   sha256: 1507c8c47bcc7358d13d24e032ffccabec07df1f7abd6a46ab712679808dc148
   md5: 6051feed0d3ed5900dd5d9355d9b4a1b
   depends:
@@ -8796,33 +7664,7 @@ packages:
   license_family: MIT
   size: 2423864
   timestamp: 1731643701666
-- kind: conda
-  name: fonttools
-  version: 4.55.0
-  build: py312h998013c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.0-py312h998013c_0.conda
-  sha256: 427d75267cfeee820498efeea59477790f7e28cdbe0f18a8484f23dae9a85cce
-  md5: b009bb8037e769ff4fd6439642268ecb
-  depends:
-  - __osx >=11.0
-  - brotli
-  - munkres
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - unicodedata2 >=15.1.0
-  license: MIT
-  license_family: MIT
-  size: 2752240
-  timestamp: 1731643678207
-- kind: conda
-  name: formulaic
-  version: 0.6.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/formulaic-0.6.6-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/formulaic-0.6.6-pyhd8ed1ab_0.conda
   sha256: d84f843134acbe4649fc5afcf9e79099a02e856b3ceac363cf24103e2e7fd457
   md5: ccd375df3e828fd581f45a25a1ad1d81
   depends:
@@ -8843,13 +7685,7 @@ packages:
   license_family: MIT
   size: 71387
   timestamp: 1696462245091
-- kind: conda
-  name: formulaic
-  version: 1.0.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/formulaic-1.0.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/formulaic-1.0.2-pyhd8ed1ab_0.conda
   sha256: b9ce675810e89ff05a7e5cce607f7e69bb0f30b5635677d5799a09111af8fa74
   md5: bca1050b5354c034fe4098d75a72addb
   depends:
@@ -8870,13 +7706,7 @@ packages:
   license_family: MIT
   size: 73236
   timestamp: 1720846414890
-- kind: conda
-  name: fqdn
-  version: 1.5.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
   sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
   md5: 642d35437078749ef23a5dca2c9bb1f3
   depends:
@@ -8886,13 +7716,7 @@ packages:
   license_family: MOZILLA
   size: 14395
   timestamp: 1638810388635
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: h267a509_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
   md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
   depends:
@@ -8902,13 +7726,7 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 634972
   timestamp: 1694615932610
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hadb7bae_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
   sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
   md5: e6085e516a3e304ce41a8ee08b9b89ad
   depends:
@@ -8917,13 +7735,7 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 596430
   timestamp: 1694616332835
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hdaf720e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
   sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
   md5: 3761b23693f768dc75a8fd0a73ca053f
   depends:
@@ -8935,12 +7747,7 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 510306
   timestamp: 1694616398888
-- kind: conda
-  name: freexl
-  version: 2.0.0
-  build: h743c826_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
   sha256: 9213f60ba710ecfd3632ce47e036775c9f15ce80a6682ff63cbf12d9dddd5382
   md5: 12e6988845706b2cfbc3bc35c9a61a95
   depends:
@@ -8952,12 +7759,18 @@ packages:
   license_family: MOZILLA
   size: 59769
   timestamp: 1694952692595
-- kind: conda
-  name: freexl
-  version: 2.0.0
-  build: h8276f4a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+  sha256: 9cb4957d1431bc57bc95b1e99a50669d91ac3441226a78f69fa030d52f2bda77
+  md5: 40722e5f48287567cda6fb2ec1f7891b
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 55132
+  timestamp: 1694952828719
+- conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
   sha256: 9ef2fcf3b35703bf61a8359038c4b707382f3d5f0c4020f3f8ffb2f665daabae
   md5: 8e02e06229c677cbc9f5dc69ba49052c
   depends:
@@ -8971,29 +7784,7 @@ packages:
   license_family: MOZILLA
   size: 77439
   timestamp: 1694953013560
-- kind: conda
-  name: freexl
-  version: 2.0.0
-  build: hfbad9fb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
-  sha256: 9cb4957d1431bc57bc95b1e99a50669d91ac3441226a78f69fa030d52f2bda77
-  md5: 40722e5f48287567cda6fb2ec1f7891b
-  depends:
-  - libexpat >=2.5.0,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - minizip >=4.0.1,<5.0a0
-  license: MPL-1.1
-  license_family: MOZILLA
-  size: 55132
-  timestamp: 1694952828719
-- kind: conda
-  name: fsspec
-  version: 2024.10.0
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
   sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
   md5: 816dbc4679a64e4417cd1385d661bb31
   depends:
@@ -9002,13 +7793,7 @@ packages:
   license_family: BSD
   size: 134745
   timestamp: 1729608972363
-- kind: conda
-  name: future
-  version: 1.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
   sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
   md5: 650a7807e689642dddd3590eb817beed
   depends:
@@ -9017,13 +7802,7 @@ packages:
   license_family: MIT
   size: 364081
   timestamp: 1708610254418
-- kind: conda
-  name: gcc
-  version: 13.3.0
-  build: h9576a4e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
   sha256: d0161362430183cbdbc3db9cf95f9a1af1793027f3ab8755b3d3586deb28bf84
   md5: 606924335b5bcdf90e9aed9a2f5d22ed
   depends:
@@ -9032,13 +7811,7 @@ packages:
   license_family: BSD
   size: 53864
   timestamp: 1724801360210
-- kind: conda
-  name: gcc_impl_linux-64
-  version: 13.3.0
-  build: hfea6d02_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
   sha256: 998ade1d487e93fc8a7a16b90e2af69ebb227355bf4646488661f7ae5887873c
   md5: 0d043dbc126b64f79d915a0e96d3a1d5
   depends:
@@ -9053,13 +7826,7 @@ packages:
   license_family: GPL
   size: 67464415
   timestamp: 1724801227937
-- kind: conda
-  name: gcc_linux-64
-  version: 13.3.0
-  build: hc28eda2_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_7.conda
   sha256: 1e5ac50580a68fdc7d2f5722abcf1a87898c24b1ab6eb5ecd322634742d93645
   md5: ac23afbf5805389eb771e2ad3b476f75
   depends:
@@ -9070,14 +7837,7 @@ packages:
   license_family: BSD
   size: 32005
   timestamp: 1731939593317
-- kind: conda
-  name: geopandas
-  version: 1.0.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_1.conda
   sha256: ea0e200967b93a1342670bee137917e93d04742f3c3c626fe435ebb29462bbd7
   md5: 79a9a8d2fd39ecb4081c0df0c10135dc
   depends:
@@ -9093,14 +7853,7 @@ packages:
   license_family: BSD
   size: 7545
   timestamp: 1726898026216
-- kind: conda
-  name: geopandas-base
-  version: 1.0.1
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
   sha256: 1b0853491a299e95d57ccf3f3c9053a1b7e49fc9b2ad959f321b0717e567e249
   md5: cad8d8e1583463e7642adc72a76dc3c5
   depends:
@@ -9113,12 +7866,7 @@ packages:
   license_family: BSD
   size: 239539
   timestamp: 1726898022361
-- kind: conda
-  name: geos
-  version: 3.13.0
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
   sha256: 5c70d6d16e044859edca85feb9d4f1c3c6062aaf88d650826f5ccdf8c44336de
   md5: 40b4ab956c90390e407bb177f8a58bab
   depends:
@@ -9128,12 +7876,16 @@ packages:
   license: LGPL-2.1-only
   size: 1869233
   timestamp: 1725676083126
-- kind: conda
-  name: geos
-  version: 3.13.0
-  build: h5a68840_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
+  sha256: 273381020b72bde1597d4e07e855ed50ffac083512e61ccbdd99d93f03c6cbf2
+  md5: 45b2e9adb9663644b1eefa5300b9eef3
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: LGPL-2.1-only
+  size: 1481430
+  timestamp: 1725676193541
+- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
   sha256: 2b46d6f304f70dfca304169299908b558bd1e83992acb5077766eefa3d3fe35f
   md5: 08a30fe29a645fc5c768c0968db116d3
   depends:
@@ -9143,49 +7895,7 @@ packages:
   license: LGPL-2.1-only
   size: 1665961
   timestamp: 1725676536384
-- kind: conda
-  name: geos
-  version: 3.13.0
-  build: hf9b8971_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
-  sha256: 273381020b72bde1597d4e07e855ed50ffac083512e61ccbdd99d93f03c6cbf2
-  md5: 45b2e9adb9663644b1eefa5300b9eef3
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: LGPL-2.1-only
-  size: 1481430
-  timestamp: 1725676193541
-- kind: conda
-  name: geotiff
-  version: 1.7.3
-  build: h496ac4d_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
-  sha256: 116120a2f4411618800c2a5ce246dfc313298e545ce1ffaa85f28cc3ac2236ac
-  md5: fb20f424102030f3952532cc7aebdbd8
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  license: MIT
-  license_family: MIT
-  size: 123087
-  timestamp: 1726603487099
-- kind: conda
-  name: geotiff
-  version: 1.7.3
-  build: h77b800c_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
   sha256: 94c7d002c70a4802a78ac2925ad6b36327cff85e0af6af2825b11a968c81ec20
   md5: 4eb52aecb43e7c72f8e4fca0c386354e
   depends:
@@ -9201,13 +7911,7 @@ packages:
   license_family: MIT
   size: 131394
   timestamp: 1726602918349
-- kind: conda
-  name: geotiff
-  version: 1.7.3
-  build: h82bf549_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h82bf549_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h82bf549_3.conda
   sha256: 7ce4d6dced3cd313ea170db69d6929b88d77ebd40715f9f38c3bcba3633d6c65
   md5: cb84033d7c167a16c4577272b4493bc5
   depends:
@@ -9222,13 +7926,23 @@ packages:
   license_family: MIT
   size: 113739
   timestamp: 1726603324989
-- kind: conda
-  name: gflags
-  version: 2.2.2
-  build: h5888daf_1005
-  build_number: 1005
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
+  sha256: 116120a2f4411618800c2a5ce246dfc313298e545ce1ffaa85f28cc3ac2236ac
+  md5: fb20f424102030f3952532cc7aebdbd8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 123087
+  timestamp: 1726603487099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
   sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
   md5: d411fc29e338efb48c5fd4576d71d881
   depends:
@@ -9239,13 +7953,7 @@ packages:
   license_family: BSD
   size: 119654
   timestamp: 1726600001928
-- kind: conda
-  name: gflags
-  version: 2.2.2
-  build: hf9b8971_1005
-  build_number: 1005
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
   sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
   md5: 57a511a5905caa37540eb914dfcbf1fb
   depends:
@@ -9255,24 +7963,7 @@ packages:
   license_family: BSD
   size: 82090
   timestamp: 1726600145480
-- kind: conda
-  name: giflib
-  version: 5.2.2
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
-  sha256: 843b3f364ff844137e37d5c0a181f11f6d51adcedd216f019d074e5aa5d7e09c
-  md5: 95fa1486c77505330c20f7202492b913
-  license: MIT
-  license_family: MIT
-  size: 71613
-  timestamp: 1712692611426
-- kind: conda
-  name: giflib
-  version: 5.2.2
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
   sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
   md5: 3bf7b9fd5a7136126e0234db4b87c8b6
   depends:
@@ -9281,13 +7972,14 @@ packages:
   license_family: MIT
   size: 77248
   timestamp: 1712692454246
-- kind: conda
-  name: git_root
-  version: '0.1'
-  build: py_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/git_root-0.1-py_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+  sha256: 843b3f364ff844137e37d5c0a181f11f6d51adcedd216f019d074e5aa5d7e09c
+  md5: 95fa1486c77505330c20f7202492b913
+  license: MIT
+  license_family: MIT
+  size: 71613
+  timestamp: 1712692611426
+- conda: https://conda.anaconda.org/conda-forge/noarch/git_root-0.1-py_0.tar.bz2
   sha256: 44d672f1a04e302d08eb3f4c59b07aa8fae7654bfc2eeea5aaf1989310f3d18a
   md5: 7614a94e5d8f65749fc5d80d47c3276d
   depends:
@@ -9296,12 +7988,7 @@ packages:
   license_family: MIT
   size: 5282
   timestamp: 1551286671604
-- kind: conda
-  name: glog
-  version: 0.7.1
-  build: hbabe93e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
   sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
   md5: ff862eebdfeb2fd048ae9dc92510baca
   depends:
@@ -9312,12 +7999,7 @@ packages:
   license_family: BSD
   size: 143452
   timestamp: 1718284177264
-- kind: conda
-  name: glog
-  version: 0.7.1
-  build: heb240a5_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
   sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
   md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
   depends:
@@ -9328,28 +8010,7 @@ packages:
   license_family: BSD
   size: 112215
   timestamp: 1718284365403
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h7bae524_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
-  md5: eed7278dfbab727b56f2c0b64330814b
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 365188
-  timestamp: 1718981343258
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: hac33072_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
   sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
   md5: c94a5994ef49749880a8139cf9afcbe1
   depends:
@@ -9358,13 +8019,16 @@ packages:
   license: GPL-2.0-or-later OR LGPL-3.0-or-later
   size: 460055
   timestamp: 1718980856608
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: h59595ed_1003
-  build_number: 1003
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
+  md5: eed7278dfbab727b56f2c0b64330814b
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 365188
+  timestamp: 1718981343258
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
   sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
   md5: f87c7b7c2cb45f323ffbce941c78ab7c
   depends:
@@ -9374,13 +8038,7 @@ packages:
   license_family: LGPL
   size: 96855
   timestamp: 1711634169756
-- kind: conda
-  name: graphlib-backport
-  version: 1.0.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/graphlib-backport-1.0.3-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/graphlib-backport-1.0.3-pyhd8ed1ab_0.tar.bz2
   sha256: 1a417887d6f2b770eae6154441be7a7819e9966ce495150e529e07922a5adb08
   md5: 33c122658a309cc9fc0b1dda47a02a84
   depends:
@@ -9389,13 +8047,7 @@ packages:
   license_family: PSF
   size: 10655
   timestamp: 1635566130699
-- kind: conda
-  name: gxx
-  version: 13.3.0
-  build: h9576a4e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_1.conda
   sha256: 5446f5d1d609d996579f706d2020e83ef48e086d943bfeef7ab807ea246888a0
   md5: 209182ca6b20aeff62f442e843961d81
   depends:
@@ -9405,13 +8057,7 @@ packages:
   license_family: BSD
   size: 53338
   timestamp: 1724801498389
-- kind: conda
-  name: gxx_impl_linux-64
-  version: 13.3.0
-  build: hdbfa832_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hdbfa832_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hdbfa832_1.conda
   sha256: 746dff24bb1efc89ab0ec108838d0711683054e3bbbcb94d042943410a98eca1
   md5: 806367e23a0a6ad21e51875b34c57d7e
   depends:
@@ -9423,13 +8069,7 @@ packages:
   license_family: GPL
   size: 13337720
   timestamp: 1724801455825
-- kind: conda
-  name: gxx_linux-64
-  version: 13.3.0
-  build: h6834431_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-h6834431_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-h6834431_7.conda
   sha256: a9b1ffea76f2cc5aedeead4793fcded7a687cce9d5e3f4fe93629f1b1d5043a6
   md5: 7c82ca9bda609b6f72f670e4219d3787
   depends:
@@ -9441,13 +8081,7 @@ packages:
   license_family: BSD
   size: 30356
   timestamp: 1731939612705
-- kind: conda
-  name: h11
-  version: 0.14.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
   sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
   md5: b21ed0883505ba1910994f1df031a428
   depends:
@@ -9457,13 +8091,7 @@ packages:
   license_family: MIT
   size: 48251
   timestamp: 1664132995560
-- kind: conda
-  name: h2
-  version: 4.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
   sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
   md5: b748fbf7060927a6e82df7cb5ee8f097
   depends:
@@ -9474,13 +8102,7 @@ packages:
   license_family: MIT
   size: 46754
   timestamp: 1634280590080
-- kind: conda
-  name: h2o-py
-  version: 3.46.0.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/h2o-py-3.46.0.6-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2o-py-3.46.0.6-pyhd8ed1ab_0.conda
   sha256: 1d34bb4db10db18f14a19a76f1d133b0f40a99eca71828d042e2158b3b0ca878
   md5: 713933345b6b55b9b41f456f2992fac6
   depends:
@@ -9494,13 +8116,7 @@ packages:
   license_family: APACHE
   size: 262173505
   timestamp: 1730920615027
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: hda332d3_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
   sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
   md5: 76b32dcf243444aea9c6b804bcfa40b8
   depends:
@@ -9516,13 +8132,7 @@ packages:
   license_family: MIT
   size: 1603653
   timestamp: 1721186240105
-- kind: conda
-  name: hpack
-  version: 4.0.0
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
   sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
   md5: 914d6646c4dbb1fd3ff539830a12fd71
   depends:
@@ -9531,14 +8141,7 @@ packages:
   license_family: MIT
   size: 25341
   timestamp: 1598856368685
-- kind: conda
-  name: httpcore
-  version: 1.0.7
-  build: pyh29332c3_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
   sha256: c84d012a245171f3ed666a8bf9319580c269b7843ffa79f26468842da3abd5df
   md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
   depends:
@@ -9552,13 +8155,7 @@ packages:
   license_family: BSD
   size: 48959
   timestamp: 1731707562362
-- kind: conda
-  name: httpx
-  version: 0.28.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
   sha256: cb7895446cd93091300accea6afbc8d9811a3c5899922ccfeeff97d9b55909dc
   md5: 22878824a87f1af2ad48665f9d5bfcc8
   depends:
@@ -9571,13 +8168,7 @@ packages:
   license_family: BSD
   size: 63183
   timestamp: 1732831049776
-- kind: conda
-  name: hyperframe
-  version: 6.0.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
   sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
   md5: 9f765cbfab6870c8435b9eefecd7a1f4
   depends:
@@ -9586,12 +8177,7 @@ packages:
   license_family: MIT
   size: 14646
   timestamp: 1619110249723
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: he02047a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   md5: 8b189310083baabfb622af68fd9d3ae3
   depends:
@@ -9602,12 +8188,7 @@ packages:
   license_family: MIT
   size: 12129203
   timestamp: 1720853576813
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: hfee45f7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
   sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
   md5: 5eb22c1d7b3fc4abb50d92d621583137
   depends:
@@ -9616,13 +8197,7 @@ packages:
   license_family: MIT
   size: 11857802
   timestamp: 1720853997952
-- kind: conda
-  name: identify
-  version: 2.6.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.3-pyhd8ed1ab_0.conda
   sha256: 2350107285349caad1a5c5c5296a1335b8649d6b1b0e8f2bde18127c404471c5
   md5: dd3acd023fc358afab730866a0e5e3f5
   depends:
@@ -9632,13 +8207,7 @@ packages:
   license_family: MIT
   size: 78352
   timestamp: 1732589463054
-- kind: conda
-  name: idna
-  version: '3.10'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
   sha256: 8c57fd68e6be5eecba4462e983aed7e85761a519aab80e834bbd7794d4b545b2
   md5: 7ba2ede0e7c795ff95088daf0dc59753
   depends:
@@ -9647,13 +8216,7 @@ packages:
   license_family: BSD
   size: 49837
   timestamp: 1726459583613
-- kind: conda
-  name: imagesize
-  version: 1.4.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
   sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
   md5: 7de5386c8fea29e76b303f37dde4c352
   depends:
@@ -9662,13 +8225,7 @@ packages:
   license_family: MIT
   size: 10164
   timestamp: 1656939625410
-- kind: conda
-  name: importlib-metadata
-  version: 8.5.0
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
   sha256: 7194700ce1a5ad2621fd68e894dd8c1ceaff9a38723e6e0e5298fdef13017b1c
   md5: 54198435fce4d64d8a89af22573012a8
   depends:
@@ -9678,13 +8235,7 @@ packages:
   license_family: APACHE
   size: 28646
   timestamp: 1726082927916
-- kind: conda
-  name: importlib_resources
-  version: 6.4.5
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
   sha256: 2cb9db3e40033c3df72d3defc678a012840378fd55a67e4351363d4b321a0dc1
   md5: c808991d29b9838fb4d96ce8267ec9ec
   depends:
@@ -9696,13 +8247,7 @@ packages:
   license_family: APACHE
   size: 32725
   timestamp: 1725921462405
-- kind: conda
-  name: iniconfig
-  version: 2.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
   sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
   md5: f800d2da156d08e289b14e87e43c1ae5
   depends:
@@ -9711,26 +8256,14 @@ packages:
   license_family: MIT
   size: 11101
   timestamp: 1673103208955
-- kind: conda
-  name: intel-openmp
-  version: 2024.2.1
-  build: h57928b3_1083
-  build_number: 1083
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
   sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
   md5: 2d89243bfb53652c182a7c73182cce4f
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   size: 1852356
   timestamp: 1723739573141
-- kind: conda
-  name: interface_meta
-  version: 1.3.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/interface_meta-1.3.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/interface_meta-1.3.0-pyhd8ed1ab_0.tar.bz2
   sha256: 3e56d658a52ee3fecee0bdcc579bdb44a3f7b6606acfae2a2edbc4df732c6869
   md5: 7fecf805b0d6088be8a8ace97728387d
   depends:
@@ -9739,13 +8272,7 @@ packages:
   license_family: MIT
   size: 16086
   timestamp: 1649036085429
-- kind: conda
-  name: ipdb
-  version: 0.13.13
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipdb-0.13.13-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipdb-0.13.13-pyhd8ed1ab_0.conda
   sha256: 16ea279fae5b3b77a694bf7bc8bcda9c310be39d6fbf78664d3111bcd5f5758a
   md5: 86baea403007ad4898d85c897c80b758
   depends:
@@ -9757,13 +8284,7 @@ packages:
   license_family: BSD
   size: 18542
   timestamp: 1679608530748
-- kind: conda
-  name: ipykernel
-  version: 6.29.5
-  build: pyh3099207_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
   sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
   md5: b40131ab6a36ac2c09b7c57d4d3fbf99
   depends:
@@ -9785,13 +8306,7 @@ packages:
   license_family: BSD
   size: 119084
   timestamp: 1719845605084
-- kind: conda
-  name: ipykernel
-  version: 6.29.5
-  build: pyh4bbf305_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
   sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
   md5: 18df5fc4944a679e085e0e8f31775fc8
   depends:
@@ -9813,13 +8328,7 @@ packages:
   license_family: BSD
   size: 119853
   timestamp: 1719845858082
-- kind: conda
-  name: ipykernel
-  version: 6.29.5
-  build: pyh57ce528_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
   sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
   md5: 9eb15d654daa0ef5a98802f586bb4ffc
   depends:
@@ -9842,13 +8351,7 @@ packages:
   license_family: BSD
   size: 119568
   timestamp: 1719845667420
-- kind: conda
-  name: ipython
-  version: 8.30.0
-  build: pyh707e725_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
   sha256: 65cdc105e5effea2943d3979cc1592590c923a589009b484d07672faaf047af1
   md5: 5d6e5cb3a4b820f61b2073f0ad5431f1
   depends:
@@ -9869,13 +8372,7 @@ packages:
   license_family: BSD
   size: 600248
   timestamp: 1732897026255
-- kind: conda
-  name: ipython
-  version: 8.30.0
-  build: pyh7428d3b_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
   sha256: 94ee8215bd1f614c9c984437b184e8dbe61a4014eb5813c276e3dcb18aaa7f46
   md5: 6cdaebbc9e3feb2811eb9f52ed0b89e1
   depends:
@@ -9896,14 +8393,7 @@ packages:
   license_family: BSD
   size: 600466
   timestamp: 1732897444811
-- kind: conda
-  name: ipython_genutils
-  version: 0.2.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
   sha256: 72fbbe8bc511f20268d347c1a06e279128237e096c4c174b2f9164a661c6b13e
   md5: f8ed9f18dce81e4ee55c858cc2f8548a
   depends:
@@ -9912,13 +8402,7 @@ packages:
   license_family: BSD
   size: 28064
   timestamp: 1716278507729
-- kind: conda
-  name: isoduration
-  version: 20.11.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
   md5: 4cb68948e0b8429534380243d063a27a
   depends:
@@ -9928,13 +8412,7 @@ packages:
   license_family: MIT
   size: 17189
   timestamp: 1638811664194
-- kind: conda
-  name: jedi
-  version: 0.19.2
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
   sha256: d37dad14c00d06d33bfb99c378d0abd7645224a9491c433af5028f24863341ab
   md5: 11ead81b00e0f7cc901fceb7ccfb92c1
   depends:
@@ -9943,13 +8421,7 @@ packages:
   license: Apache-2.0 AND MIT
   size: 842916
   timestamp: 1731317305873
-- kind: conda
-  name: jemalloc-local
-  version: 5.3.0
-  build: h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jemalloc-local-5.3.0-h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jemalloc-local-5.3.0-h5888daf_1.conda
   sha256: 2cd45846eac301d8e3962a058b67cb478053f47096c86127362d3750fc639f54
   md5: 5dc98c403afde6e36042dd5a24803f86
   depends:
@@ -9963,13 +8435,7 @@ packages:
   license_family: BSD
   size: 55787
   timestamp: 1726817711982
-- kind: conda
-  name: jemalloc-local
-  version: 5.3.0
-  build: hf9b8971_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jemalloc-local-5.3.0-hf9b8971_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jemalloc-local-5.3.0-hf9b8971_1.conda
   sha256: 097effaa8c848955377d6c7789fc618ef4a90bedd1f5b4cf503aa17bcc019bb7
   md5: ba6e300ff4ed9df873b93794e36b6ed3
   depends:
@@ -9982,13 +8448,7 @@ packages:
   license_family: BSD
   size: 55900
   timestamp: 1726817951316
-- kind: conda
-  name: jinja2
-  version: 3.1.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
   md5: 7b86ecb7d3557821c649b3c31e3eb9f2
   depends:
@@ -9998,13 +8458,7 @@ packages:
   license_family: BSD
   size: 111565
   timestamp: 1715127275924
-- kind: conda
-  name: joblib
-  version: 1.4.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
   md5: 25df261d4523d9f9783bcdb7208d872f
   depends:
@@ -10014,12 +8468,7 @@ packages:
   license_family: BSD
   size: 219731
   timestamp: 1714665585214
-- kind: conda
-  name: json-c
-  version: '0.18'
-  build: h6688a6e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
   sha256: 09e706cb388d3ea977fabcee8e28384bdaad8ce1fc49340df5f868a2bd95a7da
   md5: 38f5dbc9ac808e31c00650f7be1db93f
   depends:
@@ -10029,12 +8478,7 @@ packages:
   license_family: MIT
   size: 82709
   timestamp: 1726487116178
-- kind: conda
-  name: json-c
-  version: '0.18'
-  build: he4178ee_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
   sha256: 73179a1cd0b45c09d4f631cb359d9e755e6e573c5d908df42006728e0bf8297c
   md5: 94f14ef6157687c30feb44e1abecd577
   depends:
@@ -10043,13 +8487,7 @@ packages:
   license_family: MIT
   size: 73715
   timestamp: 1726487214495
-- kind: conda
-  name: json5
-  version: 0.10.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_0.conda
   sha256: df01c5253bb5f8c68526c8bad92b8e832ed58a0d4c40d08a65c81c51821bc23d
   md5: 165cbd1d80be88dafadeabfaae6fa588
   depends:
@@ -10058,29 +8496,7 @@ packages:
   license_family: APACHE
   size: 32030
   timestamp: 1732666224221
-- kind: conda
-  name: jsonpointer
-  version: 3.0.0
-  build: py312h2e8e312_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py312h2e8e312_1.conda
-  sha256: 6865b97780e795337f65592582aee6f25e5b96214c64ffd3f8cdf580fd64ba22
-  md5: e3ceda014d8461a11ca8552830a978f9
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 42235
-  timestamp: 1725303419414
-- kind: conda
-  name: jsonpointer
-  version: 3.0.0
-  build: py312h7900ff3_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py312h7900ff3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py312h7900ff3_1.conda
   sha256: 76ccb7bffc7761d1d3133ffbe1f7f1710a0f0d9aaa9f7ea522652e799f3601f4
   md5: 6b51f7459ea4073eeb5057207e2e1e3d
   depends:
@@ -10090,13 +8506,7 @@ packages:
   license_family: BSD
   size: 17277
   timestamp: 1725303032027
-- kind: conda
-  name: jsonpointer
-  version: 3.0.0
-  build: py312h81bd7bf_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py312h81bd7bf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py312h81bd7bf_1.conda
   sha256: f6fb3734e967d1cd0cde32844ee952809f6c0a49895da7ec1c8cfdf97739b947
   md5: 80f403c03290e1662be03e026fb5f8ab
   depends:
@@ -10107,13 +8517,17 @@ packages:
   license_family: BSD
   size: 17865
   timestamp: 1725303130815
-- kind: conda
-  name: jsonschema
-  version: 4.23.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py312h2e8e312_1.conda
+  sha256: 6865b97780e795337f65592582aee6f25e5b96214c64ffd3f8cdf580fd64ba22
+  md5: e3ceda014d8461a11ca8552830a978f9
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42235
+  timestamp: 1725303419414
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
   sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
   md5: da304c192ad59975202859b367d0f6a2
   depends:
@@ -10128,13 +8542,7 @@ packages:
   license_family: MIT
   size: 74323
   timestamp: 1720529611305
-- kind: conda
-  name: jsonschema-specifications
-  version: 2024.10.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
   sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
   md5: 720745920222587ef942acfbc578b584
   depends:
@@ -10144,13 +8552,7 @@ packages:
   license_family: MIT
   size: 16165
   timestamp: 1728418976382
-- kind: conda
-  name: jsonschema-with-format-nongpl
-  version: 4.23.0
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
   sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
   md5: 16b37612b3a2fd77f409329e213b530c
   depends:
@@ -10167,13 +8569,7 @@ packages:
   license_family: MIT
   size: 7143
   timestamp: 1720529619500
-- kind: conda
-  name: jupyter-lsp
-  version: 2.2.5
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
   sha256: 2151c2c63e0442a4c69ee0ad8a634195eedab10b7b74c0ec8266471842239a93
   md5: 885867f6adab3d7ecdf8ab6ca0785f51
   depends:
@@ -10184,13 +8580,7 @@ packages:
   license_family: BSD
   size: 55539
   timestamp: 1712707521811
-- kind: conda
-  name: jupyter_client
-  version: 8.6.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
   sha256: 4419c85e209a715f551a5c9bead746f29ee9d0fc41e772a76db3868622795671
   md5: a14218cfb29662b4a19ceb04e93e298e
   depends:
@@ -10205,14 +8595,7 @@ packages:
   license_family: BSD
   size: 106055
   timestamp: 1726610805505
-- kind: conda
-  name: jupyter_core
-  version: 5.7.2
-  build: pyh31011fe_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
   sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
   md5: 0a2980dada0dd7fd0998f0342308b1b1
   depends:
@@ -10224,14 +8607,7 @@ packages:
   license_family: BSD
   size: 57671
   timestamp: 1727163547058
-- kind: conda
-  name: jupyter_core
-  version: 5.7.2
-  build: pyh5737063_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
   sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
   md5: 46d87d1c0ea5da0aae36f77fa406e20d
   depends:
@@ -10245,13 +8621,7 @@ packages:
   license_family: BSD
   size: 58269
   timestamp: 1727164026641
-- kind: conda
-  name: jupyter_events
-  version: 0.10.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
   md5: ed45423c41b3da15ea1df39b1f80c2ca
   depends:
@@ -10267,13 +8637,7 @@ packages:
   license_family: BSD
   size: 21475
   timestamp: 1710805759187
-- kind: conda
-  name: jupyter_server
-  version: 2.14.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
   sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
   md5: ca23c71f70a7c7935b3d03f0f1a5801d
   depends:
@@ -10300,13 +8664,7 @@ packages:
   license_family: BSD
   size: 323978
   timestamp: 1720816754998
-- kind: conda
-  name: jupyter_server_terminals
-  version: 0.5.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
   sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
   md5: 219b3833aa8ed91d47d1be6ca03f30be
   depends:
@@ -10316,13 +8674,7 @@ packages:
   license_family: BSD
   size: 19818
   timestamp: 1710262791393
-- kind: conda
-  name: jupyterlab
-  version: 4.3.1
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
   sha256: ff1035eb0020dbaf4e332ef4b81a7068b595dfc57dde3313e9c4a37583772644
   md5: b4f3d579fc21a44518d52c52507461b4
   depends:
@@ -10346,14 +8698,7 @@ packages:
   license_family: BSD
   size: 7101932
   timestamp: 1731776859245
-- kind: conda
-  name: jupyterlab_pygments
-  version: 0.3.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
   sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
   md5: afcd1b53bcac8844540358e33f33d28f
   depends:
@@ -10365,13 +8710,7 @@ packages:
   license_family: BSD
   size: 18776
   timestamp: 1707149279640
-- kind: conda
-  name: jupyterlab_server
-  version: 2.27.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
   sha256: a23b26d1a35bccdb91b9232119e5f402624e1e1a252b0e64cc20c6eb5b87cefb
   md5: af8239bf1ba7e8c69b689f780f653488
   depends:
@@ -10390,13 +8729,7 @@ packages:
   license_family: BSD
   size: 49355
   timestamp: 1721163412436
-- kind: conda
-  name: jupytext
-  version: 1.16.4
-  build: pyh80e38bb_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.4-pyh80e38bb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.4-pyh80e38bb_0.conda
   sha256: e0e904bcc18a3b31dc79b05f98a3fd46c9e52b27e7942856f767f0c0b815ae15
   md5: 1df7fd1594a7f2f6496ff23834a099bf
   depends:
@@ -10411,14 +8744,7 @@ packages:
   license_family: MIT
   size: 104513
   timestamp: 1722332096729
-- kind: conda
-  name: kernel-headers_linux-64
-  version: 3.10.0
-  build: he073ed8_18
-  build_number: 18
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
   sha256: a922841ad80bd7b222502e65c07ecb67e4176c4fa5b03678a005f39fcc98be4b
   md5: ad8527bf134a90e1c9ed35fa0b64318c
   constrains:
@@ -10427,12 +8753,7 @@ packages:
   license_family: GPL
   size: 943486
   timestamp: 1729794504440
-- kind: conda
-  name: keyutils
-  version: 1.6.1
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
   sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   md5: 30186d27e2c9fa62b45fb1476b7200e3
   depends:
@@ -10440,30 +8761,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 117831
   timestamp: 1646151697040
-- kind: conda
-  name: kiwisolver
-  version: 1.4.7
-  build: py312h6142ec9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py312h6142ec9_0.conda
-  sha256: 056a2cc3b6c07c79719cb8f2eda09408fca137b49fe46f919ef14247caa6f0e9
-  md5: ea8a65d24baad7ed822ab7f07f19e105
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 60966
-  timestamp: 1725459569843
-- kind: conda
-  name: kiwisolver
-  version: 1.4.7
-  build: py312h68727a3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py312h68727a3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py312h68727a3_0.conda
   sha256: d752c53071ee5d712baa9742dd1629e60388c5ce4ab11d4e73a1690443e41769
   md5: 444266743652a4f1538145e9362f6d3b
   depends:
@@ -10476,12 +8774,20 @@ packages:
   license_family: BSD
   size: 70922
   timestamp: 1725459412788
-- kind: conda
-  name: kiwisolver
-  version: 1.4.7
-  build: py312hd5eb7cc_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py312hd5eb7cc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py312h6142ec9_0.conda
+  sha256: 056a2cc3b6c07c79719cb8f2eda09408fca137b49fe46f919ef14247caa6f0e9
+  md5: ea8a65d24baad7ed822ab7f07f19e105
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60966
+  timestamp: 1725459569843
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py312hd5eb7cc_0.conda
   sha256: b5b3ed78e4c44483afb68f53427db3d232ddf7930ca180bb00fa86ceca7cf7e4
   md5: 1eddb74a9fbb1d4d6fde9aef272ad1d0
   depends:
@@ -10494,30 +8800,7 @@ packages:
   license_family: BSD
   size: 55405
   timestamp: 1725459633511
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h237132a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
-  md5: c6dc8a0fdec13a0565936655c33069a1
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.3.1,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1155530
-  timestamp: 1719463474401
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h659f571_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
   depends:
@@ -10531,12 +8814,20 @@ packages:
   license_family: MIT
   size: 1370023
   timestamp: 1719463201255
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: hdf4eb48_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
   sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
   md5: 31aec030344e962fbd7dbbbbd68e60a9
   depends:
@@ -10548,12 +8839,28 @@ packages:
   license_family: MIT
   size: 712034
   timestamp: 1719463874284
-- kind: conda
-  name: lcms2
-  version: '2.16'
-  build: h67d730c_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
   sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
   md5: d3592435917b62a8becff3a60db674f6
   depends:
@@ -10566,44 +8873,7 @@ packages:
   license_family: MIT
   size: 507632
   timestamp: 1701648249706
-- kind: conda
-  name: lcms2
-  version: '2.16'
-  build: ha0e7c42_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
-  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
-  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  license: MIT
-  license_family: MIT
-  size: 211959
-  timestamp: 1701647962657
-- kind: conda
-  name: lcms2
-  version: '2.16'
-  build: hb7c19ff_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
-  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
-  md5: 51bb7010fc86f70eee639b4bb7a894f5
-  depends:
-  - libgcc-ng >=12
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  license: MIT
-  license_family: MIT
-  size: 245247
-  timestamp: 1701647787198
-- kind: conda
-  name: ld64
-  version: '951.9'
-  build: h39a299f_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h39a299f_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h39a299f_2.conda
   sha256: 041d712eadca1911fac7112171db5c5c2e478c75b65ae4663005c49b77c65a45
   md5: caf11d8b84c7dd198309056dbd457b86
   depends:
@@ -10616,13 +8886,7 @@ packages:
   license_family: Other
   size: 18503
   timestamp: 1732552594547
-- kind: conda
-  name: ld64_osx-arm64
-  version: '951.9'
-  build: h3f9b568_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-h3f9b568_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-h3f9b568_2.conda
   sha256: c67453a58870ce19b6acaa1d0db2c49848b7584c062d969f5d06c82ebd1454ef
   md5: 68841f5b5956607ea9760cafa14271c5
   depends:
@@ -10640,13 +8904,7 @@ packages:
   license_family: Other
   size: 1017788
   timestamp: 1732552505749
-- kind: conda
-  name: ld_impl_linux-64
-  version: '2.43'
-  build: h712a8e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
   sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
   md5: 048b02e3962f066da18efe3a21b77672
   depends:
@@ -10657,12 +8915,7 @@ packages:
   license_family: GPL
   size: 669211
   timestamp: 1729655358674
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h27087fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
   sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
   md5: 76bbff344f0134279f225174e9064c8f
   depends:
@@ -10672,12 +8925,16 @@ packages:
   license_family: Apache
   size: 281798
   timestamp: 1657977462600
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
   sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
   md5: 1900cb3cab5055833cfddb0ba233b074
   depends:
@@ -10687,28 +8944,7 @@ packages:
   license_family: Apache
   size: 194365
   timestamp: 1657977692274
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h9a09cb3_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
-  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
-  md5: de462d5aacda3b30721b512c5da4e742
-  depends:
-  - libcxx >=13.0.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 215721
-  timestamp: 1657977558796
-- kind: conda
-  name: liac-arff
-  version: 2.5.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/liac-arff-2.5.0-pyhd8ed1ab_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/liac-arff-2.5.0-pyhd8ed1ab_1.tar.bz2
   sha256: 7b2263a042636cc68a90979e4d9aab3076e0ae26d57304c4285ce7b9d4c89c3a
   md5: f63de4caf3c2c294e3fb034174017562
   depends:
@@ -10717,13 +8953,7 @@ packages:
   license_family: MIT
   size: 15598
   timestamp: 1612178140784
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
   sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
   md5: e1f604644fe8d78e22660e2fec6756bc
   depends:
@@ -10737,13 +8967,20 @@ packages:
   license_family: Apache
   size: 1310521
   timestamp: 1727295454064
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_he0c23c2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1179072
+  timestamp: 1727295571173
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
   sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
   md5: 3f59a73b07a05530b252ecb07dd882b9
   depends:
@@ -10757,31 +8994,25 @@ packages:
   license_family: Apache
   size: 1777570
   timestamp: 1727296115119
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_hf9b8971_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
-  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
-  md5: 706da5e791c569a7b9814877098a6a0a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-hadbb8c3_0.conda
+  sha256: 68afcb4519d08cebf71845aff6038e7273f021efc04ef48246f8d41e4e462a61
+  md5: 4a099677417658748239616b6ca96bb6
   depends:
-  - __osx >=11.0
-  - libcxx >=17
-  constrains:
-  - libabseil-static =20240722.0=cxx17*
-  - abseil-cpp =20240722.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1179072
-  timestamp: 1727295571173
-- kind: conda
-  name: libarchive
-  version: 3.7.7
-  build: h7c07d2a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h7c07d2a_0.conda
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libxml2 >=2.13.5,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 874221
+  timestamp: 1732614239458
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h7c07d2a_0.conda
   sha256: 10d5c755761c6823d20c6ddbd42292ef91f34e271b6ba3e78d0c5fa81c22b3ed
   md5: 49b28e291693b70cf8a7e70f290834d8
   depends:
@@ -10799,12 +9030,7 @@ packages:
   license_family: BSD
   size: 777074
   timestamp: 1732614642044
-- kind: conda
-  name: libarchive
-  version: 3.7.7
-  build: h88ece9c_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h88ece9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h88ece9c_0.conda
   sha256: afc496c826ec21cb898018695a7785baced3ebb66a90e39a1c2604dfaa1546be
   md5: 37c6e11d9f2e69789198ef2bfc661392
   depends:
@@ -10823,116 +9049,8 @@ packages:
   license_family: BSD
   size: 977329
   timestamp: 1732614920501
-- kind: conda
-  name: libarchive
-  version: 3.7.7
-  build: hadbb8c3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-hadbb8c3_0.conda
-  sha256: 68afcb4519d08cebf71845aff6038e7273f021efc04ef48246f8d41e4e462a61
-  md5: 4a099677417658748239616b6ca96bb6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=13
-  - libxml2 >=2.13.5,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - lzo >=2.10,<3.0a0
-  - openssl >=3.4.0,<4.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 874221
-  timestamp: 1732614239458
-- kind: conda
-  name: libarrow
-  version: 18.1.0
-  build: h0ea94f9_2_cpu
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.1.0-h0ea94f9_2_cpu.conda
-  sha256: 212996b0a7efe74c01f9a045f4db2253175ad95dee088fc2cb8c2944f8df9ab0
-  md5: 0fc0ae2ddd001a52d6715ba88c651e8e
-  depends:
-  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
-  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgoogle-cloud >=2.31.0,<2.32.0a0
-  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
-  - libre2-11 >=2024.7.2
-  - libutf8proc >=2.9.0,<2.10.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.3,<2.0.4.0a0
-  - re2
-  - snappy >=1.2.1,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.42.34433
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - apache-arrow-proc =*=cpu
-  - parquet-cpp <0.0a0
-  - arrow-cpp <0.0a0
-  license: Apache-2.0
-  size: 5248470
-  timestamp: 1732950405896
-- kind: conda
-  name: libarrow
-  version: 18.1.0
-  build: h654e1bb_2_cpu
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.1.0-h654e1bb_2_cpu.conda
-  sha256: 925dcb034f36536eed21d9323f096bf2ebf1111d14c61e1ae0b90e5de131f1e1
-  md5: e69934ff9dd8745fea8927028d1603ee
-  depends:
-  - __osx >=11.0
-  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
-  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
-  - azure-core-cpp >=1.14.0,<1.14.1.0a0
-  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
-  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
-  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - glog >=0.7.1,<0.8.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libcxx >=18
-  - libgoogle-cloud >=2.31.0,<2.32.0a0
-  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
-  - libre2-11 >=2024.7.2
-  - libutf8proc >=2.9.0,<2.10.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.3,<2.0.4.0a0
-  - re2
-  - snappy >=1.2.1,<1.3.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - arrow-cpp <0.0a0
-  - parquet-cpp <0.0a0
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  size: 5475725
-  timestamp: 1732947802614
-- kind: conda
-  name: libarrow
-  version: 18.1.0
-  build: he15abb1_1_cpu
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-he15abb1_1_cpu.conda
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-he15abb1_1_cpu.conda
   sha256: afc81af2e533cc35295aebae4fb382e770310d9b1ac31837456b440d35c54cf7
   md5: bd3e35a6f3f869b4777488452f315008
   depends:
@@ -10970,13 +9088,78 @@ packages:
   license_family: APACHE
   size: 8780597
   timestamp: 1732863546099
-- kind: conda
-  name: libarrow-acero
-  version: 18.1.0
-  build: h5888daf_1_cpu
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.1.0-h654e1bb_2_cpu.conda
+  build_number: 2
+  sha256: 925dcb034f36536eed21d9323f096bf2ebf1111d14c61e1ae0b90e5de131f1e1
+  md5: e69934ff9dd8745fea8927028d1603ee
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.9.0,<2.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  size: 5475725
+  timestamp: 1732947802614
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.1.0-h0ea94f9_2_cpu.conda
+  build_number: 2
+  sha256: 212996b0a7efe74c01f9a045f4db2253175ad95dee088fc2cb8c2944f8df9ab0
+  md5: 0fc0ae2ddd001a52d6715ba88c651e8e
+  depends:
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.9.0,<2.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  size: 5248470
+  timestamp: 1732950405896
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-h5888daf_1_cpu.conda
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-h5888daf_1_cpu.conda
   sha256: 3de5719a7035baad7e665116dce7bb3d069f0c1916e163c553e2e491bbe8b614
   md5: 6197dcb930f6254e9b2fdc416be56b71
   depends:
@@ -10988,13 +9171,8 @@ packages:
   license_family: APACHE
   size: 611272
   timestamp: 1732863586114
-- kind: conda
-  name: libarrow-acero
-  version: 18.1.0
-  build: h605b82c_2_cpu
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.1.0-h605b82c_2_cpu.conda
   build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.1.0-h605b82c_2_cpu.conda
   sha256: cfe32f1b0712b77d2c792a839fe4ea2790cabd99d47cd8e1b20ba2d3c8b113b2
   md5: 60351279d7dfd7c254c46aabf9aa35a6
   depends:
@@ -11004,13 +9182,8 @@ packages:
   license: Apache-2.0
   size: 483362
   timestamp: 1732948000606
-- kind: conda
-  name: libarrow-acero
-  version: 18.1.0
-  build: hb6457b2_2_cpu
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.1.0-hb6457b2_2_cpu.conda
   build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.1.0-hb6457b2_2_cpu.conda
   sha256: e17750b6fe6c863b1f2496e5ebf5c181416a0a40526efd9072cd200b44e7d587
   md5: b21ccd9073c96c689db3e620ffa15cc4
   depends:
@@ -11021,13 +9194,8 @@ packages:
   license: Apache-2.0
   size: 446442
   timestamp: 1732950538361
-- kind: conda
-  name: libarrow-dataset
-  version: 18.1.0
-  build: h5888daf_1_cpu
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-h5888daf_1_cpu.conda
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-h5888daf_1_cpu.conda
   sha256: 7b3db3d5a7e411f8897e8d74403c1d871f3054300f5009c4bdf75da011bc3f42
   md5: 77501831a2aabbaabac55e8cb3b6900a
   depends:
@@ -11041,13 +9209,8 @@ packages:
   license_family: APACHE
   size: 585458
   timestamp: 1732863686753
-- kind: conda
-  name: libarrow-dataset
-  version: 18.1.0
-  build: h605b82c_2_cpu
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.1.0-h605b82c_2_cpu.conda
   build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.1.0-h605b82c_2_cpu.conda
   sha256: eeae9e8d382c482076f4739455b53f16851d7f99be219b6f96dd4e765132b446
   md5: b5fcaddabf47aa15e50feff072a55ada
   depends:
@@ -11059,13 +9222,8 @@ packages:
   license: Apache-2.0
   size: 489769
   timestamp: 1732949732423
-- kind: conda
-  name: libarrow-dataset
-  version: 18.1.0
-  build: hb6457b2_2_cpu
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.1.0-hb6457b2_2_cpu.conda
   build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.1.0-hb6457b2_2_cpu.conda
   sha256: 6fece2e5e0480839ce1408769ec1dbb72ba7220388a65b37ba4cdc8cc0430f31
   md5: a33883871abd3033d5ad4096d977131a
   depends:
@@ -11078,35 +9236,8 @@ packages:
   license: Apache-2.0
   size: 433194
   timestamp: 1732951105863
-- kind: conda
-  name: libarrow-substrait
-  version: 18.1.0
-  build: h30d554c_2_cpu
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.1.0-h30d554c_2_cpu.conda
-  sha256: c936be773ff3c3d87a521e8e53ff2f631474c3a9714a981027236853003c984f
-  md5: ee7c83f7afe66b6ce158632e70c36be2
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libarrow 18.1.0 h0ea94f9_2_cpu
-  - libarrow-acero 18.1.0 hb6457b2_2_cpu
-  - libarrow-dataset 18.1.0 hb6457b2_2_cpu
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.42.34433
-  license: Apache-2.0
-  size: 364194
-  timestamp: 1732951352741
-- kind: conda
-  name: libarrow-substrait
-  version: 18.1.0
-  build: h5c8f2c3_1_cpu
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h5c8f2c3_1_cpu.conda
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h5c8f2c3_1_cpu.conda
   sha256: e77a354bfc0ba7b04c856f1bb16e7b08950bcde54026087bafec46090380fcc1
   md5: 5d47bd2674afd104dbe2f2f3534594b0
   depends:
@@ -11123,13 +9254,8 @@ packages:
   license_family: APACHE
   size: 520681
   timestamp: 1732863726954
-- kind: conda
-  name: libarrow-substrait
-  version: 18.1.0
-  build: h9b432b6_2_cpu
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.1.0-h9b432b6_2_cpu.conda
   build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.1.0-h9b432b6_2_cpu.conda
   sha256: 6dde802134bd2e78581eb838c049b2e7e378899706b471f7072222a6b1284b90
   md5: 49e7c0460532a73f34bd127fff009224
   depends:
@@ -11144,13 +9270,24 @@ packages:
   license: Apache-2.0
   size: 451127
   timestamp: 1732950194322
-- kind: conda
-  name: libavif16
-  version: 1.1.1
-  build: h1909e37_2
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.1.0-h30d554c_2_cpu.conda
   build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
+  sha256: c936be773ff3c3d87a521e8e53ff2f631474c3a9714a981027236853003c984f
+  md5: ee7c83f7afe66b6ce158632e70c36be2
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - libarrow-acero 18.1.0 hb6457b2_2_cpu
+  - libarrow-dataset 18.1.0 hb6457b2_2_cpu
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  size: 364194
+  timestamp: 1732951352741
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
   sha256: e06da844b007a64a9ac35d4e3dc4dbc66583f79b57d08166cf58f2f08723a6e8
   md5: 21e468ed3786ebcb2124b123aa2484b7
   depends:
@@ -11164,13 +9301,7 @@ packages:
   license_family: BSD
   size: 116202
   timestamp: 1730268687453
-- kind: conda
-  name: libavif16
-  version: 1.1.1
-  build: h45b7238_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-h45b7238_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-h45b7238_2.conda
   sha256: c671365e8c822d29b53f20c4573fdbc70f18b50ff9a4b5b2b6b3c8f7ad2ac2a9
   md5: 7571064a60bc193ff5c25f36ed23394a
   depends:
@@ -11183,13 +9314,7 @@ packages:
   license_family: BSD
   size: 96781
   timestamp: 1730268761553
-- kind: conda
-  name: libavif16
-  version: 1.1.1
-  build: h4d049a7_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h4d049a7_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h4d049a7_2.conda
   sha256: f74662ac8325dedbc786bf4f3faef39ad4981739cf0239c2ea2d80c791b04de5
   md5: e7e7405d962ebcb6803f29dc4eabae69
   depends:
@@ -11205,13 +9330,8 @@ packages:
   license_family: BSD
   size: 97828
   timestamp: 1730269135854
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 20_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
   build_number: 20
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
   sha256: 8a0ee1de693a9b3da4a11b95ec81b40dd434bd01fa1f5f38f8268cd2146bf8f0
   md5: 2b7bb4f7562c8cf334fc2e20c2d28abc
   depends:
@@ -11226,34 +9346,8 @@ packages:
   license_family: BSD
   size: 14433
   timestamp: 1700568383457
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 20_osxarm64_openblas
-  build_number: 20
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-20_osxarm64_openblas.conda
-  sha256: 5b5b8394352c8ca06b15dcc9319d0af3e9f1dc03fc0a6f6deef05d664d6b763a
-  md5: 49bc8dec26663241ee064b2d7116ec2d
-  depends:
-  - libopenblas >=0.3.25,<0.3.26.0a0
-  - libopenblas >=0.3.25,<1.0a0
-  constrains:
-  - liblapack 3.9.0 20_osxarm64_openblas
-  - liblapacke 3.9.0 20_osxarm64_openblas
-  - libcblas 3.9.0 20_osxarm64_openblas
-  - blas * openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14722
-  timestamp: 1700568881837
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_linux64_mkl
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_mkl.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_mkl.conda
   sha256: aa3d0151ebe5e89dd82afc1465ad2c95701c3d276dcd06099a6b4fe506ecb5f5
   md5: b77ebfb548eae4d91639e2ca003662c8
   depends:
@@ -11269,13 +9363,8 @@ packages:
   license_family: BSD
   size: 16079
   timestamp: 1729642913956
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
   md5: 8ea26d42ca88ec5258802715fe1ee10b
   depends:
@@ -11290,13 +9379,24 @@ packages:
   license_family: BSD
   size: 15677
   timestamp: 1729642900350
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-20_osxarm64_openblas.conda
+  build_number: 20
+  sha256: 5b5b8394352c8ca06b15dcc9319d0af3e9f1dc03fc0a6f6deef05d664d6b763a
+  md5: 49bc8dec26663241ee064b2d7116ec2d
+  depends:
+  - libopenblas >=0.3.25,<0.3.26.0a0
+  - libopenblas >=0.3.25,<1.0a0
+  constrains:
+  - liblapack 3.9.0 20_osxarm64_openblas
+  - liblapacke 3.9.0 20_osxarm64_openblas
+  - libcblas 3.9.0 20_osxarm64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14722
+  timestamp: 1700568881837
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
   sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
   md5: f8cf4d920ff36ce471619010eff59cac
   depends:
@@ -11311,13 +9411,8 @@ packages:
   license_family: BSD
   size: 15913
   timestamp: 1729643265495
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_win64_blis
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_blis.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_blis.conda
   sha256: 1599fcbef3d856e1d4fd08c5008858f7f4b071931ce51c827cdb4ca9a09c9c86
   md5: ba954c9a0130f688a2df2b1880f09fc9
   depends:
@@ -11331,13 +9426,8 @@ packages:
   license_family: BSD
   size: 1574517
   timestamp: 1729643648425
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
   sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
   md5: 499208e81242efb6e5abc7366c91c816
   depends:
@@ -11351,13 +9441,8 @@ packages:
   license_family: BSD
   size: 3736641
   timestamp: 1729643534444
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_win64_openblas
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_openblas.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_openblas.conda
   sha256: 2105d8084c67f575143284c351c21235d369767a06d5133555373fa6c10dc3b0
   md5: 972ba814d59ce8c06a6be4664de45fa1
   depends:
@@ -11373,13 +9458,26 @@ packages:
   license_family: BSD
   size: 3973491
   timestamp: 1729643650915
-- kind: conda
-  name: libbrotlicommon
-  version: 1.1.0
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 68851
+  timestamp: 1725267660471
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68426
+  timestamp: 1725267943211
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
   sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
   md5: f7dc9a8f21d74eab46456df301da2972
   depends:
@@ -11390,44 +9488,28 @@ packages:
   license_family: MIT
   size: 70526
   timestamp: 1725268159739
-- kind: conda
-  name: libbrotlicommon
-  version: 1.1.0
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
-  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
-  md5: 41b599ed2b02abcfdd84302bff174b23
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
   depends:
   - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 68851
-  timestamp: 1725267660471
-- kind: conda
-  name: libbrotlicommon
-  version: 1.1.0
-  build: hd74edd7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
-  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
-  md5: d0bf1dff146b799b319ea0434b93f779
+  size: 32696
+  timestamp: 1725267669305
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
   depends:
   - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
   license: MIT
   license_family: MIT
-  size: 68426
-  timestamp: 1725267943211
-- kind: conda
-  name: libbrotlidec
-  version: 1.1.0
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  size: 28378
+  timestamp: 1725267980316
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
   sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
   md5: 9bae75ce723fa34e98e239d21d752a7e
   depends:
@@ -11439,46 +9521,28 @@ packages:
   license_family: MIT
   size: 32685
   timestamp: 1725268208844
-- kind: conda
-  name: libbrotlidec
-  version: 1.1.0
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
-  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
-  md5: 9566f0bd264fbd463002e759b8a82401
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
   depends:
   - __glibc >=2.17,<3.0.a0
   - libbrotlicommon 1.1.0 hb9d3cd8_2
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 32696
-  timestamp: 1725267669305
-- kind: conda
-  name: libbrotlidec
-  version: 1.1.0
-  build: hd74edd7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
-  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
-  md5: 55e66e68ce55523a6811633dd1ac74e2
+  size: 281750
+  timestamp: 1725267679782
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
   depends:
   - __osx >=11.0
   - libbrotlicommon 1.1.0 hd74edd7_2
   license: MIT
   license_family: MIT
-  size: 28378
-  timestamp: 1725267980316
-- kind: conda
-  name: libbrotlienc
-  version: 1.1.0
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  size: 279644
+  timestamp: 1725268003553
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
   sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
   md5: 85741a24d97954a991e55e34bc55990b
   depends:
@@ -11490,46 +9554,8 @@ packages:
   license_family: MIT
   size: 245929
   timestamp: 1725268238259
-- kind: conda
-  name: libbrotlienc
-  version: 1.1.0
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
-  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
-  md5: 06f70867945ea6a84d35836af780f1de
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.1.0 hb9d3cd8_2
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 281750
-  timestamp: 1725267679782
-- kind: conda
-  name: libbrotlienc
-  version: 1.1.0
-  build: hd74edd7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
-  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
-  md5: 4f3a434504c67b2c42565c0b85c1885c
-  depends:
-  - __osx >=11.0
-  - libbrotlicommon 1.1.0 hd74edd7_2
-  license: MIT
-  license_family: MIT
-  size: 279644
-  timestamp: 1725268003553
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 20_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
   build_number: 20
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
   sha256: 0e34fb0f82262f02fcb279ab4a1db8d50875dc98e3019452f8f387e6bf3c0247
   md5: 36d486d72ab64ffea932329a1d3729a3
   depends:
@@ -11542,32 +9568,8 @@ packages:
   license_family: BSD
   size: 14383
   timestamp: 1700568410580
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 20_osxarm64_openblas
-  build_number: 20
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-20_osxarm64_openblas.conda
-  sha256: d3a74638f60e034202e373cf2950c69a8d831190d497881d13cbf789434d2489
-  md5: 89f4718753c08afe8cda4dd5791ba94c
-  depends:
-  - libblas 3.9.0 20_osxarm64_openblas
-  constrains:
-  - liblapack 3.9.0 20_osxarm64_openblas
-  - liblapacke 3.9.0 20_osxarm64_openblas
-  - blas * openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14642
-  timestamp: 1700568912840
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_linux64_mkl
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_mkl.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_mkl.conda
   sha256: 987afa03c42202f5c163c53fde16cb5680243bdbf743bef02a5b9e2954c829d5
   md5: e48aeb4ab1a293f621fe995959f1d32f
   depends:
@@ -11582,13 +9584,8 @@ packages:
   license_family: BSD
   size: 15622
   timestamp: 1729642919639
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
   md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
   depends:
@@ -11601,13 +9598,22 @@ packages:
   license_family: BSD
   size: 15613
   timestamp: 1729642905619
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-20_osxarm64_openblas.conda
+  build_number: 20
+  sha256: d3a74638f60e034202e373cf2950c69a8d831190d497881d13cbf789434d2489
+  md5: 89f4718753c08afe8cda4dd5791ba94c
+  depends:
+  - libblas 3.9.0 20_osxarm64_openblas
+  constrains:
+  - liblapack 3.9.0 20_osxarm64_openblas
+  - liblapacke 3.9.0 20_osxarm64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14642
+  timestamp: 1700568912840
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
   sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
   md5: 4df0fae81f0b5bf47d48c882b086da11
   depends:
@@ -11620,13 +9626,8 @@ packages:
   license_family: BSD
   size: 15837
   timestamp: 1729643270793
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_win64_blis
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_blis.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_blis.conda
   sha256: 28c6ec9959e105ed1918f415cf0e6fc86b995b0e4d2a0e3f6abc9d1a9ae24e92
   md5: 887b9efd92ddb95454dfb0bd43fdaabf
   depends:
@@ -11639,13 +9640,8 @@ packages:
   license_family: BSD
   size: 1574484
   timestamp: 1729643665920
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
   sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
   md5: 3ed189ba03a9888a8013aaee0d67c49d
   depends:
@@ -11658,13 +9654,8 @@ packages:
   license_family: BSD
   size: 3732258
   timestamp: 1729643561581
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_win64_openblas
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_openblas.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_openblas.conda
   sha256: c5b4d41c34a28e577511a909cd05b776cc1bac49c1418d57e448f9f586de4c41
   md5: ee5350a8985a792cefa39199d3a9872a
   depends:
@@ -11679,13 +9670,7 @@ packages:
   license_family: BSD
   size: 3970863
   timestamp: 1729643685394
-- kind: conda
-  name: libclang-cpp17
-  version: 17.0.6
-  build: default_h146c034_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
   sha256: 2e338629ae19faae0d1a85543b8c84441ead61957cf69a65c0031d5b18ebac08
   md5: bc6797a6a66ec6f919cc8d4d9285b11c
   depends:
@@ -11696,27 +9681,7 @@ packages:
   license_family: Apache
   size: 12408943
   timestamp: 1725505311206
-- kind: conda
-  name: libcrc32c
-  version: 1.1.2
-  build: h0e60522_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
-  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
-  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25694
-  timestamp: 1633684287072
-- kind: conda
-  name: libcrc32c
-  version: 1.1.2
-  build: h9c3ff4c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
   sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
   md5: c965a5aa0d5c1c37ffc62dff36e28400
   depends:
@@ -11726,12 +9691,7 @@ packages:
   license_family: BSD
   size: 20440
   timestamp: 1633683576494
-- kind: conda
-  name: libcrc32c
-  version: 1.1.2
-  build: hbdafb3b_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
   sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
   md5: 32bd82a6a625ea6ce090a81c3d34edeb
   depends:
@@ -11740,13 +9700,17 @@ packages:
   license_family: BSD
   size: 18765
   timestamp: 1633683992603
-- kind: conda
-  name: libcups
-  version: 2.3.3
-  build: h4637d8d_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
   sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
   md5: d4529f4dff3057982a7617c7ac58fde3
   depends:
@@ -11758,51 +9722,7 @@ packages:
   license_family: Apache
   size: 4519402
   timestamp: 1689195353551
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h13a7ad3_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
-  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
-  md5: d84030d0863ffe7dea00b9a807fee961
-  depends:
-  - __osx >=11.0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 379948
-  timestamp: 1726660033582
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h1ee3ff0_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
-  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
-  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
-  depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: curl
-  license_family: MIT
-  size: 342388
-  timestamp: 1726660508261
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: hbbe4b11_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
   sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
   md5: 6e801c50a40301f6978c53976917b277
   depends:
@@ -11818,12 +9738,36 @@ packages:
   license_family: MIT
   size: 424900
   timestamp: 1726659794676
-- kind: conda
-  name: libcxx
-  version: 19.1.4
-  build: ha82da77_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.4-ha82da77_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.4-ha82da77_0.conda
   sha256: 342896ebc1d6acbf022ca6df006a936b9a472579e91e3c502cb1f52f218b78e9
   md5: a2d3d484d95889fccdd09498d8f6bf9a
   depends:
@@ -11832,13 +9776,7 @@ packages:
   license_family: Apache
   size: 520678
   timestamp: 1732060258949
-- kind: conda
-  name: libcxx-devel
-  version: 17.0.6
-  build: h86353a2_6
-  build_number: 6
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-17.0.6-h86353a2_6.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-17.0.6-h86353a2_6.conda
   sha256: 914cc589f356dfc64ddc4f0dc305fce401356b688730b62e24b4f52358595a58
   md5: 555639d6c7a4c6838cec6e50453fea43
   depends:
@@ -11847,12 +9785,7 @@ packages:
   license_family: Apache
   size: 820887
   timestamp: 1725403726157
-- kind: conda
-  name: libde265
-  version: 1.0.15
-  build: h00ab1b0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
   sha256: 7cf7e294e1a7c8219065885e186d8f52002fb900bf384d815f159b5874204e3d
   md5: 407fee7a5d7ab2dca12c9ca7f62310ad
   depends:
@@ -11862,12 +9795,7 @@ packages:
   license_family: LGPL
   size: 411814
   timestamp: 1703088639063
-- kind: conda
-  name: libde265
-  version: 1.0.15
-  build: h2ffa867_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
   sha256: 13747fa634f7f16d7f222b7d3869e3c1aab9d3a2791edeb2fc632a87663950e0
   md5: 7c718ee6d8497702145612fa0898a12d
   depends:
@@ -11876,12 +9804,7 @@ packages:
   license_family: LGPL
   size: 277861
   timestamp: 1703089176970
-- kind: conda
-  name: libde265
-  version: 1.0.15
-  build: h91493d7_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libde265-1.0.15-h91493d7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libde265-1.0.15-h91493d7_0.conda
   sha256: f52c603151743486d2faec37e161c60731001d9c955e0f12ac9ad334c1119116
   md5: 9dc3c1fbc1c7bc6204e8a603f45e156b
   depends:
@@ -11892,12 +9815,26 @@ packages:
   license_family: LGPL
   size: 252968
   timestamp: 1703089151021
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
   sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
   md5: a3439ce12d4e3cd887270d9436f9a4c8
   depends:
@@ -11908,57 +9845,7 @@ packages:
   license_family: MIT
   size: 155506
   timestamp: 1728177485361
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
-  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
-  md5: b422943d5d772b7cc858b36ad2a92db5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 72242
-  timestamp: 1728177071251
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: hd74edd7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
-  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
-  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 54089
-  timestamp: 1728177149927
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: hc8eb9b7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
-  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
-  md5: 30e4362988a2623e9eb34337b83e01f9
-  depends:
-  - ncurses >=6.2,<7.0.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 96607
-  timestamp: 1597616630749
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
   md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
   depends:
@@ -11968,26 +9855,16 @@ packages:
   license_family: BSD
   size: 123878
   timestamp: 1597616541093
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: h93a5062_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
-  md5: 36d33e440c31857372a72137f78bacf5
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
   license: BSD-2-Clause
   license_family: BSD
-  size: 107458
-  timestamp: 1702146414478
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
   depends:
@@ -11996,13 +9873,24 @@ packages:
   license_family: BSD
   size: 112766
   timestamp: 1702146165126
-- kind: conda
-  name: libevent
-  version: 2.1.12
-  build: h2757513_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
   sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
   md5: 1a109764bff3bdc7bdd84088347d71dc
   depends:
@@ -12011,13 +9899,7 @@ packages:
   license_family: BSD
   size: 368167
   timestamp: 1685726248899
-- kind: conda
-  name: libevent
-  version: 2.1.12
-  build: h3671451_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
   sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
   md5: 25efbd786caceef438be46da78a7b5ef
   depends:
@@ -12029,44 +9911,7 @@ packages:
   license_family: BSD
   size: 410555
   timestamp: 1685726568668
-- kind: conda
-  name: libevent
-  version: 2.1.12
-  build: hf998b51_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
-  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
-  depends:
-  - libgcc-ng >=12
-  - openssl >=3.1.1,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 427426
-  timestamp: 1685725977222
-- kind: conda
-  name: libexpat
-  version: 2.6.4
-  build: h286801f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
-  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
-  md5: 38d2656dd914feb0cab8c629370768bf
-  depends:
-  - __osx >=11.0
-  constrains:
-  - expat 2.6.4.*
-  license: MIT
-  license_family: MIT
-  size: 64693
-  timestamp: 1730967175868
-- kind: conda
-  name: libexpat
-  version: 2.6.4
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
   sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
   md5: db833e03127376d461e1e13e76f09b6c
   depends:
@@ -12078,12 +9923,18 @@ packages:
   license_family: MIT
   size: 73304
   timestamp: 1730967041968
-- kind: conda
-  name: libexpat
-  version: 2.6.4
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
   sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
   md5: eb383771c680aa792feb529eaf9df82f
   depends:
@@ -12096,26 +9947,7 @@ packages:
   license_family: MIT
   size: 139068
   timestamp: 1730967442102
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h3422bc3_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
-  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-  md5: 086914b672be056eb70fd4285b6783b6
-  license: MIT
-  license_family: MIT
-  size: 39020
-  timestamp: 1636488587153
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h7f98852_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
   sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   md5: d645c6d2ac96843a2bfaccd2d62b3ac3
   depends:
@@ -12124,13 +9956,14 @@ packages:
   license_family: MIT
   size: 58292
   timestamp: 1636488182923
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h8ffe710_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
   sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
   md5: 2c96d1b6915b408893f9472569dee135
   depends:
@@ -12140,32 +9973,31 @@ packages:
   license_family: MIT
   size: 42063
   timestamp: 1636489106777
-- kind: conda
-  name: libflang
-  version: 5.0.0
-  build: h6538335_20180525
-  build_number: 20180525
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
   sha256: 0b893b511190332320f4a3e3d6424fbd350271ffbca34eb25b5cd8bc451f1a05
   md5: 9f473a344e18668e99a93f7e21a54b69
   depends:
   - openmp 5.0.0
   - vc >=14,<15.0a0
-  arch: x86_64
-  platform: win
   track_features:
   - flang
   license: Apache 2.0
   size: 531143
   timestamp: 1527899216421
-- kind: conda
-  name: libgcc
-  version: 14.2.0
-  build: h1383e82_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
   sha256: ef840e797714440bb10b69446d815966fff41fdac79f79c4e19c475d81cd375d
   md5: 75fdd34824997a0f9950a703b15d8ac5
   depends:
@@ -12179,33 +10011,7 @@ packages:
   license_family: GPL
   size: 666386
   timestamp: 1729089506769
-- kind: conda
-  name: libgcc
-  version: 14.2.0
-  build: h77fa898_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
-  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
-  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
-  depends:
-  - _libgcc_mutex 0.1 conda_forge
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgomp 14.2.0 h77fa898_1
-  - libgcc-ng ==14.2.0=*_1
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 848745
-  timestamp: 1729027721139
-- kind: conda
-  name: libgcc-devel_linux-64
-  version: 13.3.0
-  build: h84ea5a7_101
-  build_number: 101
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
   sha256: 027cfb011328a108bc44f512a2dec6d954db85709e0b79b748c3392f85de0c64
   md5: 0ce69d40c142915ac9734bc6134e514a
   depends:
@@ -12214,13 +10020,7 @@ packages:
   license_family: GPL
   size: 2598313
   timestamp: 1724801050802
-- kind: conda
-  name: libgcc-ng
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
   sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
@@ -12229,104 +10029,7 @@ packages:
   license_family: GPL
   size: 54142
   timestamp: 1729027726517
-- kind: conda
-  name: libgdal-core
-  version: 3.10.0
-  build: h1476194_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.0-h1476194_2.conda
-  sha256: bc64d2a1baeb66985aff69e0ea0f4a1441ef9ef8d0c3a2ecd548003c74c506b4
-  md5: e79854bb7cddc78aa8d09a15a06da166
-  depends:
-  - __osx >=11.0
-  - blosc >=1.21.6,<2.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - geotiff >=1.7.3,<1.8.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - lerc >=4.0.0,<5.0a0
-  - libarchive >=3.7.7,<3.8.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libcxx >=18
-  - libdeflate >=1.22,<1.23.0a0
-  - libexpat >=2.6.4,<3.0a0
-  - libheif >=1.18.2,<1.19.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxml2 >=2.13.5,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.4.0,<4.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - xerces-c >=3.2.5,<3.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - libgdal 3.10.0.*
-  license: MIT
-  license_family: MIT
-  size: 8481363
-  timestamp: 1732732439438
-- kind: conda
-  name: libgdal-core
-  version: 3.10.0
-  build: hce5bd25_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.0-hce5bd25_2.conda
-  sha256: 576eabc93657dddecd4442b38df4ad1f92661621da31ab22f058e60d437b321c
-  md5: 686c90266552d6b201ffb7f91f82a6f6
-  depends:
-  - blosc >=1.21.6,<2.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - geotiff >=1.7.3,<1.8.0a0
-  - lerc >=4.0.0,<5.0a0
-  - libarchive >=3.7.7,<3.8.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libexpat >=2.6.4,<3.0a0
-  - libheif >=1.18.2,<1.19.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxml2 >=2.13.5,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.4.0,<4.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xerces-c >=3.2.5,<3.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - libgdal 3.10.0.*
-  license: MIT
-  license_family: MIT
-  size: 8423813
-  timestamp: 1732732742395
-- kind: conda
-  name: libgdal-core
-  version: 3.10.0
-  build: hef9eae6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.0-hef9eae6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.0-hef9eae6_2.conda
   sha256: dc8c61317e5235be3e9ee96064cc6f6ca73fdefa27da9afbb65730129a74cd84
   md5: 94ad74bce06086606cfa60c1595bf3bb
   depends:
@@ -12368,28 +10071,86 @@ packages:
   license_family: MIT
   size: 10818538
   timestamp: 1732731493346
-- kind: conda
-  name: libgfortran
-  version: 5.0.0
-  build: 13_2_0_hd922786_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
-  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
-  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.0-h1476194_2.conda
+  sha256: bc64d2a1baeb66985aff69e0ea0f4a1441ef9ef8d0c3a2ecd548003c74c506b4
+  md5: e79854bb7cddc78aa8d09a15a06da166
   depends:
-  - libgfortran5 13.2.0 hf226fd6_3
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 110233
-  timestamp: 1707330749033
-- kind: conda
-  name: libgfortran
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.23.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 8481363
+  timestamp: 1732732439438
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.0-hce5bd25_2.conda
+  sha256: 576eabc93657dddecd4442b38df4ad1f92661621da31ab22f058e60d437b321c
+  md5: 686c90266552d6b201ffb7f91f82a6f6
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 8423813
+  timestamp: 1732732742395
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
   sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
   md5: f1fd30127802683586f768875127a987
   depends:
@@ -12400,13 +10161,16 @@ packages:
   license_family: GPL
   size: 53997
   timestamp: 1729027752995
-- kind: conda
-  name: libgfortran
-  version: 14.2.0
-  build: h719f0c7_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgfortran-14.2.0-h719f0c7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgfortran-14.2.0-h719f0c7_1.conda
   sha256: cfa2c89da3ac55cfeee7bacf40e2244d71f8241c58850496df288efd97c7942a
   md5: bd709ec903eeb030208c78e4c35691d6
   depends:
@@ -12417,13 +10181,7 @@ packages:
   license_family: GPL
   size: 53929
   timestamp: 1729089783355
-- kind: conda
-  name: libgfortran-ng
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
   sha256: 423f1e2403f0c665748e42d335e421e53fd03c08d457cfb6f360d329d9459851
   md5: 0a7f4cd238267c88e5d69f7826a407eb
   depends:
@@ -12432,30 +10190,7 @@ packages:
   license_family: GPL
   size: 54106
   timestamp: 1729027945817
-- kind: conda
-  name: libgfortran5
-  version: 13.2.0
-  build: hf226fd6_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
-  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
-  md5: 66ac81d54e95c534ae488726c1f698ea
-  depends:
-  - llvm-openmp >=8.0.0
-  constrains:
-  - libgfortran 5.0.0 13_2_0_*_3
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 997381
-  timestamp: 1707330687590
-- kind: conda
-  name: libgfortran5
-  version: 14.2.0
-  build: hd5240d6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
   sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
   md5: 9822b874ea29af082e5d36098d25427d
   depends:
@@ -12466,13 +10201,18 @@ packages:
   license_family: GPL
   size: 1462645
   timestamp: 1729027735353
-- kind: conda
-  name: libgfortran5
-  version: 14.2.0
-  build: hf020157_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgfortran5-14.2.0-hf020157_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgfortran5-14.2.0-hf020157_1.conda
   sha256: ee5061b606ca297c42cfcdbbfae5714161878752ea8e032d41c4b9622745f880
   md5: 294a5033b744648a2ba816b34ffd810a
   depends:
@@ -12484,12 +10224,7 @@ packages:
   license_family: GPL
   size: 1704890
   timestamp: 1729089518496
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h2ff4ddf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
   sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
   md5: 13e8e54035ddd2b91875ba399f0f7c04
   depends:
@@ -12504,13 +10239,16 @@ packages:
   license: LGPL-2.1-or-later
   size: 3931898
   timestamp: 1729191404130
-- kind: conda
-  name: libgomp
-  version: 14.2.0
-  build: h1383e82_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
   sha256: d8739b834608f35775209b032f0c2be752ef187863c7ec847afcebe2f681be4e
   md5: 9e2d4d1214df6f21cba12f6eff4972f9
   depends:
@@ -12521,50 +10259,7 @@ packages:
   license_family: GPL
   size: 524249
   timestamp: 1729089441747
-- kind: conda
-  name: libgomp
-  version: 14.2.0
-  build: h77fa898_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
-  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
-  md5: cc3573974587f12dda90d96e3e55a702
-  depends:
-  - _libgcc_mutex 0.1 conda_forge
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 460992
-  timestamp: 1729027639220
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.31.0
-  build: h07d40e7_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
-  sha256: 40d5aa338c0aca8e619c777cc552d19f5810f1408b695c9de8f1dc7e279d8550
-  md5: 94320a551af951938e22e9b5dbd60b50
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgrpc >=1.67.1,<1.68.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libgoogle-cloud 2.31.0 *_0
-  license: Apache-2.0
-  license_family: Apache
-  size: 14474
-  timestamp: 1731122599862
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.31.0
-  build: h804f50b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
   sha256: b2de99c83516236ff591d30436779f8345bcc11bb0ec76a7ca3a38a3b23b6423
   md5: 35ab838423b60f233391eb86d324a830
   depends:
@@ -12583,12 +10278,7 @@ packages:
   license_family: Apache
   size: 1248705
   timestamp: 1731122589027
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.31.0
-  build: h8d8be31_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
   sha256: 184d650d55453a40935c128ea309088ae52e15a68cd87ab17ae7c77704251168
   md5: a338736f1514e6f999db8726fe0965b1
   depends:
@@ -12606,12 +10296,25 @@ packages:
   license_family: Apache
   size: 873497
   timestamp: 1731121684939
-- kind: conda
-  name: libgoogle-cloud-storage
-  version: 2.31.0
-  build: h0121fbd_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+  sha256: 40d5aa338c0aca8e619c777cc552d19f5810f1408b695c9de8f1dc7e279d8550
+  md5: 94320a551af951938e22e9b5dbd60b50
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14474
+  timestamp: 1731122599862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
   sha256: 3c38b0a80441f82323dc5a72b96c0dd7476bd5184fbfcdf825a8e15249c849af
   md5: 568d6a09a6ed76337a7b97c84ae7c0f8
   depends:
@@ -12628,12 +10331,7 @@ packages:
   license_family: Apache
   size: 782150
   timestamp: 1731122728715
-- kind: conda
-  name: libgoogle-cloud-storage
-  version: 2.31.0
-  build: h7081f7f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
   sha256: 01f5156584b816d34270a60a61f6b6561f2a01cb3b4eeb455a4e1808d763d486
   md5: 548fd1d31741ee6b13df4124db4a9f5f
   depends:
@@ -12649,12 +10347,7 @@ packages:
   license_family: Apache
   size: 526858
   timestamp: 1731122580689
-- kind: conda
-  name: libgoogle-cloud-storage
-  version: 2.31.0
-  build: he5eb982_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
   sha256: 0deaba4051d1caec99f2e76bad65979007a01e912eecf8bdd895b5bddb96a085
   md5: 5de1d1089bc7d21b2cbc7273a0c2022d
   depends:
@@ -12670,38 +10363,7 @@ packages:
   license_family: Apache
   size: 14355
   timestamp: 1731122772886
-- kind: conda
-  name: libgrpc
-  version: 1.67.1
-  build: h7aa3b8a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
-  sha256: 986dafe9c3219e88a82389e679a2804d4256aa9ddaead193f91b7d6b4ef89ea1
-  md5: daad5d4a1c24c1afe748afbb83377e43
-  depends:
-  - c-ares >=1.34.2,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libre2-11 >=2024.7.2
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - re2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - grpc-cpp =1.67.1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 17167461
-  timestamp: 1730236510917
-- kind: conda
-  name: libgrpc
-  version: 1.67.1
-  build: hc2c308b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
   sha256: 870550c1faf524e9a695262cd4c31441b18ad542f16893bd3c5dbc93106705f7
   md5: 4606a4647bfe857e3cfe21ca12ac3afb
   depends:
@@ -12722,12 +10384,7 @@ packages:
   license_family: APACHE
   size: 7362336
   timestamp: 1730236333879
-- kind: conda
-  name: libgrpc
-  version: 1.67.1
-  build: hc70892a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
   sha256: d2393fcd3c3584e5d58da4122f48bcf297567d2f6f14b3d1fcbd34fdd5040694
   md5: 624e27571fde34f8acc2afec840ac435
   depends:
@@ -12747,56 +10404,28 @@ packages:
   license_family: APACHE
   size: 4882208
   timestamp: 1730236299095
-- kind: conda
-  name: libheif
-  version: 1.18.2
-  build: gpl_hc631cee_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libheif-1.18.2-gpl_hc631cee_100.conda
-  sha256: 8d7f1a2015d826a14728ddc1c1bb3a5619d15063d6189acb564e4e264f9255ee
-  md5: 4e127b124dcddec36018c97129720671
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+  sha256: 986dafe9c3219e88a82389e679a2804d4256aa9ddaead193f91b7d6b4ef89ea1
+  md5: daad5d4a1c24c1afe748afbb83377e43
   depends:
-  - aom >=3.9.1,<3.10.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - libavif16 >=1.1.1,<2.0a0
-  - libde265 >=1.0.15,<1.0.16.0a0
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - x265 >=3.5,<3.6.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 330638
-  timestamp: 1723121942820
-- kind: conda
-  name: libheif
-  version: 1.18.2
-  build: gpl_he913df3_100
-  build_number: 100
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.18.2-gpl_he913df3_100.conda
-  sha256: 34a70c5889989013b199c6266a30362539af9e24211a6963a0cb0d7ba786f12d
-  md5: 29911afbc2ec42a42914d5255dea52e6
-  depends:
-  - __osx >=11.0
-  - aom >=3.9.1,<3.10.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - libavif16 >=1.1.1,<2.0a0
-  - libcxx >=16
-  - libde265 >=1.0.15,<1.0.16.0a0
-  - x265 >=3.5,<3.6.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 351064
-  timestamp: 1723121589940
-- kind: conda
-  name: libheif
-  version: 1.18.2
-  build: gpl_hffcb242_100
-  build_number: 100
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.18.2-gpl_hffcb242_100.conda
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17167461
+  timestamp: 1730236510917
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.18.2-gpl_hffcb242_100.conda
   sha256: 82af131dc112f4f36ca9226f30a7b1b3e05ed4fb3f85003e8f1af72b6a8e44bc
   md5: 76ac2c07b62d45c192940f010eea11fa
   depends:
@@ -12812,13 +10441,38 @@ packages:
   license_family: LGPL
   size: 428886
   timestamp: 1723121455966
-- kind: conda
-  name: libhwloc
-  version: 2.11.2
-  build: default_h0d58e46_1001
-  build_number: 1001
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.18.2-gpl_he913df3_100.conda
+  sha256: 34a70c5889989013b199c6266a30362539af9e24211a6963a0cb0d7ba786f12d
+  md5: 29911afbc2ec42a42914d5255dea52e6
+  depends:
+  - __osx >=11.0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libcxx >=16
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 351064
+  timestamp: 1723121589940
+- conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.18.2-gpl_hc631cee_100.conda
+  sha256: 8d7f1a2015d826a14728ddc1c1bb3a5619d15063d6189acb564e4e264f9255ee
+  md5: 4e127b124dcddec36018c97129720671
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 330638
+  timestamp: 1723121942820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
   sha256: d14c016482e1409ae1c50109a9ff933460a50940d2682e745ab1c172b5282a69
   md5: 804ca9e91bcaea0824a341d55b1684f2
   depends:
@@ -12830,13 +10484,7 @@ packages:
   license_family: BSD
   size: 2423200
   timestamp: 1731374922090
-- kind: conda
-  name: libhwloc
-  version: 2.11.2
-  build: default_ha69328c_1001
-  build_number: 1001
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
   sha256: 850e255997f538d5fb6ed651321141155a33bb781d43d326fc4ff62114dd2842
   md5: b87a0ac5ab6495d8225db5dc72dd21cd
   depends:
@@ -12849,25 +10497,21 @@ packages:
   license_family: BSD
   size: 2390021
   timestamp: 1731375651179
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: h0d3ecfb_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
   sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
   md5: 69bda57310071cf6d2b86caf11573d2d
   license: LGPL-2.1-only
   size: 676469
   timestamp: 1702682458114
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hcfcfb64_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
   sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
   md5: e1eb10b1cca179f2baa3601e4efc8712
   depends:
@@ -12877,27 +10521,7 @@ packages:
   license: LGPL-2.1-only
   size: 636146
   timestamp: 1702682547199
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
-  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
-  md5: d66573916ffcf376178462f1b61c941e
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  size: 705775
-  timestamp: 1702682170569
-- kind: conda
-  name: libjemalloc-local
-  version: 5.3.0
-  build: h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjemalloc-local-5.3.0-h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjemalloc-local-5.3.0-h5888daf_1.conda
   sha256: 0b0b3d00feb5783c4fd0c22e49111e18a86918ff459fdc3dd418be8119af8770
   md5: 8b9fc24896d9eaafecc758e8b2e823e9
   depends:
@@ -12908,13 +10532,7 @@ packages:
   license_family: BSD
   size: 1500855
   timestamp: 1726817567331
-- kind: conda
-  name: libjemalloc-local
-  version: 5.3.0
-  build: hf9b8971_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjemalloc-local-5.3.0-hf9b8971_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjemalloc-local-5.3.0-hf9b8971_1.conda
   sha256: 349292bfdb38263521b5f42c8a9707b9983306a4e5fd031f7f8f943ba3398924
   md5: 8740a31fcecfa7bfd72deec0dcc2f27a
   depends:
@@ -12924,13 +10542,17 @@ packages:
   license_family: BSD
   size: 186656
   timestamp: 1726817745808
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hb547adb_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
   sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
   md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
   constrains:
@@ -12938,13 +10560,7 @@ packages:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 547541
   timestamp: 1694475104253
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hcfcfb64_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
   sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
   md5: 3f1b948619c45b1ca714d60c7389092c
   depends:
@@ -12956,68 +10572,7 @@ packages:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 822966
   timestamp: 1694475223854
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
-  md5: ea25936bb4080d843790b586850f82b8
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - jpeg <0.0.0a
-  license: IJG AND BSD-3-Clause AND Zlib
-  size: 618575
-  timestamp: 1694474974816
-- kind: conda
-  name: libkml
-  version: 1.3.0
-  build: h538826c_1021
-  build_number: 1021
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
-  sha256: 81a6096a2db500f0c3527ae59398eacca0634c3381559713ab28022d711dd3bd
-  md5: 431ec3b40b041576811641e2d643954e
-  depends:
-  - libexpat >=2.6.2,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - uriparser >=0.9.8,<1.0a0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1651104
-  timestamp: 1724667610262
-- kind: conda
-  name: libkml
-  version: 1.3.0
-  build: he250239_1021
-  build_number: 1021
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
-  sha256: e578ba448489465b8fea743e214272a9fcfccb0d152ba1ff57657aaa76a0cd7d
-  md5: 891bb2a18eaef684f37bd4fb942cd8b2
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libexpat >=2.6.2,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - uriparser >=0.9.8,<1.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 281362
-  timestamp: 1724667138089
-- kind: conda
-  name: libkml
-  version: 1.3.0
-  build: hf539b9f_1021
-  build_number: 1021
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
   sha256: 721c3916d41e052ffd8b60e77f2da6ee47ff0d18babfca48ccf93606f1e0656a
   md5: e8c7620cc49de0c6a2349b6dd6e39beb
   depends:
@@ -13031,13 +10586,35 @@ packages:
   license_family: BSD
   size: 402219
   timestamp: 1724667059411
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 20_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
+  sha256: e578ba448489465b8fea743e214272a9fcfccb0d152ba1ff57657aaa76a0cd7d
+  md5: 891bb2a18eaef684f37bd4fb942cd8b2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281362
+  timestamp: 1724667138089
+- conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
+  sha256: 81a6096a2db500f0c3527ae59398eacca0634c3381559713ab28022d711dd3bd
+  md5: 431ec3b40b041576811641e2d643954e
+  depends:
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - uriparser >=0.9.8,<1.0a0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1651104
+  timestamp: 1724667610262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
   build_number: 20
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
   sha256: ad7745b8d0f2ccb9c3ba7aaa7167d62fc9f02e45eb67172ae5f0dfb5a3b1a2cc
   md5: 6fabc51f5e647d09cc010c40061557e0
   depends:
@@ -13050,32 +10627,8 @@ packages:
   license_family: BSD
   size: 14350
   timestamp: 1700568424034
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 20_osxarm64_openblas
-  build_number: 20
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-20_osxarm64_openblas.conda
-  sha256: e13f79828a7752f6e0a74cbe62df80c551285f6c37de86bc3bd9987c97faca57
-  md5: 1fefac78f2315455ce2d7f34782eac0a
-  depends:
-  - libblas 3.9.0 20_osxarm64_openblas
-  constrains:
-  - liblapacke 3.9.0 20_osxarm64_openblas
-  - libcblas 3.9.0 20_osxarm64_openblas
-  - blas * openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14648
-  timestamp: 1700568930669
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_linux64_mkl
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_mkl.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_mkl.conda
   sha256: e23e7793f27320f1c1294962c5334c0ae5152591bc034e55d009d2de5002798e
   md5: d5afbe3777c594434e4de6481254e99c
   depends:
@@ -13090,13 +10643,8 @@ packages:
   license_family: BSD
   size: 15628
   timestamp: 1729642925339
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
   md5: 4dc03a53fc69371a6158d0ed37214cd3
   depends:
@@ -13109,13 +10657,22 @@ packages:
   license_family: BSD
   size: 15608
   timestamp: 1729642910812
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-20_osxarm64_openblas.conda
+  build_number: 20
+  sha256: e13f79828a7752f6e0a74cbe62df80c551285f6c37de86bc3bd9987c97faca57
+  md5: 1fefac78f2315455ce2d7f34782eac0a
+  depends:
+  - libblas 3.9.0 20_osxarm64_openblas
+  constrains:
+  - liblapacke 3.9.0 20_osxarm64_openblas
+  - libcblas 3.9.0 20_osxarm64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14648
+  timestamp: 1700568930669
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
   sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
   md5: 19bbddfec972d401838330453186108d
   depends:
@@ -13128,13 +10685,8 @@ packages:
   license_family: BSD
   size: 15823
   timestamp: 1729643275943
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
   sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
   md5: f716ef84564c574e8e74ae725f5d5f93
   depends:
@@ -13147,13 +10699,8 @@ packages:
   license_family: BSD
   size: 3736560
   timestamp: 1729643588182
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_win64_openblas
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_openblas.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_openblas.conda
   sha256: 3dd2e57fb0da4218deabee14caa5886d4bef08eaf3af273b15c77a82a62ddb4b
   md5: 6a036cd00efd51283831536792c56f58
   depends:
@@ -13168,13 +10715,8 @@ packages:
   license_family: BSD
   size: 3973640
   timestamp: 1729643717290
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 8_h719fc58_netlib
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-8_h719fc58_netlib.conda
   build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-8_h719fc58_netlib.conda
   sha256: 44e818d47b2969330a701ef165ac384ff9c137e1a4675f2dabffd2ca1c64cbd5
   md5: cfc89f763be8742b4ed54926395e4f69
   depends:
@@ -13188,13 +10730,8 @@ packages:
   license_family: BSD
   size: 2027371
   timestamp: 1731108480269
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_linux64_mkl
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-25_linux64_mkl.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-25_linux64_mkl.conda
   sha256: 522c7cfc7525baf001c28c78978a72b2b24239d17c2176abb0da5769c4103062
   md5: cbddb4169d3d24b13b308403b45f401e
   depends:
@@ -13209,13 +10746,8 @@ packages:
   license_family: BSD
   size: 15627
   timestamp: 1729642931034
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-25_win64_mkl.conda
   sha256: a7a6d417bf963659bdfa6ef6f5604696fb0717f7bed7f594ceb1ceedf7d93d16
   md5: d59fc46f1e1c2f3cf38a08a0a76ffee5
   depends:
@@ -13228,13 +10760,7 @@ packages:
   license_family: BSD
   size: 3736581
   timestamp: 1729643615092
-- kind: conda
-  name: libllvm14
-  version: 14.0.6
-  build: hcd5def8_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
   sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
   md5: 73301c133ded2bf71906aa2104edae8b
   depends:
@@ -13245,13 +10771,7 @@ packages:
   license_family: Apache
   size: 31484415
   timestamp: 1690557554081
-- kind: conda
-  name: libllvm14
-  version: 14.0.6
-  build: hd1a9a77_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
   sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
   md5: 9f3dce5d26ea56a9000cd74c034582bd
   depends:
@@ -13261,13 +10781,7 @@ packages:
   license_family: Apache
   size: 20571387
   timestamp: 1690559110016
-- kind: conda
-  name: libllvm17
-  version: 17.0.6
-  build: h5090b49_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
   sha256: 5829e490e395d85442fb6c7edb0ec18d1a5bb1bc529919a89337d34235205064
   md5: 443b26505722696a9535732bc2a07576
   depends:
@@ -13280,12 +10794,16 @@ packages:
   license_family: Apache
   size: 24612870
   timestamp: 1718320971519
-- kind: conda
-  name: libmpdec
-  version: 4.0.0
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
+  sha256: f7917de9117d3a5fe12a39e185c7ce424f8d5010a6f97b4333e8a1dcb2889d16
+  md5: 7476305c35dd9acef48da8f754eedb40
+  depends:
+  - __osx >=11.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 69263
+  timestamp: 1723817629767
+- conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
   sha256: fc529fc82c7caf51202cc5cec5bb1c2e8d90edbac6d0a4602c966366efe3c7bf
   md5: 74860100b2029e2523cf480804c76b9b
   depends:
@@ -13296,26 +10814,7 @@ packages:
   license_family: BSD
   size: 88657
   timestamp: 1723861474602
-- kind: conda
-  name: libmpdec
-  version: 4.0.0
-  build: h99b78c6_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
-  sha256: f7917de9117d3a5fe12a39e185c7ce424f8d5010a6f97b4333e8a1dcb2889d16
-  md5: 7476305c35dd9acef48da8f754eedb40
-  depends:
-  - __osx >=11.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 69263
-  timestamp: 1723817629767
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: h161d5f1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
   sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
   md5: 19e57602824042dfd0446292ef90488b
   depends:
@@ -13331,12 +10830,7 @@ packages:
   license_family: MIT
   size: 647599
   timestamp: 1729571887612
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: h6d7220d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
   sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
   md5: 3408c02539cee5f1141f9f11450b6a51
   depends:
@@ -13351,12 +10845,7 @@ packages:
   license_family: MIT
   size: 566719
   timestamp: 1729572385640
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
   sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
@@ -13365,30 +10854,7 @@ packages:
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
-- kind: conda
-  name: libopenblas
-  version: 0.3.25
-  build: openmp_h6c19121_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.25-openmp_h6c19121_0.conda
-  sha256: b112e0d500bc0314ea8d393efac3ab8c67857e5a2b345348c98e703ee92723e5
-  md5: a1843550403212b9dedeeb31466ade03
-  depends:
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - llvm-openmp >=16.0.6
-  constrains:
-  - openblas >=0.3.25,<0.3.26.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2896390
-  timestamp: 1700535987588
-- kind: conda
-  name: libopenblas
-  version: 0.3.25
-  build: pthreads_h413a1c8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
   sha256: 628564517895ee1b09cf72c817548bd80ef1acce6a8214a8520d9f7b44c4cfaf
   md5: d172b34a443b95f86089e8229ddc9a17
   depends:
@@ -13401,33 +10867,7 @@ packages:
   license_family: BSD
   size: 5545169
   timestamp: 1700536004164
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: openmp_hf332438_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
-  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
-  md5: 40803a48d947c8639da6704e9a44d3ce
-  depends:
-  - __osx >=11.0
-  - libgfortran 5.*
-  - libgfortran5 >=13.2.0
-  - llvm-openmp >=18.1.8
-  constrains:
-  - openblas >=0.3.28,<0.3.29.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4165774
-  timestamp: 1730772154295
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: pthreads_h94d23a6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
   sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
   md5: 62857b389e42b36b686331bec0922050
   depends:
@@ -13441,12 +10881,34 @@ packages:
   license_family: BSD
   size: 5578513
   timestamp: 1730772671118
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: pthreads_hf0a32cb_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.28-pthreads_hf0a32cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.25-openmp_h6c19121_0.conda
+  sha256: b112e0d500bc0314ea8d393efac3ab8c67857e5a2b345348c98e703ee92723e5
+  md5: a1843550403212b9dedeeb31466ade03
+  depends:
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.25,<0.3.26.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2896390
+  timestamp: 1700535987588
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
+  md5: 40803a48d947c8639da6704e9a44d3ce
+  depends:
+  - __osx >=11.0
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4165774
+  timestamp: 1730772154295
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.28-pthreads_hf0a32cb_0.conda
   sha256: 4574b0f99afb72e248df016443ac5ee4b2b59c22fe73c3cf63540ddda28885bd
   md5: 3a27ab073561e48706ba93ffe1552697
   depends:
@@ -13460,31 +10922,8 @@ packages:
   license_family: BSD
   size: 3975623
   timestamp: 1723935076109
-- kind: conda
-  name: libparquet
-  version: 18.1.0
-  build: h5168bdf_2_cpu
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.1.0-h5168bdf_2_cpu.conda
-  sha256: 454487d113974b923b4214a65aab780fd90c4914390d0b1f4640b1bf60537bff
-  md5: f995df7ee206617a3e858fd932d7bd2d
-  depends:
-  - __osx >=11.0
-  - libarrow 18.1.0 h654e1bb_2_cpu
-  - libcxx >=18
-  - libthrift >=0.21.0,<0.21.1.0a0
-  - openssl >=3.4.0,<4.0a0
-  license: Apache-2.0
-  size: 872333
-  timestamp: 1732949558028
-- kind: conda
-  name: libparquet
-  version: 18.1.0
-  build: h6bd9018_1_cpu
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h6bd9018_1_cpu.conda
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h6bd9018_1_cpu.conda
   sha256: 0df119f4c1a2387d910e132c670b29ee5b29dd79384549de6f1a43067515c8ba
   md5: 1054909202f86e38bbbb7ca1131b8471
   depends:
@@ -13498,13 +10937,21 @@ packages:
   license_family: APACHE
   size: 1203523
   timestamp: 1732863665743
-- kind: conda
-  name: libparquet
-  version: 18.1.0
-  build: he61daf8_2_cpu
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.1.0-h5168bdf_2_cpu.conda
   build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.1.0-he61daf8_2_cpu.conda
+  sha256: 454487d113974b923b4214a65aab780fd90c4914390d0b1f4640b1bf60537bff
+  md5: f995df7ee206617a3e858fd932d7bd2d
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  size: 872333
+  timestamp: 1732949558028
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.1.0-he61daf8_2_cpu.conda
+  build_number: 2
   sha256: 22f314491e7f9fa3241e2ed721184c722f8b7c3bc404927385e1e30cba3d66ee
   md5: a0b4b350dba8924ced639a629c5e3cb4
   depends:
@@ -13517,12 +10964,26 @@ packages:
   license: Apache-2.0
   size: 811713
   timestamp: 1732950983570
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: h3ca93ac_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
   sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
   md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
   depends:
@@ -13533,41 +10994,7 @@ packages:
   license: zlib-acknowledgement
   size: 348933
   timestamp: 1726235196095
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: hadc24fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
-  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
-  md5: f4cc49d7aa68316213e4b12be35308d1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  size: 290661
-  timestamp: 1726234747153
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: hc14010f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
-  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
-  md5: fb36e93f0ea6a6f5d2b99984f34b049e
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  size: 263385
-  timestamp: 1726234714421
-- kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: h5b01275_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
   sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
   md5: ab0bff36363bec94720275a681af8b83
   depends:
@@ -13581,12 +11008,7 @@ packages:
   license_family: BSD
   size: 2945348
   timestamp: 1728565355702
-- kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: h8f0b736_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
   sha256: f732a6fa918428e2d5ba61e78fe11bb44a002cc8f6bb74c94ee5b1297fefcfd8
   md5: d2cb5991f2fb8eb079c80084435e9ce6
   depends:
@@ -13599,12 +11021,7 @@ packages:
   license_family: BSD
   size: 2374965
   timestamp: 1728565334796
-- kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: hcaed137_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
   sha256: 798c6675fb709ceaa6a9bd83e9cffe06bc98e83f519c7d7d881243d2e6d0c34d
   md5: 97c6d2f83edd7b400a22660e2a4d1488
   depends:
@@ -13618,13 +11035,7 @@ packages:
   license_family: BSD
   size: 6033581
   timestamp: 1728565880841
-- kind: conda
-  name: libpysal
-  version: 4.12.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/libpysal-4.12.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libpysal-4.12.1-pyhd8ed1ab_0.conda
   sha256: d1925dc9b9edfc1b01a26cc1b7032b65ca1ab69197d4e275085d2dde82307dfb
   md5: c88ffc80b8c7d51646f4d81c1e0913a5
   depends:
@@ -13643,54 +11054,7 @@ packages:
   license_family: BSD
   size: 2186464
   timestamp: 1725000451863
-- kind: conda
-  name: libre2-11
-  version: 2024.07.02
-  build: h2348fd5_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
-  sha256: 6facca42cfc85a05b33e484a8b0df7857cc092db34806946d022270098d8d20f
-  md5: 5a7065309a66097738be6a06fd04b7ef
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  constrains:
-  - re2 2024.07.02.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 165956
-  timestamp: 1728779107218
-- kind: conda
-  name: libre2-11
-  version: 2024.07.02
-  build: h4eb7d71_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
-  sha256: 39908d18620d48406ea3492bf111eface5b3a88c1a2d166c6d513b03f450df5d
-  md5: d8dbfb066c8e3e85439687613d32057d
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - re2 2024.07.02.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 260860
-  timestamp: 1728779502416
-- kind: conda
-  name: libre2-11
-  version: 2024.07.02
-  build: hbbce691_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
   sha256: f8ad6a4f6d4fd54ebe3e5e712a01e663222fc57f49d16b6b8b10c30990dafb8f
   md5: 2124de47357b7a516c0a3efd8f88c143
   depends:
@@ -13705,13 +11069,36 @@ packages:
   license_family: BSD
   size: 211096
   timestamp: 1728778964655
-- kind: conda
-  name: librttopo
-  version: 1.1.0
-  build: h97f6797_17
-  build_number: 17
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+  sha256: 6facca42cfc85a05b33e484a8b0df7857cc092db34806946d022270098d8d20f
+  md5: 5a7065309a66097738be6a06fd04b7ef
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 165956
+  timestamp: 1728779107218
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+  sha256: 39908d18620d48406ea3492bf111eface5b3a88c1a2d166c6d513b03f450df5d
+  md5: d8dbfb066c8e3e85439687613d32057d
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260860
+  timestamp: 1728779502416
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
   sha256: 1fb8a71bdbc236b8e74f0475887786735d5fa6f5d76d9a4135021279c7ff54b8
   md5: e16e9b1333385c502bf915195f421934
   depends:
@@ -13723,13 +11110,7 @@ packages:
   license_family: GPL
   size: 231770
   timestamp: 1727338518657
-- kind: conda
-  name: librttopo
-  version: 1.1.0
-  build: ha2cf0f4_17
-  build_number: 17
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha2cf0f4_17.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha2cf0f4_17.conda
   sha256: 9ff3162d035a1d9022f6145755a70d0c0ce6c9152792402bc42294354c871a17
   md5: ba729f000ea379b76ed2190119d21e13
   depends:
@@ -13740,13 +11121,7 @@ packages:
   license_family: GPL
   size: 191064
   timestamp: 1727265842691
-- kind: conda
-  name: librttopo
-  version: 1.1.0
-  build: hd4c2148_17
-  build_number: 17
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
   sha256: 0f4a1c8ed579f96ccb73245b4002d7152a2a8ecd05a01d49901c5d280561f766
   md5: 06ea16b8c60b4ce1970c06191f8639d4
   depends:
@@ -13758,13 +11133,7 @@ packages:
   license_family: GPL
   size: 404515
   timestamp: 1727265928370
-- kind: conda
-  name: libsanitizer
-  version: 13.3.0
-  build: heb74ff8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
   sha256: c86d130f0a3099e46ff51aa7ffaab73cb44fc420d27a96076aab3b9a326fc137
   md5: c4cb22f270f501f5c59a122dc2adf20a
   depends:
@@ -13774,12 +11143,7 @@ packages:
   license_family: GPL
   size: 4133922
   timestamp: 1724801171589
-- kind: conda
-  name: libsodium
-  version: 1.0.20
-  build: h4ab18f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
   sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
   md5: a587892d3c13b6621a6091be690dbca2
   depends:
@@ -13787,12 +11151,7 @@ packages:
   license: ISC
   size: 205978
   timestamp: 1716828628198
-- kind: conda
-  name: libsodium
-  version: 1.0.20
-  build: h99b78c6_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
   sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
   md5: a7ce36e284c5faaf93c220dfc39e3abd
   depends:
@@ -13800,12 +11159,7 @@ packages:
   license: ISC
   size: 164972
   timestamp: 1716828607917
-- kind: conda
-  name: libsodium
-  version: 1.0.20
-  build: hc70643c_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
   sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
   md5: 198bb594f202b205c7d18b936fa4524f
   depends:
@@ -13815,13 +11169,7 @@ packages:
   license: ISC
   size: 202344
   timestamp: 1716828757533
-- kind: conda
-  name: libspatialite
-  version: 5.1.0
-  build: h1b4f908_11
-  build_number: 11
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
   sha256: 11d8537d472c5fc25176fda7af6b9aa47f37ba98d0467b77cb713be18ed847ea
   md5: 43a7f3df7d100e8fc280e6636680a870
   depends:
@@ -13842,40 +11190,7 @@ packages:
   license_family: MOZILLA
   size: 4045908
   timestamp: 1727341751247
-- kind: conda
-  name: libspatialite
-  version: 5.1.0
-  build: h939089a_11
-  build_number: 11
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
-  sha256: 76da01457b92be57ac0635cec2681c5423a46252713b144391c14aa0dffe61ba
-  md5: 3ff7b70e2c517f3a43f0b3f87475915a
-  depends:
-  - freexl >=2
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - librttopo >=1.1.0,<1.2.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - sqlite
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  license: MPL-1.1
-  license_family: MOZILLA
-  size: 8293459
-  timestamp: 1727341947641
-- kind: conda
-  name: libspatialite
-  version: 5.1.0
-  build: hffd3212_11
-  build_number: 11
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hffd3212_11.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hffd3212_11.conda
   sha256: 593f50ff3828a2760e7aa131233d9ca410bf5bca764e6eac563a4c5b4a57b2d9
   md5: b8e9d3018a9bb0ddf92d68f19e543604
   depends:
@@ -13896,29 +11211,28 @@ packages:
   license_family: MOZILLA
   size: 2984267
   timestamp: 1727341782874
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: h2466b09_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
-  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
-  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+- conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
+  sha256: 76da01457b92be57ac0635cec2681c5423a46252713b144391c14aa0dffe61ba
+  md5: 3ff7b70e2c517f3a43f0b3f87475915a
   depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  license: Unlicense
-  size: 892175
-  timestamp: 1730208431651
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hadc24fc_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 8293459
+  timestamp: 1727341947641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
   sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
   md5: b6f02b52a174e612e89548f4663ce56a
   depends:
@@ -13928,13 +11242,7 @@ packages:
   license: Unlicense
   size: 875349
   timestamp: 1730208050020
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hbaaea75_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
   sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
   md5: 07a14fbe439eef078cc479deca321161
   depends:
@@ -13943,12 +11251,29 @@ packages:
   license: Unlicense
   size: 837683
   timestamp: 1730208293578
-- kind: conda
-  name: libssh2
-  version: 1.11.1
-  build: h9cc3647_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
+  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 892175
+  timestamp: 1730208431651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+  sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
+  md5: be2de152d8073ef1c01b7728475f2fe7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304278
+  timestamp: 1732349402869
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
   sha256: f7047c6ed44bcaeb04432e8c74da87591940d091b0a3940c0d884b7faa8062e9
   md5: ddc7194676c285513706e5fc64f214d7
   depends:
@@ -13958,12 +11283,7 @@ packages:
   license_family: BSD
   size: 279028
   timestamp: 1732349599461
-- kind: conda
-  name: libssh2
-  version: 1.11.1
-  build: he619c9f_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
   sha256: 4b3256bd2b4e4b3183005d3bd8826d651eccd1a4740b70625afa2b7e7123d191
   md5: af0cbf037dd614c34399b3b3e568c557
   depends:
@@ -13976,30 +11296,7 @@ packages:
   license_family: BSD
   size: 291889
   timestamp: 1732349796504
-- kind: conda
-  name: libssh2
-  version: 1.11.1
-  build: hf672d98_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
-  sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
-  md5: be2de152d8073ef1c01b7728475f2fe7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.4.0,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 304278
-  timestamp: 1732349402869
-- kind: conda
-  name: libstdcxx
-  version: 14.2.0
-  build: hc0a3c3a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
   sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
   md5: 234a5554c53625688d51062645337328
   depends:
@@ -14008,14 +11305,7 @@ packages:
   license_family: GPL
   size: 3893695
   timestamp: 1729027746910
-- kind: conda
-  name: libstdcxx-devel_linux-64
-  version: 13.3.0
-  build: h84ea5a7_101
-  build_number: 101
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-h84ea5a7_101.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-h84ea5a7_101.conda
   sha256: 0a9226c1b994f996229ffb54fa40d608cd4e4b48e8dc73a66134bea8ce949412
   md5: 29b5a4ed4613fa81a07c21045e3f5bf6
   depends:
@@ -14024,13 +11314,7 @@ packages:
   license_family: GPL
   size: 14074676
   timestamp: 1724801075448
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.2.0
-  build: h4852527_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
   sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
   md5: 8371ac6457591af2cf6159439c1fd051
   depends:
@@ -14039,12 +11323,7 @@ packages:
   license_family: GPL
   size: 54105
   timestamp: 1729027780628
-- kind: conda
-  name: libthrift
-  version: 0.21.0
-  build: h0e7cc3e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
   sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
   md5: dcb95c0a98ba9ff737f7ae482aef7833
   depends:
@@ -14058,12 +11337,7 @@ packages:
   license_family: APACHE
   size: 425773
   timestamp: 1727205853307
-- kind: conda
-  name: libthrift
-  version: 0.21.0
-  build: h64651cc_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
   sha256: 7a6c7d5f58cbbc2ccd6493b4b821639fdb0701b9b04c737a949e8cb6adf1c9ad
   md5: 7ce2bd2f650f8c31ad7ba4c7bfea61b7
   depends:
@@ -14076,12 +11350,7 @@ packages:
   license_family: APACHE
   size: 324342
   timestamp: 1727206096912
-- kind: conda
-  name: libthrift
-  version: 0.21.0
-  build: hbe90ef8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
   sha256: 81ca4873ba09055c307f8777fb7d967b5c26291f38095785ae52caed75946488
   md5: 7699570e1f97de7001a7107aabf2d677
   depends:
@@ -14095,13 +11364,7 @@ packages:
   license_family: APACHE
   size: 633857
   timestamp: 1727206429954
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: he137b08_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
   sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
   md5: 63872517c98aa305da58a757c443698e
   depends:
@@ -14118,35 +11381,7 @@ packages:
   license: HPND
   size: 428156
   timestamp: 1728232228989
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hfc51747_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
-  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
-  md5: eac317ed1cc6b9c0af0c27297e364665
-  depends:
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: HPND
-  size: 978865
-  timestamp: 1728232594877
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hfce79cd_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
   sha256: 97ba24c74750b6e731b3fe0d2a751cda6148b4937d2cc3f72d43bf7b3885c39d
   md5: b9abf45f7c64caf3303725f1aa0e9a4d
   depends:
@@ -14162,13 +11397,23 @@ packages:
   license: HPND
   size: 366323
   timestamp: 1728232400072
-- kind: conda
-  name: libutf8proc
-  version: 2.8.0
-  build: hf23e847_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978865
+  timestamp: 1728232594877
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
   sha256: 104cf5b427fc914fec63e55f685a39480abeb4beb34bdbc77dea084c8f5a55cb
   md5: b1aa0faa95017bca11369bd080487ec4
   depends:
@@ -14178,13 +11423,16 @@ packages:
   license_family: MIT
   size: 80852
   timestamp: 1732829699583
-- kind: conda
-  name: libutf8proc
-  version: 2.9.0
-  build: h2466b09_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.9.0-h2466b09_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.9.0-h5505292_1.conda
+  sha256: ea88f06e97ef8fa2490f7594f8885bb542577226edf8abba3144302d951a53c2
+  md5: f777470d31c78cd0abe1903a2fda436f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 83000
+  timestamp: 1732868631531
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.9.0-h2466b09_1.conda
   sha256: 19386d93341d8fa3800033a7555ab00b9fef1db1dbd0a50b6e547b532860b603
   md5: 6f35a14d54f6fe4d013005cf56031842
   depends:
@@ -14195,27 +11443,7 @@ packages:
   license_family: MIT
   size: 84392
   timestamp: 1732868780863
-- kind: conda
-  name: libutf8proc
-  version: 2.9.0
-  build: h5505292_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.9.0-h5505292_1.conda
-  sha256: ea88f06e97ef8fa2490f7594f8885bb542577226edf8abba3144302d951a53c2
-  md5: f777470d31c78cd0abe1903a2fda436f
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 83000
-  timestamp: 1732868631531
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
@@ -14224,12 +11452,18 @@ packages:
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
   sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
   md5: c0af0edfebe780b19940e94871f1a765
   constrains:
@@ -14238,12 +11472,7 @@ packages:
   license_family: BSD
   size: 287750
   timestamp: 1713200194013
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
   sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
   md5: abd61d0ab127ec5cd68f62c2969e6f34
   depends:
@@ -14256,29 +11485,7 @@ packages:
   license_family: BSD
   size: 274359
   timestamp: 1713200524021
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
-  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
-  md5: b26e8aa824079e1be0294e7152ca4559
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - libwebp 1.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 438953
-  timestamp: 1713199854503
-- kind: conda
-  name: libwinpthread
-  version: 12.0.0.r4.gg4f2fc60ca
-  build: h57928b3_8
-  build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
   sha256: 6d5e158813ab8d553fbb0fedd0abe7bf92970b0be3a9ddf12da0f6cbad78f506
   md5: 03cccbba200ee0523bde1f3dad60b1f3
   depends:
@@ -14289,12 +11496,32 @@ packages:
   license: MIT AND BSD-3-Clause-Clear
   size: 35433
   timestamp: 1724681489463
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: h0e4246c_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
   sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
   md5: a69bbf778a462da324489976c84cfc8c
   depends:
@@ -14308,48 +11535,7 @@ packages:
   license_family: MIT
   size: 1208687
   timestamp: 1727279378819
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: h8a09558_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
-  md5: 92ed62436b625154323d40d5f2f11dd7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  size: 395888
-  timestamp: 1727278577118
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: hdb1d25a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
-  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
-  md5: af523aae2eca6dfa1c8eec693f5b9a79
-  depends:
-  - __osx >=11.0
-  - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  size: 323658
-  timestamp: 1727278733917
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
@@ -14357,12 +11543,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 100393
   timestamp: 1702724383534
-- kind: conda
-  name: libxml2
-  version: 2.13.5
-  build: h064dc61_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h064dc61_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h064dc61_0.conda
   sha256: 7ab7fb45a0014981d35247cd5b09057fc8ed3c07378086a6c7ad552915928647
   md5: fb16b85a5be1328ac1c44b098b74c570
   depends:
@@ -14377,49 +11558,7 @@ packages:
   license_family: MIT
   size: 689363
   timestamp: 1731489619071
-- kind: conda
-  name: libxml2
-  version: 2.13.5
-  build: h376fa9f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-h376fa9f_0.conda
-  sha256: d443703d324f3dbd628d58ea498ab0e474c06d5771e7f55baf215fdbc11ceb87
-  md5: adea92805465ed3dcf0776b428e34744
-  depends:
-  - __osx >=11.0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - icu <0.0a0
-  license: MIT
-  license_family: MIT
-  size: 582076
-  timestamp: 1731489850179
-- kind: conda
-  name: libxml2
-  version: 2.13.5
-  build: h442d1da_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
-  sha256: 020466b17c143190bd5a6540be2ceef4c1f8d514408bd5f0adaafcd9d0057b5c
-  md5: 1fbabbec60a3c7c519a5973b06c3b2f4
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 1511585
-  timestamp: 1731489892312
-- kind: conda
-  name: libxml2
-  version: 2.13.5
-  build: hb346dea_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
   sha256: 8c9d6a3a421ac5bf965af495d1b0a08c6fb2245ba156550bc064a7b4f8fc7bd8
   md5: c81a9f1118541aaa418ccb22190c817e
   depends:
@@ -14433,12 +11572,21 @@ packages:
   license_family: MIT
   size: 689626
   timestamp: 1731489608971
-- kind: conda
-  name: libxml2
-  version: 2.13.5
-  build: hbbdcc80_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-hbbdcc80_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-h376fa9f_0.conda
+  sha256: d443703d324f3dbd628d58ea498ab0e474c06d5771e7f55baf215fdbc11ceb87
+  md5: adea92805465ed3dcf0776b428e34744
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 582076
+  timestamp: 1731489850179
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-hbbdcc80_0.conda
   sha256: 936de9c0e91cb6f178c48ea14313cf6c79bdb1f474c785c117c41492b0407a98
   md5: 967d4a9dadd710415ee008d862a07c99
   depends:
@@ -14451,13 +11599,43 @@ packages:
   license_family: MIT
   size: 583082
   timestamp: 1731489765442
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+  sha256: 020466b17c143190bd5a6540be2ceef4c1f8d514408bd5f0adaafcd9d0057b5c
+  md5: 1fbabbec60a3c7c519a5973b06c3b2f4
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1511585
+  timestamp: 1731489892312
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
   sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
   md5: 41fbfac52c601159df6c01f875de31b9
   depends:
@@ -14470,48 +11648,7 @@ packages:
   license_family: Other
   size: 55476
   timestamp: 1727963768015
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h8359307_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
-  md5: 369964e85dc26bfe78f41399b366c435
-  depends:
-  - __osx >=11.0
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 46438
-  timestamp: 1727963202283
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 60963
-  timestamp: 1727963148474
-- kind: conda
-  name: lifelines
-  version: 0.30.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/lifelines-0.30.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/lifelines-0.30.0-pyhd8ed1ab_0.conda
   sha256: 226cf5033ddf1a5a977dd7fa754d06d518f58f4dbdcadbfbc4e9e4768642d91c
   md5: b8d86da95fef6c11135562d2b37ce3e3
   depends:
@@ -14527,13 +11664,7 @@ packages:
   license_family: MIT
   size: 266707
   timestamp: 1730245900323
-- kind: conda
-  name: line_profiler
-  version: 4.1.3
-  build: py312h68727a3_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/line_profiler-4.1.3-py312h68727a3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/line_profiler-4.1.3-py312h68727a3_1.conda
   sha256: f958e9dfcefe8ef1cf42b132b4ee43ce6cf6f59fb0a748230083064aa2e5b39e
   md5: 99138c6ce27e4183895ca935afd33aa4
   depends:
@@ -14549,35 +11680,7 @@ packages:
   license_family: BSD
   size: 161888
   timestamp: 1725450839438
-- kind: conda
-  name: line_profiler
-  version: 4.1.3
-  build: py313h1ec8472_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/line_profiler-4.1.3-py313h1ec8472_1.conda
-  sha256: b9b562635e48a48950a9b70a579d7d22f576a80e65f7f3dd2104bb2a2c225e08
-  md5: 6aa719a02632118432467a9abb4edf51
-  depends:
-  - python >=3.13.0rc1,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - rich >=12.3.0
-  - ipython >=8.14.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 169720
-  timestamp: 1725451310024
-- kind: conda
-  name: line_profiler
-  version: 4.1.3
-  build: py313hf9c7212_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/line_profiler-4.1.3-py313hf9c7212_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/line_profiler-4.1.3-py313hf9c7212_1.conda
   sha256: 7975aecc8d108f0967ff9c816368dd9658ab5bf946e09673d29fb6f179a8a4ca
   md5: 4043af3cfdb3f0461446e930000b5296
   depends:
@@ -14593,24 +11696,29 @@ packages:
   license_family: BSD
   size: 151375
   timestamp: 1725451056999
-- kind: conda
-  name: llvm-meta
-  version: 5.0.0
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/line_profiler-4.1.3-py313h1ec8472_1.conda
+  sha256: b9b562635e48a48950a9b70a579d7d22f576a80e65f7f3dd2104bb2a2c225e08
+  md5: 6aa719a02632118432467a9abb4edf51
+  depends:
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - rich >=12.3.0
+  - ipython >=8.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169720
+  timestamp: 1725451310024
+- conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
   sha256: 090bbeacc3297ff579b53f55ad184f05c30e316fe9d5d7df63df1d2ad4578b79
   md5: 213b5b5ad34008147a824460e50a691c
   license: BSD-3-Clause
   license_family: BSD
   size: 2667
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.4
-  build: h024ca30_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.4-h024ca30_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.4-h024ca30_0.conda
   sha256: 5ef60133379c3146d369672d39729690cf0735116fc1a8b6b32788618199ce17
   md5: 9370a10ba6a13079cc0c0e09d2ec13a8
   depends:
@@ -14621,12 +11729,7 @@ packages:
   license_family: APACHE
   size: 3182956
   timestamp: 1732102390545
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.4
-  build: hdb05f8b_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.4-hdb05f8b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.4-hdb05f8b_0.conda
   sha256: dfdcd8de37899d984326f9734b28f46f80b88c068e44c562933a8b3117f2401a
   md5: 76ca179ec970bea6e275e2fa477c2d3c
   depends:
@@ -14637,13 +11740,7 @@ packages:
   license_family: APACHE
   size: 281554
   timestamp: 1732102484807
-- kind: conda
-  name: llvm-tools
-  version: 17.0.6
-  build: h5090b49_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-17.0.6-h5090b49_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-17.0.6-h5090b49_2.conda
   sha256: a8011fffc1ab3b49f2027fbdba0887e90a2d288240484a4ba4c1b80617522541
   md5: df635fb4c27fc012c0caf53adf61f043
   depends:
@@ -14661,34 +11758,7 @@ packages:
   license_family: Apache
   size: 21864486
   timestamp: 1718321368877
-- kind: conda
-  name: llvmlite
-  version: 0.43.0
-  build: py312h1f7db74_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py312h1f7db74_1.conda
-  sha256: 77e37e8b6223d185e1a3a1dfda5c5d9eb940e4935d06de3bab74c881b69ac873
-  md5: 570a33dbbfdb2f497cac407f41a8e1b7
-  depends:
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - vs2015_runtime
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 17112697
-  timestamp: 1725305550641
-- kind: conda
-  name: llvmlite
-  version: 0.43.0
-  build: py312h374181b_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py312h374181b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py312h374181b_1.conda
   sha256: b260285b29834f9b003e2928d778c19b8ed0ca1aff5aa8aa7ec8f21f9b23c2e4
   md5: ed6ead7e9ab9469629c6cfb363b5c6e2
   depends:
@@ -14703,13 +11773,7 @@ packages:
   license_family: BSD
   size: 3442782
   timestamp: 1725305160474
-- kind: conda
-  name: llvmlite
-  version: 0.43.0
-  build: py312ha9ca408_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py312ha9ca408_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py312ha9ca408_1.conda
   sha256: bd443500b61d770237837f2bdb043f27d789459c0d7036cf2673221c0e2c3238
   md5: f081ee72987624a949a3562020b1135d
   depends:
@@ -14724,13 +11788,22 @@ packages:
   license_family: BSD
   size: 370106
   timestamp: 1725305440993
-- kind: conda
-  name: locket
-  version: 1.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py312h1f7db74_1.conda
+  sha256: 77e37e8b6223d185e1a3a1dfda5c5d9eb940e4935d06de3bab74c881b69ac873
+  md5: 570a33dbbfdb2f497cac407f41a8e1b7
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17112697
+  timestamp: 1725305550641
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
   sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
   md5: 91e27ef3d05cc772ce627e51cff111c4
   depends:
@@ -14739,13 +11812,33 @@ packages:
   license_family: BSD
   size: 8250
   timestamp: 1650660473123
-- kind: conda
-  name: lz4
-  version: 4.3.3
-  build: py312h0608a1d_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py312h0608a1d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py312hb3f7f12_1.conda
+  sha256: ea8151b4f55fa1f9b8d2220c7193c91f545aa15d44415cddbac9ea1f8782c117
+  md5: b99d90ef4e77acdab74828f79705a919
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39432
+  timestamp: 1725089587134
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py312h11d1bbd_1.conda
+  sha256: 592e903be664d4daca335bc8b95f7e092aef0276830a2a7b5962ca7bbca60ee6
+  md5: 4a9eb3dc0ba76484cae3084b99d008e5
+  depends:
+  - __osx >=11.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108178
+  timestamp: 1725089672204
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py312h0608a1d_1.conda
   sha256: 4ebd0ffbe8ce40924459cb3bf1837b5e22bcf3bd0cb807a51795b460878a400a
   md5: 90e9d18bcbfe59ac7d6064a58432f365
   depends:
@@ -14759,64 +11852,7 @@ packages:
   license_family: BSD
   size: 76980
   timestamp: 1725090008004
-- kind: conda
-  name: lz4
-  version: 4.3.3
-  build: py312h11d1bbd_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py312h11d1bbd_1.conda
-  sha256: 592e903be664d4daca335bc8b95f7e092aef0276830a2a7b5962ca7bbca60ee6
-  md5: 4a9eb3dc0ba76484cae3084b99d008e5
-  depends:
-  - __osx >=11.0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 108178
-  timestamp: 1725089672204
-- kind: conda
-  name: lz4
-  version: 4.3.3
-  build: py312hb3f7f12_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py312hb3f7f12_1.conda
-  sha256: ea8151b4f55fa1f9b8d2220c7193c91f545aa15d44415cddbac9ea1f8782c117
-  md5: b99d90ef4e77acdab74828f79705a919
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - lz4-c >=1.9.3,<1.10.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39432
-  timestamp: 1725089587134
-- kind: conda
-  name: lz4-c
-  version: 1.9.4
-  build: hb7217d7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
-  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
-  md5: 45505bec548634f7d05e02fb25262cb9
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 141188
-  timestamp: 1674727268278
-- kind: conda
-  name: lz4-c
-  version: 1.9.4
-  build: hcb278e6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
   sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
   md5: 318b08df404f9c9be5712aaa5a6f0bb0
   depends:
@@ -14826,12 +11862,16 @@ packages:
   license_family: BSD
   size: 143402
   timestamp: 1674727076728
-- kind: conda
-  name: lz4-c
-  version: 1.9.4
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
   sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
   md5: e34720eb20a33fc3bfb8451dd837ab7a
   depends:
@@ -14842,26 +11882,23 @@ packages:
   license_family: BSD
   size: 134235
   timestamp: 1674728465431
-- kind: conda
-  name: lzo
-  version: '2.10'
-  build: h93a5062_1001
-  build_number: 1001
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+  sha256: 88433b98a9dd9da315400e7fb9cd5f70804cb17dca8b1c85163a64f90f584126
+  md5: ec7398d21e2651e0dcb0044d03b9a339
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 171416
+  timestamp: 1713515738503
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
   sha256: b68160b0a8ec374cea12de7afb954ca47419cdc300358232e19cec666d60b929
   md5: 915996063a7380c652f83609e970c2a7
   license: GPL-2.0-or-later
   license_family: GPL2
   size: 131447
   timestamp: 1713516009610
-- kind: conda
-  name: lzo
-  version: '2.10'
-  build: hcfcfb64_1001
-  build_number: 1001
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
   sha256: 39e176b8cc8fe878d87594fae0504c649d1c2c6d5476dd7238237d19eb825751
   md5: 629f4f4e874cf096eb93a23240910cee
   depends:
@@ -14872,28 +11909,7 @@ packages:
   license_family: GPL2
   size: 142771
   timestamp: 1713516312465
-- kind: conda
-  name: lzo
-  version: '2.10'
-  build: hd590300_1001
-  build_number: 1001
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
-  sha256: 88433b98a9dd9da315400e7fb9cd5f70804cb17dca8b1c85163a64f90f584126
-  md5: ec7398d21e2651e0dcb0044d03b9a339
-  depends:
-  - libgcc-ng >=12
-  license: GPL-2.0-or-later
-  license_family: GPL2
-  size: 171416
-  timestamp: 1713515738503
-- kind: conda
-  name: m2w64-gcc-libgfortran
-  version: 5.3.0
-  build: '6'
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
   sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
   md5: 066552ac6b907ec6d72c0ddab29050dc
   depends:
@@ -14902,13 +11918,7 @@ packages:
   license: GPL, LGPL, FDL, custom
   size: 350687
   timestamp: 1608163451316
-- kind: conda
-  name: m2w64-gcc-libs
-  version: 5.3.0
-  build: '7'
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
   sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
   md5: fe759119b8b3bfa720b8762c6fdc35de
   depends:
@@ -14920,13 +11930,7 @@ packages:
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 532390
   timestamp: 1608163512830
-- kind: conda
-  name: m2w64-gcc-libs-core
-  version: 5.3.0
-  build: '7'
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
   sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
   md5: 4289d80fb4d272f1f3b56cfe87ac90bd
   depends:
@@ -14936,13 +11940,7 @@ packages:
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 219240
   timestamp: 1608163481341
-- kind: conda
-  name: m2w64-gmp
-  version: 6.1.0
-  build: '2'
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
   sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
   md5: 53a1c73e1e3d185516d7e3af177596d9
   depends:
@@ -14950,13 +11948,7 @@ packages:
   license: LGPL3
   size: 743501
   timestamp: 1608163782057
-- kind: conda
-  name: m2w64-libwinpthread-git
-  version: 5.0.0.4634.697f757
-  build: '2'
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
   sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
   md5: 774130a326dee16f1ceb05cc687ee4f0
   depends:
@@ -14964,13 +11956,26 @@ packages:
   license: MIT, BSD
   size: 31928
   timestamp: 1608166099896
-- kind: conda
-  name: make
-  version: 4.4.1
-  build: h0e40799_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/make-4.4.1-h0e40799_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+  sha256: d652c7bd4d3b6f82b0f6d063b0d8df6f54cc47531092d7ff008e780f3261bdda
+  md5: 33405d2a66b1411db9f7242c8b97c9e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 513088
+  timestamp: 1727801714848
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/make-4.4.1-hc9fafa5_2.conda
+  sha256: 90ca65e788406d9029ae23ad4bd944a8b5353ad5f59bd6ce326f980cde46f37e
+  md5: 9f44ef1fea0a25d6a3491c58f3af8460
+  depends:
+  - __osx >=11.0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 274048
+  timestamp: 1727801725384
+- conda: https://conda.anaconda.org/conda-forge/win-64/make-4.4.1-h0e40799_2.conda
   sha256: a810cdca3d5fa50d562cda23c0c1195b45ff5f9b0c41e0d4c8c2dd3c043ff4f2
   md5: 77ff648ad9fec660f261aa8ab0949f62
   depends:
@@ -14981,44 +11986,7 @@ packages:
   license_family: GPL
   size: 2176937
   timestamp: 1727802346950
-- kind: conda
-  name: make
-  version: 4.4.1
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
-  sha256: d652c7bd4d3b6f82b0f6d063b0d8df6f54cc47531092d7ff008e780f3261bdda
-  md5: 33405d2a66b1411db9f7242c8b97c9e7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 513088
-  timestamp: 1727801714848
-- kind: conda
-  name: make
-  version: 4.4.1
-  build: hc9fafa5_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/make-4.4.1-hc9fafa5_2.conda
-  sha256: 90ca65e788406d9029ae23ad4bd944a8b5353ad5f59bd6ce326f980cde46f37e
-  md5: 9f44ef1fea0a25d6a3491c58f3af8460
-  depends:
-  - __osx >=11.0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 274048
-  timestamp: 1727801725384
-- kind: conda
-  name: mako
-  version: 1.3.6
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.6-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.6-pyhff2d567_0.conda
   sha256: 58d87748483313d271835db14e136a1f1138e79a30cd726aaeaf949b51a25a93
   md5: bcd0b2d006b1d1b3725a9fa0ad4243f0
   depends:
@@ -15029,13 +11997,7 @@ packages:
   license_family: MIT
   size: 66935
   timestamp: 1731872937527
-- kind: conda
-  name: mapclassify
-  version: 2.8.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_0.conda
   sha256: ce49505ac5c1d2d0bab6543b057c7cf698b0135ef92cd0eb151a41ea09d24c8c
   md5: e75920f936efb86f64517d144d610107
   depends:
@@ -15049,13 +12011,7 @@ packages:
   license_family: BSD
   size: 58204
   timestamp: 1727220839687
-- kind: conda
-  name: markdown-it-py
-  version: 3.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
   md5: 93a8e71256479c62074356ef6ebf501b
   depends:
@@ -15065,12 +12021,7 @@ packages:
   license_family: MIT
   size: 64356
   timestamp: 1686175179621
-- kind: conda
-  name: markupsafe
-  version: 3.0.2
-  build: py312h178313f_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_0.conda
   sha256: 15f14ab429c846aacd47fada0dc4f341d64491e097782830f0906d00cb7b48b6
   md5: a755704ea0e2503f8c227d84829a8e81
   depends:
@@ -15084,12 +12035,35 @@ packages:
   license_family: BSD
   size: 24878
   timestamp: 1729351558563
-- kind: conda
-  name: markupsafe
-  version: 3.0.2
-  build: py312h31fea79_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py312h31fea79_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py312ha0ccf2a_0.conda
+  sha256: 360e958055f35e5087942b9c499eaafae984a951b84cf354ef7481a2806f340d
+  md5: c6ff9f291d011c9d4f0b840f49435c64
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24495
+  timestamp: 1729351534830
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py313heb2b014_0.conda
+  sha256: 749b1f081ba6d327df6056387f54a7b1234e4bce483a809f44ea7882cbba0a0f
+  md5: 6d41ed5825393b6d408bae2c966c391a
+  depends:
+  - __osx >=11.0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24620
+  timestamp: 1729351507962
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py312h31fea79_0.conda
   sha256: eb0f3768890291f2d5fb666ab31b32b37a821e4a30968c6b3cd332472957abe7
   md5: e2ff001440760f2cbac24765d8a3d84a
   depends:
@@ -15104,31 +12078,7 @@ packages:
   license_family: BSD
   size: 27358
   timestamp: 1729351504449
-- kind: conda
-  name: markupsafe
-  version: 3.0.2
-  build: py312ha0ccf2a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py312ha0ccf2a_0.conda
-  sha256: 360e958055f35e5087942b9c499eaafae984a951b84cf354ef7481a2806f340d
-  md5: c6ff9f291d011c9d4f0b840f49435c64
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 24495
-  timestamp: 1729351534830
-- kind: conda
-  name: markupsafe
-  version: 3.0.2
-  build: py313hb4c8b1a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py313hb4c8b1a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py313hb4c8b1a_0.conda
   sha256: 2b7500300aba9726f785781ded5fb1205c76d3047a93cd30868712e1e02f8c6e
   md5: 4ab654528518cea7e94f53af79bd3171
   depends:
@@ -15143,96 +12093,7 @@ packages:
   license_family: BSD
   size: 27813
   timestamp: 1729351491668
-- kind: conda
-  name: markupsafe
-  version: 3.0.2
-  build: py313heb2b014_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py313heb2b014_0.conda
-  sha256: 749b1f081ba6d327df6056387f54a7b1234e4bce483a809f44ea7882cbba0a0f
-  md5: 6d41ed5825393b6d408bae2c966c391a
-  depends:
-  - __osx >=11.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 24620
-  timestamp: 1729351507962
-- kind: conda
-  name: matplotlib-base
-  version: 3.9.2
-  build: py312h90004f6_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py312h90004f6_2.conda
-  sha256: b5594565710754d1f37a5464f194e9baa7e89103292d12d4d63fd4ec0f220a43
-  md5: b9c696b4dda80ff18e95178aa19a6ebc
-  depends:
-  - certifi >=2020.06.20
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
-  - kiwisolver >=1.3.1
-  - numpy >=1.19,<3
-  - numpy >=1.23
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python >=3.12,<3.13.0a0
-  - python-dateutil >=2.7
-  - python_abi 3.12.* *_cp312
-  - qhull >=2020.2,<2020.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: PSF-2.0
-  license_family: PSF
-  size: 7747352
-  timestamp: 1731026164150
-- kind: conda
-  name: matplotlib-base
-  version: 3.9.2
-  build: py312h9bd0bc6_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py312h9bd0bc6_2.conda
-  sha256: 78ffc8f58af8faa583867afb303e18a423d2c6087fc58da0033c35e02c2184d6
-  md5: faf7592748a40887a1a80424f136bf86
-  depends:
-  - __osx >=11.0
-  - certifi >=2020.06.20
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
-  - kiwisolver >=1.3.1
-  - libcxx >=17
-  - numpy >=1.19,<3
-  - numpy >=1.23
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python-dateutil >=2.7
-  - python_abi 3.12.* *_cp312
-  - qhull >=2020.2,<2020.3.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 7786050
-  timestamp: 1731025378750
-- kind: conda
-  name: matplotlib-base
-  version: 3.9.2
-  build: py312hd3ec401_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py312hd3ec401_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py312hd3ec401_2.conda
   sha256: f199be5149f45a14c88d465d9cb83cfba5efe17c45a0233354ef62cdcb7eab9e
   md5: 2380c9ba933ffaac9ad16d8eac8e3318
   depends:
@@ -15259,13 +12120,59 @@ packages:
   license_family: PSF
   size: 7965171
   timestamp: 1731025360821
-- kind: conda
-  name: matplotlib-inline
-  version: 0.1.7
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py312h9bd0bc6_2.conda
+  sha256: 78ffc8f58af8faa583867afb303e18a423d2c6087fc58da0033c35e02c2184d6
+  md5: faf7592748a40887a1a80424f136bf86
+  depends:
+  - __osx >=11.0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.12.* *_cp312
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7786050
+  timestamp: 1731025378750
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py312h90004f6_2.conda
+  sha256: b5594565710754d1f37a5464f194e9baa7e89103292d12d4d63fd4ec0f220a43
+  md5: b9c696b4dda80ff18e95178aa19a6ebc
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.12,<3.13.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.12.* *_cp312
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 7747352
+  timestamp: 1731026164150
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
   sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
   md5: 779345c95648be40d22aaa89de7d4254
   depends:
@@ -15275,13 +12182,7 @@ packages:
   license_family: BSD
   size: 14599
   timestamp: 1713250613726
-- kind: conda
-  name: mdit-py-plugins
-  version: 0.4.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
   sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
   md5: 5387f2cfa28f8a3afa3368bb4ba201e8
   depends:
@@ -15291,13 +12192,7 @@ packages:
   license_family: MIT
   size: 42126
   timestamp: 1725995333692
-- kind: conda
-  name: mdurl
-  version: 0.1.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
   sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
   md5: 776a8dd9e824f77abac30e6ef43a8f7a
   depends:
@@ -15306,13 +12201,7 @@ packages:
   license_family: MIT
   size: 14680
   timestamp: 1704317789138
-- kind: conda
-  name: memory_profiler
-  version: 0.61.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/memory_profiler-0.61.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/memory_profiler-0.61.0-pyhd8ed1ab_0.tar.bz2
   sha256: d1d11b26be1fd8dfe042586d03739f4fec6822ac38158bb7a06ae0d4c24b9f3e
   md5: 8b45f9f2b2f7a98b0ec179c8991a4a9b
   depends:
@@ -15322,13 +12211,7 @@ packages:
   license_family: BSD
   size: 32666
   timestamp: 1668586136439
-- kind: conda
-  name: minio
-  version: 7.2.12
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/minio-7.2.12-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/minio-7.2.12-pyhd8ed1ab_0.conda
   sha256: 5547128d3f06392e339041eb88d00a056bccb40dc349c7afd2f60ee18949906c
   md5: fcac6b6490123199112d88b146cd37fe
   depends:
@@ -15342,53 +12225,7 @@ packages:
   license_family: Apache
   size: 69044
   timestamp: 1732601938996
-- kind: conda
-  name: minizip
-  version: 4.0.6
-  build: hb638d1e_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
-  sha256: b334446aa40fe368ea816f5ee47145aea4408812a5a8d016db51923d7c465835
-  md5: 43e2b972e258a25a1e01790ad0e3287a
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: Zlib
-  license_family: Other
-  size: 85324
-  timestamp: 1717296997985
-- kind: conda
-  name: minizip
-  version: 4.0.7
-  build: h27ee973_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
-  sha256: 8216190bed8462758d1fea34964f4f46e6314e92696d8b6607bde588895663ad
-  md5: 73dcdab1f21da49048a4f26d648c87a9
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libcxx >=16
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.1,<4.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: Zlib
-  license_family: Other
-  size: 77944
-  timestamp: 1718483144234
-- kind: conda
-  name: minizip
-  version: 4.0.7
-  build: h401b404_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
   sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
   md5: 4474532a312b2245c5c77f1176989b46
   depends:
@@ -15404,13 +12241,38 @@ packages:
   license_family: Other
   size: 91409
   timestamp: 1718483022284
-- kind: conda
-  name: mistune
-  version: 3.0.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
+  sha256: 8216190bed8462758d1fea34964f4f46e6314e92696d8b6607bde588895663ad
+  md5: 73dcdab1f21da49048a4f26d648c87a9
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 77944
+  timestamp: 1718483144234
+- conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+  sha256: b334446aa40fe368ea816f5ee47145aea4408812a5a8d016db51923d7c465835
+  md5: 43e2b972e258a25a1e01790ad0e3287a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 85324
+  timestamp: 1717296997985
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
   sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
   md5: 5cbee699846772cc939bef23a0d524ed
   depends:
@@ -15419,29 +12281,7 @@ packages:
   license_family: BSD
   size: 66022
   timestamp: 1698947249750
-- kind: conda
-  name: mkl
-  version: 2024.2.2
-  build: h66d3029_14
-  build_number: 14
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
-  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
-  md5: f011e7cc21918dc9d1efe0209e27fa16
-  depends:
-  - intel-openmp 2024.*
-  - tbb 2021.*
-  license: LicenseRef-IntelSimplifiedSoftwareOct2022
-  license_family: Proprietary
-  size: 103019089
-  timestamp: 1727378392081
-- kind: conda
-  name: mkl
-  version: 2024.2.2
-  build: ha957f24_16
-  build_number: 16
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha957f24_16.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha957f24_16.conda
   sha256: 77906b0acead8f86b489da46f53916e624897338770dbf70b04b8f673c9273c1
   md5: 1459379c79dda834673426504d52b319
   depends:
@@ -15453,29 +12293,17 @@ packages:
   license_family: Proprietary
   size: 124718448
   timestamp: 1730231808335
-- kind: conda
-  name: mkl-devel
-  version: 2024.2.2
-  build: h57928b3_14
-  build_number: 14
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-devel-2024.2.2-h57928b3_14.conda
-  sha256: cf3e0f9606f1ee12d4525e335ad95fcd03981d8a698631fdb529b8c4824ce8a7
-  md5: ecc2c244eff5cb6289b6db5e0401c0aa
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
+  md5: f011e7cc21918dc9d1efe0209e27fa16
   depends:
-  - mkl 2024.2.2 h66d3029_14
-  - mkl-include 2024.2.2 h66d3029_14
+  - intel-openmp 2024.*
+  - tbb 2021.*
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
-  size: 5351834
-  timestamp: 1727378976728
-- kind: conda
-  name: mkl-devel
-  version: 2024.2.2
-  build: ha770c72_16
-  build_number: 16
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2024.2.2-ha770c72_16.conda
+  size: 103019089
+  timestamp: 1727378392081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2024.2.2-ha770c72_16.conda
   sha256: d2c6fb42c36f1ec48fd34192827dee619791b2a4ee73798cbf3cd0e6195ceff4
   md5: 140891ea14285fc634353b31e9e40a95
   depends:
@@ -15485,56 +12313,31 @@ packages:
   license_family: Proprietary
   size: 35857
   timestamp: 1730232581563
-- kind: conda
-  name: mkl-include
-  version: 2024.2.2
-  build: h66d3029_14
-  build_number: 14
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-include-2024.2.2-h66d3029_14.conda
-  sha256: 77b36c1ce29848e43c136aebd5b71521b7607b694404f55468d74ef820f1970d
-  md5: 19e51a50ba5fc6f7421f12fba6d0b775
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-devel-2024.2.2-h57928b3_14.conda
+  sha256: cf3e0f9606f1ee12d4525e335ad95fcd03981d8a698631fdb529b8c4824ce8a7
+  md5: ecc2c244eff5cb6289b6db5e0401c0aa
+  depends:
+  - mkl 2024.2.2 h66d3029_14
+  - mkl-include 2024.2.2 h66d3029_14
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
-  size: 797860
-  timestamp: 1727377855450
-- kind: conda
-  name: mkl-include
-  version: 2024.2.2
-  build: ha957f24_16
-  build_number: 16
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2024.2.2-ha957f24_16.conda
+  size: 5351834
+  timestamp: 1727378976728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2024.2.2-ha957f24_16.conda
   sha256: 4b72b3acd46c69a8fb56d9f5d8240da811820a18be40765df6e2bd8ea859fbc7
   md5: 42b0d14354b5910a9f41e29289914f6b
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   size: 716756
   timestamp: 1730232137421
-- kind: conda
-  name: msgpack-python
-  version: 1.1.0
-  build: py312h6142ec9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py312h6142ec9_0.conda
-  sha256: 2b8c22f8a4e0031c2d6fa81d32814c8afdaf7e7fe2e681bf2369a35ff3eab1fd
-  md5: 0dfc3750cc6bbc463d72c0b727e60d8a
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  size: 90793
-  timestamp: 1725975279147
-- kind: conda
-  name: msgpack-python
-  version: 1.1.0
-  build: py312h68727a3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py312h68727a3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-include-2024.2.2-h66d3029_14.conda
+  sha256: 77b36c1ce29848e43c136aebd5b71521b7607b694404f55468d74ef820f1970d
+  md5: 19e51a50ba5fc6f7421f12fba6d0b775
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 797860
+  timestamp: 1727377855450
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py312h68727a3_0.conda
   sha256: 4bc53333774dea1330643b7e23aa34fd6880275737fc2e07491795872d3af8dd
   md5: 5c9b020a3f86799cdc6115e55df06146
   depends:
@@ -15547,12 +12350,20 @@ packages:
   license_family: Apache
   size: 105271
   timestamp: 1725975182669
-- kind: conda
-  name: msgpack-python
-  version: 1.1.0
-  build: py312hd5eb7cc_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py312hd5eb7cc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py312h6142ec9_0.conda
+  sha256: 2b8c22f8a4e0031c2d6fa81d32814c8afdaf7e7fe2e681bf2369a35ff3eab1fd
+  md5: 0dfc3750cc6bbc463d72c0b727e60d8a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  size: 90793
+  timestamp: 1725975279147
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py312hd5eb7cc_0.conda
   sha256: 3fd45d9c0830e931e34990cb90e88ba53cc7f89fce69fc7d1a8289639d363e85
   md5: ff4f1e63a6438a06d1ab259936e5c2ac
   depends:
@@ -15565,25 +12376,12 @@ packages:
   license_family: Apache
   size: 88169
   timestamp: 1725975418157
-- kind: conda
-  name: msys2-conda-epoch
-  version: '20160418'
-  build: '1'
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
   sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
   md5: b0309b72560df66f71a9d5e34a5efdfa
   size: 3227
   timestamp: 1608166968312
-- kind: conda
-  name: multipledispatch
-  version: 0.6.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
   sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
   md5: 121a57fce7fff0857ec70fa03200962f
   depends:
@@ -15593,13 +12391,7 @@ packages:
   license_family: BSD
   size: 17254
   timestamp: 1721907640382
-- kind: conda
-  name: munkres
-  version: 1.1.4
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
   sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
   md5: 2ba8498c1018c1e9c61eb99b973dfe19
   depends:
@@ -15608,12 +12400,7 @@ packages:
   license_family: Apache
   size: 12452
   timestamp: 1600387789153
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py310ha75aee5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py310ha75aee5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py310ha75aee5_0.conda
   sha256: f27ee5c45bffe2f83a7b5234fdc6d6d4c7433e38989cfa0314738839d5428a67
   md5: 8fefd2dc8dac219c0bde063e08ea849d
   depends:
@@ -15629,12 +12416,130 @@ packages:
   license_family: MIT
   size: 17946771
   timestamp: 1729644508105
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py310ha8f682b_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py310ha8f682b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py311h9ecbd09_0.conda
+  sha256: 460f3eb43160dc9e9a1f2aeabdf8cd809aefcf776c33ffd155f9bd2420a005c5
+  md5: 0111eaad55bea1e607d90d4f84089f74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 18589441
+  timestamp: 1729644798449
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py312h66e93f0_0.conda
+  sha256: fbd1a5ac0e0e0fb16ab65395fb9b6d86aa9fb1e32689df13ee45829294a7ec57
+  md5: 824a5a98260d4ee4d12fcad92d153c47
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 18799862
+  timestamp: 1729644961295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py39h8cd3c5a_0.conda
+  sha256: 4440658ff0b043c4b59972fa087956a51216c826051ec36955b0cefd7b3f11dc
+  md5: 0db34b6e3e37d1f2344fb6a98e967f52
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - tomli >=1.1.0
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 17886162
+  timestamp: 1729645061883
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py310hf9df320_0.conda
+  sha256: d6106053436d24d7244857d783e20e8186599f1b3fbad7e937663c7cd615b985
+  md5: fc8b463ac044ebf3d6f55ccfc5f75d5d
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - tomli >=1.1.0
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 9382045
+  timestamp: 1729644753309
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py311hae2e1ce_0.conda
+  sha256: 23c4fec92c5926baf3fe6ca8c0ad8b3d8ada66786d5b697d6e641d8885ac8ac6
+  md5: 8b3f3c83db062e4970ba7a04890c83d5
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 10035528
+  timestamp: 1729644442917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py312h0bf5046_0.conda
+  sha256: 29ee058cff0242c843452aceb9a04a1ffb79e979bf60134318ade1d6e3d508be
+  md5: a214c5fa30882205c822cc40fdde84f5
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 9891567
+  timestamp: 1729644203196
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py313h63a2874_0.conda
+  sha256: 47219e7f385cc93eb07f491b6c1b8bc1f52a14f272fb71a09bd5ace369e85953
+  md5: f68edfe045fc7832a1ca15ec89d8182c
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 9929683
+  timestamp: 1729644322804
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py39h57695bc_0.conda
+  sha256: d85db5e6ce49f5ae763d441e691dde17775ef5bb8d5fa84a637485533f610077
+  md5: 14f96b04c0eea42bf23057ccb661ba2a
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  - tomli >=1.1.0
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 9255293
+  timestamp: 1729644247950
+- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py310ha8f682b_0.conda
   sha256: ae3303b3b841a13196470fdebe908325690b94b356c8fc556480427d22d6c006
   md5: 5fb3ac99fc40566c8e98b921b13cc636
   depends:
@@ -15651,73 +12556,7 @@ packages:
   license_family: MIT
   size: 9762121
   timestamp: 1729644340764
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py310hf9df320_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py310hf9df320_0.conda
-  sha256: d6106053436d24d7244857d783e20e8186599f1b3fbad7e937663c7cd615b985
-  md5: fc8b463ac044ebf3d6f55ccfc5f75d5d
-  depends:
-  - __osx >=11.0
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - tomli >=1.1.0
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 9382045
-  timestamp: 1729644753309
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py311h9ecbd09_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py311h9ecbd09_0.conda
-  sha256: 460f3eb43160dc9e9a1f2aeabdf8cd809aefcf776c33ffd155f9bd2420a005c5
-  md5: 0111eaad55bea1e607d90d4f84089f74
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 18589441
-  timestamp: 1729644798449
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py311hae2e1ce_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py311hae2e1ce_0.conda
-  sha256: 23c4fec92c5926baf3fe6ca8c0ad8b3d8ada66786d5b697d6e641d8885ac8ac6
-  md5: 8b3f3c83db062e4970ba7a04890c83d5
-  depends:
-  - __osx >=11.0
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 10035528
-  timestamp: 1729644442917
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py311he736701_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py311he736701_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py311he736701_0.conda
   sha256: 64755a058d8c224458632a758c40ec4f23b2c9eb9d8507c41f47236a3deb1da3
   md5: 9b6cea739bd03854b5998cf612363673
   depends:
@@ -15733,32 +12572,7 @@ packages:
   license_family: MIT
   size: 10453140
   timestamp: 1729643961603
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py312h0bf5046_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py312h0bf5046_0.conda
-  sha256: 29ee058cff0242c843452aceb9a04a1ffb79e979bf60134318ade1d6e3d508be
-  md5: a214c5fa30882205c822cc40fdde84f5
-  depends:
-  - __osx >=11.0
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 9891567
-  timestamp: 1729644203196
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py312h4389bb4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py312h4389bb4_0.conda
   sha256: b22c8da3d64137de86e2db64e853f6e7349eb79c1ab356fe0b8fbc21473ec0e4
   md5: 13294c27c75c2f5aa133ee394041f187
   depends:
@@ -15774,52 +12588,7 @@ packages:
   license_family: MIT
   size: 10210508
   timestamp: 1729644157985
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py312h66e93f0_0.conda
-  sha256: fbd1a5ac0e0e0fb16ab65395fb9b6d86aa9fb1e32689df13ee45829294a7ec57
-  md5: 824a5a98260d4ee4d12fcad92d153c47
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 18799862
-  timestamp: 1729644961295
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py313h63a2874_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py313h63a2874_0.conda
-  sha256: 47219e7f385cc93eb07f491b6c1b8bc1f52a14f272fb71a09bd5ace369e85953
-  md5: f68edfe045fc7832a1ca15ec89d8182c
-  depends:
-  - __osx >=11.0
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 9929683
-  timestamp: 1729644322804
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py313ha7868ed_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py313ha7868ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py313ha7868ed_0.conda
   sha256: d6cfe5e927940da760312d16305e4a0013e5be318da2bb893a0f62004db298de
   md5: e432bc642eaf6e36b5e4a3f615e2e91f
   depends:
@@ -15835,54 +12604,7 @@ packages:
   license_family: MIT
   size: 8608743
   timestamp: 1729644175962
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py39h57695bc_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.13.0-py39h57695bc_0.conda
-  sha256: d85db5e6ce49f5ae763d441e691dde17775ef5bb8d5fa84a637485533f610077
-  md5: 14f96b04c0eea42bf23057ccb661ba2a
-  depends:
-  - __osx >=11.0
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  - tomli >=1.1.0
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 9255293
-  timestamp: 1729644247950
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py39h8cd3c5a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py39h8cd3c5a_0.conda
-  sha256: 4440658ff0b043c4b59972fa087956a51216c826051ec36955b0cefd7b3f11dc
-  md5: 0db34b6e3e37d1f2344fb6a98e967f52
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - tomli >=1.1.0
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 17886162
-  timestamp: 1729645061883
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py39ha55e580_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py39ha55e580_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.13.0-py39ha55e580_0.conda
   sha256: 1e3174a6a1b3b667ca8a8ff9d5a1ff25cc510c02d95755aad8597d44a7e0c3a8
   md5: 4511c2818f9cb0b5ec69e108000534b6
   depends:
@@ -15899,13 +12621,7 @@ packages:
   license_family: MIT
   size: 9708721
   timestamp: 1729644247270
-- kind: conda
-  name: mypy_extensions
-  version: 1.0.0
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
   sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
   md5: 4eccaeba205f0aed9ac3a9ea58568ca3
   depends:
@@ -15914,13 +12630,7 @@ packages:
   license_family: MIT
   size: 10492
   timestamp: 1675543414256
-- kind: conda
-  name: narwhals
-  version: 1.15.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.15.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.15.1-pyhd8ed1ab_0.conda
   sha256: a6c40c1347371b0b6d4f8035f610e456ea79ceeb565295d9054499d72c7f0fa7
   md5: aae74cdba80bb8c7dac72fd745fb9285
   depends:
@@ -15928,13 +12638,7 @@ packages:
   license: MIT
   size: 135349
   timestamp: 1733070342006
-- kind: conda
-  name: nbclassic
-  version: 1.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
   sha256: da3330a8ffff1f5b15b558543fbec69e05a48750ed50b53369b93da788abedc5
   md5: 6275b55edf34cfa1f01ba40b699dd915
   depends:
@@ -15947,13 +12651,7 @@ packages:
   license_family: BSD
   size: 5493243
   timestamp: 1716838925077
-- kind: conda
-  name: nbclient
-  version: 0.10.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
   sha256: 564e22c4048f2f00c7ee79417dea364f95cf069a1f2565dc26d5ece1fc3fd779
   md5: 3ee79082e59a28e1db11e2a9c3bcd85a
   depends:
@@ -15966,14 +12664,7 @@ packages:
   license_family: BSD
   size: 27878
   timestamp: 1732882434219
-- kind: conda
-  name: nbconvert
-  version: 7.16.4
-  build: hd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.4-hd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.4-hd8ed1ab_1.conda
   sha256: e014e8a583ca2f2fc751bf9093ee95bfd203bd189bafe0f512c0262fece69bce
   md5: ab83e3b9ca2b111d8f332e9dc8b2170f
   depends:
@@ -15983,14 +12674,7 @@ packages:
   license_family: BSD
   size: 8335
   timestamp: 1718135538730
-- kind: conda
-  name: nbconvert-core
-  version: 7.16.4
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
   sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
   md5: e2d2abb421c13456a9a9f80272fdf543
   depends:
@@ -16018,14 +12702,7 @@ packages:
   license_family: BSD
   size: 189599
   timestamp: 1718135529468
-- kind: conda
-  name: nbconvert-pandoc
-  version: 7.16.4
-  build: hd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.4-hd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.4-hd8ed1ab_1.conda
   sha256: 31df882e97b227e7e57a328a36840e65ea3247023ac2ce502fd5d4b621da8dbe
   md5: 37cec2cf68f4c09563d8bc833791096b
   depends:
@@ -16035,13 +12712,7 @@ packages:
   license_family: BSD
   size: 8371
   timestamp: 1718135533429
-- kind: conda
-  name: nbformat
-  version: 5.10.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
   sha256: 36fe73da4d37bc7ac2d1540526ecd294fbd09acda04e096181ab8f1ccd2b464c
   md5: 0b57b5368ab7fc7cdc9e3511fa867214
   depends:
@@ -16054,13 +12725,7 @@ packages:
   license_family: BSD
   size: 101232
   timestamp: 1712239122969
-- kind: conda
-  name: nbsphinx
-  version: 0.9.5
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbsphinx-0.9.5-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbsphinx-0.9.5-pyhd8ed1ab_0.conda
   sha256: 0fc92fc4e1eab73ce7808b5055c33f319a8949b4ad272fc69ebb96b2f157d5eb
   md5: b808b8a0494c5cca76200c73e260a060
   depends:
@@ -16075,27 +12740,7 @@ packages:
   license_family: MIT
   size: 33725
   timestamp: 1723612159088
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: h7bae524_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
-  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
-  md5: cb2b0ea909b97b3d70cd3921d1445e1a
-  depends:
-  - __osx >=11.0
-  license: X11 AND BSD-3-Clause
-  size: 802321
-  timestamp: 1724658775723
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: he02047a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
   sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
   md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
   depends:
@@ -16104,13 +12749,15 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 889086
   timestamp: 1724658547447
-- kind: conda
-  name: nest-asyncio
-  version: 1.6.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
   sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
   md5: 6598c056f64dc8800d40add25e4e2c34
   depends:
@@ -16119,14 +12766,7 @@ packages:
   license_family: BSD
   size: 11638
   timestamp: 1705850780510
-- kind: conda
-  name: networkx
-  version: 3.4.2
-  build: pyh267e887_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyh267e887_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyh267e887_2.conda
   sha256: 39625cd0c9747fa5c46a9a90683b8997d8b9649881b3dc88336b13b7bdd60117
   md5: fd40bf7f7f4bc4b647dc8512053d9873
   depends:
@@ -16141,13 +12781,7 @@ packages:
   license_family: BSD
   size: 1265008
   timestamp: 1731521053408
-- kind: conda
-  name: nodeenv
-  version: 1.9.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
   sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
   md5: dfe0528d0f1c16c1f7c528ea5536ab30
   depends:
@@ -16157,13 +12791,7 @@ packages:
   license_family: BSD
   size: 34489
   timestamp: 1717585382642
-- kind: conda
-  name: nomkl
-  version: '1.0'
-  build: h5ca1d4c_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
   sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
   md5: 9a66894dfd07c4510beb6b3f9672ccc0
   constrains:
@@ -16172,13 +12800,7 @@ packages:
   license_family: BSD
   size: 3843
   timestamp: 1582593857545
-- kind: conda
-  name: notebook-shim
-  version: 0.2.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
   sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
   md5: 3d85618e2c97ab896b5b5e298d32b5b3
   depends:
@@ -16188,12 +12810,30 @@ packages:
   license_family: BSD
   size: 16880
   timestamp: 1707957948029
-- kind: conda
-  name: numba
-  version: 0.60.0
-  build: py312h41cea2d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py312h41cea2d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py312h83e6fd3_0.conda
+  sha256: af31c1989ddf1cd46f073f32a8150274c606fdc9fced0e4f5aaf0571b97bd09f
+  md5: e064ca33edf91ac117236c4b5dee207a
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5695278
+  timestamp: 1718888170104
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py312h41cea2d_0.conda
   sha256: 2a7597cf215e47f973923ee0403d2b1b37aed4eb611e03628ce31ec08f105037
   md5: deed63e07bfe8494e806baccc9d7fd1b
   depends:
@@ -16218,40 +12858,7 @@ packages:
   license_family: BSD
   size: 5653160
   timestamp: 1718888513922
-- kind: conda
-  name: numba
-  version: 0.60.0
-  build: py312h83e6fd3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py312h83e6fd3_0.conda
-  sha256: af31c1989ddf1cd46f073f32a8150274c606fdc9fced0e4f5aaf0571b97bd09f
-  md5: e064ca33edf91ac117236c4b5dee207a
-  depends:
-  - _openmp_mutex >=4.5
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - llvmlite >=0.43.0,<0.44.0a0
-  - numpy >=1.19,<3
-  - numpy >=1.22.3,<2.1
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - cuda-version >=11.2
-  - tbb >=2021.6.0
-  - cuda-python >=11.6
-  - scipy >=1.0
-  - libopenblas !=0.3.6
-  - cudatoolkit >=11.2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 5695278
-  timestamp: 1718888170104
-- kind: conda
-  name: numba
-  version: 0.60.0
-  build: py312hcccf92d_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py312hcccf92d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py312hcccf92d_0.conda
   sha256: cb2b0dd6ddc65c83dc9fb759b5cdbeb53261e1e3fbaa5415c99493fa73940ece
   md5: 4df11a0943ff8658df9aba7e5de92040
   depends:
@@ -16274,53 +12881,7 @@ packages:
   license_family: BSD
   size: 5677692
   timestamp: 1718888811663
-- kind: conda
-  name: numexpr
-  version: 2.10.0
-  build: py39h4919eaa_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.0-py39h4919eaa_100.conda
-  sha256: cf5b9f92ece436ebb2422dee3861545e2936ac58613c63375ce2a84d214fac03
-  md5: 4d273ca86100b2257d783aafb2e03c77
-  depends:
-  - nomkl
-  - numpy >=1.19,<3
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 127672
-  timestamp: 1716812943880
-- kind: conda
-  name: numexpr
-  version: 2.10.0
-  build: py39h998126f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.0-py39h998126f_0.conda
-  sha256: 8f21c15da95776338ef4738efcb3fadcc6e4d161c1d7f77273b2d1499d670c78
-  md5: 1d91ceb653a8677ef4e0823929a2e31e
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  - numpy >=1.19,<3
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  license: MIT
-  license_family: MIT
-  size: 118431
-  timestamp: 1716812668366
-- kind: conda
-  name: numexpr
-  version: 2.10.0
-  build: py39he85e4be_100
-  build_number: 100
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.0-py39he85e4be_100.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.0-py39he85e4be_100.conda
   sha256: 79006f8ac9626f3a112f94be700f2839f5609dee4e3a06b6e7fa3b804db3eb49
   md5: 8836c415986b35a56957321272fa145f
   depends:
@@ -16334,12 +12895,7 @@ packages:
   license_family: MIT
   size: 134873
   timestamp: 1716812272410
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: mkl_py312hacae085_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-mkl_py312hacae085_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-mkl_py312hacae085_0.conda
   sha256: fc09c3617b1d3396866f23f79bc0614ecbe2966bd55424cf77e697f144fcf191
   md5: 3081b0cb4effa04f7f6e3ab31ff0fef1
   depends:
@@ -16356,12 +12912,175 @@ packages:
   license_family: MIT
   size: 198143
   timestamp: 1732612960325
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: mkl_py313hda4395b_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-mkl_py313hda4395b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py310hdb6e06b_100.conda
+  sha256: 6e30eafa5f9fec9f9fa3733b7475c61edcf262371d00923641c036bba3e6a88d
+  md5: 0d869e0096ccd43eeb3d387f2f65d1a7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - nomkl
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 173175
+  timestamp: 1732612969507
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py311h38b10cd_100.conda
+  sha256: ed8383a500c7c68c5632d0a57b539237b94762d259d681f2473bf2766a7a4247
+  md5: e7fdfe7d8b2e8d594c3d766ee8650a6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - nomkl
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 200575
+  timestamp: 1732612981942
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py312h6a710ac_100.conda
+  sha256: c91a397de5acceb1fcdf6c871ee7da953baf7b826e6d9c0dc2324466f0d7bd01
+  md5: 67bf1e95cdc344f82b990ee422792426
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - nomkl
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  size: 196064
+  timestamp: 1732612943259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py39h0a7e20a_100.conda
+  sha256: bc10e0e5abe0806e8207a52a68dcec251527995359eaab5158b95610710223b6
+  md5: 8e59c93e9f53f010e93b7007a8472684
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - nomkl
+  - numpy >=1.19,<3
+  - numpy >=1.23.0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: MIT
+  license_family: MIT
+  size: 172562
+  timestamp: 1732612906511
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.0-py39h998126f_0.conda
+  sha256: 8f21c15da95776338ef4738efcb3fadcc6e4d161c1d7f77273b2d1499d670c78
+  md5: 1d91ceb653a8677ef4e0823929a2e31e
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - numpy >=1.19,<3
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  license: MIT
+  license_family: MIT
+  size: 118431
+  timestamp: 1716812668366
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py310h5e08031_0.conda
+  sha256: b8c7ec0baa360e3c0abb38b140e2c65afaa45b13f7885e52d36f23dba252834d
+  md5: 41b98ac8d10b9e716e29f2b4b9295df7
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 161288
+  timestamp: 1732613157388
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py311h7469182_0.conda
+  sha256: 5a65af18038e6aa11a97dab099d75eead89ef6223417f19c20b8373404e862f0
+  md5: 506d58d925ab5f62780744ec1ead5f7e
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 187892
+  timestamp: 1732613049200
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py312hbbbb429_0.conda
+  sha256: f82ad4de3ea4dcd01c1ccd59dd7278710d00f20348be2651ce4efc475dcaac2b
+  md5: b02d84bc1dfb80c9651f1625d443737f
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  size: 184003
+  timestamp: 1732613181952
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py313ha6fd940_0.conda
+  sha256: 39ed17031c4809fd79b4d52439ac841218b539f50855dee3165e40a715e5e31a
+  md5: c7096c16a5822ce2a13b6ad14b8e2fb5
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 185097
+  timestamp: 1732613068742
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py39h82972a1_0.conda
+  sha256: 0096d8134f1c6a3ee158a177ce8839b1189a8ffe42e7d2031301cfa3b9716dc0
+  md5: f2661e56c5db36642acb28533a09ee74
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23.0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  license: MIT
+  license_family: MIT
+  size: 160650
+  timestamp: 1732613071382
+- conda: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.0-py39h4919eaa_100.conda
+  sha256: cf5b9f92ece436ebb2422dee3861545e2936ac58613c63375ce2a84d214fac03
+  md5: 4d273ca86100b2257d783aafb2e03c77
+  depends:
+  - nomkl
+  - numpy >=1.19,<3
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 127672
+  timestamp: 1716812943880
+- conda: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-mkl_py313hda4395b_0.conda
   sha256: 0591f99e55144a4c05cde1a54ae167622e22a8e0685a4e1bbbeb92aa8c5dc199
   md5: 237e0cffdc1131303a9b0a1b53a2ca79
   depends:
@@ -16378,33 +13097,7 @@ packages:
   license_family: MIT
   size: 189669
   timestamp: 1732736775419
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py310h5e08031_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py310h5e08031_0.conda
-  sha256: b8c7ec0baa360e3c0abb38b140e2c65afaa45b13f7885e52d36f23dba252834d
-  md5: 41b98ac8d10b9e716e29f2b4b9295df7
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.21,<3
-  - numpy >=1.23.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: MIT
-  license_family: MIT
-  size: 161288
-  timestamp: 1732613157388
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py310hc0c24f9_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py310hc0c24f9_100.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py310hc0c24f9_100.conda
   sha256: 9f5c534ff42d5f68d759713332b4bbc646ccc8901e7f8de15dea43b1f681ec0d
   md5: 81a7d0433dd32a70589c16149f1fb11a
   depends:
@@ -16420,77 +13113,7 @@ packages:
   license_family: MIT
   size: 165875
   timestamp: 1732736783723
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py310hdb6e06b_100
-  build_number: 100
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py310hdb6e06b_100.conda
-  sha256: 6e30eafa5f9fec9f9fa3733b7475c61edcf262371d00923641c036bba3e6a88d
-  md5: 0d869e0096ccd43eeb3d387f2f65d1a7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - nomkl
-  - numpy >=1.21,<3
-  - numpy >=1.23.0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: MIT
-  license_family: MIT
-  size: 173175
-  timestamp: 1732612969507
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py311h38b10cd_100
-  build_number: 100
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py311h38b10cd_100.conda
-  sha256: ed8383a500c7c68c5632d0a57b539237b94762d259d681f2473bf2766a7a4247
-  md5: e7fdfe7d8b2e8d594c3d766ee8650a6c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - nomkl
-  - numpy >=1.21,<3
-  - numpy >=1.23.0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  size: 200575
-  timestamp: 1732612981942
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py311h7469182_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py311h7469182_0.conda
-  sha256: 5a65af18038e6aa11a97dab099d75eead89ef6223417f19c20b8373404e862f0
-  md5: 506d58d925ab5f62780744ec1ead5f7e
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.21,<3
-  - numpy >=1.23.0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  size: 187892
-  timestamp: 1732613049200
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py311hbd35803_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py311hbd35803_100.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py311hbd35803_100.conda
   sha256: 9e4d02133fa6eeeee17d37a823b986c3bc54d04c0a239241ef7a2bb3e871ff94
   md5: 8b929a14e87b8328ec5854abef00e674
   depends:
@@ -16506,13 +13129,7 @@ packages:
   license_family: MIT
   size: 192407
   timestamp: 1732736788241
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py312h4f83d31_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py312h4f83d31_100.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py312h4f83d31_100.conda
   sha256: 7ebd585a8329711625513dd28ea15ef82d3fd315eae31d6b4dbaa36c381d2731
   md5: 3c94a73e3416472ba255b8f1b86adfd6
   depends:
@@ -16528,75 +13145,7 @@ packages:
   license_family: MIT
   size: 188586
   timestamp: 1732737100032
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py312h6a710ac_100
-  build_number: 100
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py312h6a710ac_100.conda
-  sha256: c91a397de5acceb1fcdf6c871ee7da953baf7b826e6d9c0dc2324466f0d7bd01
-  md5: 67bf1e95cdc344f82b990ee422792426
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - nomkl
-  - numpy >=1.21,<3
-  - numpy >=1.23.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 196064
-  timestamp: 1732612943259
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py312hbbbb429_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py312hbbbb429_0.conda
-  sha256: f82ad4de3ea4dcd01c1ccd59dd7278710d00f20348be2651ce4efc475dcaac2b
-  md5: b02d84bc1dfb80c9651f1625d443737f
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.21,<3
-  - numpy >=1.23.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 184003
-  timestamp: 1732613181952
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py313ha6fd940_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py313ha6fd940_0.conda
-  sha256: 39ed17031c4809fd79b4d52439ac841218b539f50855dee3165e40a715e5e31a
-  md5: c7096c16a5822ce2a13b6ad14b8e2fb5
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.21,<3
-  - numpy >=1.23.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 185097
-  timestamp: 1732613068742
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py313had569e0_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py313had569e0_100.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py313had569e0_100.conda
   sha256: 1aa4eb6a26e262e99d94b2bcafe52f53f3336146e781e5e4e6a36916c04a79b3
   md5: 800988f35a6db22d9f6cc552a6f44c02
   depends:
@@ -16612,35 +13161,7 @@ packages:
   license_family: MIT
   size: 190073
   timestamp: 1732736753075
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py39h0a7e20a_100
-  build_number: 100
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py39h0a7e20a_100.conda
-  sha256: bc10e0e5abe0806e8207a52a68dcec251527995359eaab5158b95610710223b6
-  md5: 8e59c93e9f53f010e93b7007a8472684
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - nomkl
-  - numpy >=1.19,<3
-  - numpy >=1.23.0
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: MIT
-  license_family: MIT
-  size: 172562
-  timestamp: 1732612906511
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py39h545706d_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py39h545706d_100.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numexpr-2.10.2-py39h545706d_100.conda
   sha256: 118037f6272583553e763c4a41988e208ae5ab70bae0a622a282b00406ae3e57
   md5: 19c96f603e5f3152d7b3a602be0b5136
   depends:
@@ -16656,76 +13177,7 @@ packages:
   license_family: MIT
   size: 165613
   timestamp: 1732736625608
-- kind: conda
-  name: numexpr
-  version: 2.10.2
-  build: py39h82972a1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py39h82972a1_0.conda
-  sha256: 0096d8134f1c6a3ee158a177ce8839b1189a8ffe42e7d2031301cfa3b9716dc0
-  md5: f2661e56c5db36642acb28533a09ee74
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  - numpy >=1.19,<3
-  - numpy >=1.23.0
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  license: MIT
-  license_family: MIT
-  size: 160650
-  timestamp: 1732613071382
-- kind: conda
-  name: numpy
-  version: 1.22.4
-  build: py39h0948cea_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.22.4-py39h0948cea_0.tar.bz2
-  sha256: 91e1818a00756c8943297097f4d8ff7765172ebed22a29359de2992945e4b72f
-  md5: a3d0bb2b75ee4f923ff520d25cecbe7f
-  depends:
-  - libblas >=3.8.0,<4.0a0
-  - libcblas >=3.8.0,<4.0a0
-  - liblapack >=3.8.0,<4.0a0
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - vc >=14.1,<15
-  - vs2015_runtime >=14.16.27033
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6419736
-  timestamp: 1653326979780
-- kind: conda
-  name: numpy
-  version: 1.22.4
-  build: py39h7df2422_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.22.4-py39h7df2422_0.tar.bz2
-  sha256: 764545697b30257c7d2a38bf775b701e3dceba4a6fc644f2480c05d7409dff0a
-  md5: 859d854797724490cd0f171c35f0c38f
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=13.0.1
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5998159
-  timestamp: 1653326474988
-- kind: conda
-  name: numpy
-  version: 1.22.4
-  build: py39hc58783e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.22.4-py39hc58783e_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.22.4-py39hc58783e_0.tar.bz2
   sha256: 891389d22ed1b81f6c34805a1a9f1506f02a595910f8355b19d2bf6455a46d3d
   md5: a09094871a38a0abec011ec36e742045
   depends:
@@ -16742,57 +13194,7 @@ packages:
   license_family: BSD
   size: 7145497
   timestamp: 1653325654166
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312h8442bc7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
-  sha256: c8841d6d6f61fd70ca80682efbab6bdb8606dc77c68d8acabfbd7c222054f518
-  md5: d83fc83d589e2625a3451c9a7e21047c
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6073136
-  timestamp: 1707226249608
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312h8753938_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
-  sha256: 73570817a5109d396b4ebbe5124a89525959269fd33fa33fd413700289fbe0ef
-  md5: f9ac74c3b07c396014434aca1e58d362
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6495445
-  timestamp: 1707226412944
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312heda63a1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
   sha256: fe3459c75cf84dcef6ef14efcc4adb0ade66038ddd27cadb894f34f4797687d8
   md5: d8285bea2a350f63fab23bf460221f3f
   depends:
@@ -16809,61 +13211,7 @@ packages:
   license_family: BSD
   size: 7484186
   timestamp: 1707225809722
-- kind: conda
-  name: numpy
-  version: 2.0.2
-  build: py39h3ba1154_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py39h3ba1154_1.conda
-  sha256: f5f4b8cad78dd961e763d7850c338004b57dd5fdad2a0bce7da25e2a9bad45cb
-  md5: 786fc37a306970ceee8d3654be4cf936
-  depends:
-  - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=18
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5796232
-  timestamp: 1732314910635
-- kind: conda
-  name: numpy
-  version: 2.0.2
-  build: py39h60232e0_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py39h60232e0_1.conda
-  sha256: 2c007a74ec5d1ee991e8960b527fab8e67dfc81a3676e41adf03acde75a6565b
-  md5: d8801e13476c0ae89e410307fbc5a612
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6325759
-  timestamp: 1732315239998
-- kind: conda
-  name: numpy
-  version: 2.0.2
-  build: py39h9cb892a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py39h9cb892a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py39h9cb892a_1.conda
   sha256: cac3d9a87db5a3b54f8a97c77ee1cf35af6a7f9c725b6911bc5f1d6c6d101637
   md5: be95cf76ebd05d08be67e50e88d3cd49
   depends:
@@ -16881,58 +13229,7 @@ packages:
   license_family: BSD
   size: 7925462
   timestamp: 1732314760363
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py310h1ec8c79_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py310h1ec8c79_0.conda
-  sha256: 5c47cabe3da23a791b6163acbc6ff8c4b4debd6a72e41f9f4f5294738bc3b321
-  md5: 478874a4b6f52f275e71641284343488
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6513869
-  timestamp: 1730588869612
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py310h530be0a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py310h530be0a_0.conda
-  sha256: 006b3a60d912f53c244e2b2a1062b4b092be631191204b2502e1f3e45e7decca
-  md5: 197700c4ca191088c1d47bab613020a4
-  depends:
-  - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=18
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5934307
-  timestamp: 1730588442975
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py310hd6e36ab_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py310hd6e36ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py310hd6e36ab_0.conda
   sha256: f75a5ffd197be7b4f965307770d89234c7ea42431ecd4a72a584a8be29bc3616
   md5: b67f4f02236b75765deec42f5cf2b35b
   depends:
@@ -16950,58 +13247,7 @@ packages:
   license_family: BSD
   size: 7879497
   timestamp: 1730588558893
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py311h35ffc71_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py311h35ffc71_0.conda
-  sha256: 09b0b580e5c4e2eb5dd1b5c44487a274a444d7cc44caced61324a65a8cfa2741
-  md5: aa627d29d5d1ed4192e70cd5a6cb1f4f
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7659216
-  timestamp: 1730588918527
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py311h649a571_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py311h649a571_0.conda
-  sha256: 5a95da4a8de64fb44b0045c92f579d3529b2cccbd5a38ec7901e03ee10f707d5
-  md5: 3205b87adf34406ae1a83e8bf46cd987
-  depends:
-  - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=18
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7041966
-  timestamp: 1730588523973
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py311h71ddf71_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py311h71ddf71_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py311h71ddf71_0.conda
   sha256: d2fdae6b0e80c23248f0f6bf7b5e3b6e0f56f69f420e9f5da5a6aae2c95b1493
   md5: 1b3c543b0cc96310bcf0b825d5a68cb1
   depends:
@@ -17019,35 +13265,7 @@ packages:
   license_family: BSD
   size: 8978113
   timestamp: 1730588531967
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py312h49bc9c5_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py312h49bc9c5_0.conda
-  sha256: f7e6648e2e55de450c8022008eb86158c55786f360aacc91fe3a5a53ba52d5d8
-  md5: 4d03cad3ea6c6cc575f1fd811691432f
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6965471
-  timestamp: 1730589010831
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py312h58c1407_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py312h58c1407_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py312h58c1407_0.conda
   sha256: e4c14f71588a5627a6935d3e7d9ca78a8387229ec8ebc91616b0988ce57ba0dc
   md5: dfdbc12e6d81889ba4c494a23f23eba8
   depends:
@@ -17065,12 +13283,95 @@ packages:
   license_family: BSD
   size: 8388631
   timestamp: 1730588649810
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py312h94ee1e1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py312h94ee1e1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.22.4-py39h7df2422_0.tar.bz2
+  sha256: 764545697b30257c7d2a38bf775b701e3dceba4a6fc644f2480c05d7409dff0a
+  md5: 859d854797724490cd0f171c35f0c38f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=13.0.1
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5998159
+  timestamp: 1653326474988
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
+  sha256: c8841d6d6f61fd70ca80682efbab6bdb8606dc77c68d8acabfbd7c222054f518
+  md5: d83fc83d589e2625a3451c9a7e21047c
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6073136
+  timestamp: 1707226249608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py39h3ba1154_1.conda
+  sha256: f5f4b8cad78dd961e763d7850c338004b57dd5fdad2a0bce7da25e2a9bad45cb
+  md5: 786fc37a306970ceee8d3654be4cf936
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5796232
+  timestamp: 1732314910635
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py310h530be0a_0.conda
+  sha256: 006b3a60d912f53c244e2b2a1062b4b092be631191204b2502e1f3e45e7decca
+  md5: 197700c4ca191088c1d47bab613020a4
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5934307
+  timestamp: 1730588442975
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py311h649a571_0.conda
+  sha256: 5a95da4a8de64fb44b0045c92f579d3529b2cccbd5a38ec7901e03ee10f707d5
+  md5: 3205b87adf34406ae1a83e8bf46cd987
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7041966
+  timestamp: 1730588523973
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py312h94ee1e1_0.conda
   sha256: cd287b6c270ee8af77d200c46d56fdfe1e2a9deeff68044439718b8d073214dd
   md5: a2af54c86582e08718805c69af737897
   depends:
@@ -17088,12 +13389,7 @@ packages:
   license_family: BSD
   size: 6398123
   timestamp: 1730588490904
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py313hca4752e_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py313hca4752e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py313hca4752e_0.conda
   sha256: 3e8bb3474fc90e8c5c1799f4a4e8b887d31b50a0e94fd9f63e2725f7be2e3d4f
   md5: c9d17b236cff44f7a24f19808842ec39
   depends:
@@ -17111,12 +13407,114 @@ packages:
   license_family: BSD
   size: 6468921
   timestamp: 1730588494311
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py313hee8cc43_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py313hee8cc43_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.22.4-py39h0948cea_0.tar.bz2
+  sha256: 91e1818a00756c8943297097f4d8ff7765172ebed22a29359de2992945e4b72f
+  md5: a3d0bb2b75ee4f923ff520d25cecbe7f
+  depends:
+  - libblas >=3.8.0,<4.0a0
+  - libcblas >=3.8.0,<4.0a0
+  - liblapack >=3.8.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6419736
+  timestamp: 1653326979780
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
+  sha256: 73570817a5109d396b4ebbe5124a89525959269fd33fa33fd413700289fbe0ef
+  md5: f9ac74c3b07c396014434aca1e58d362
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6495445
+  timestamp: 1707226412944
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py39h60232e0_1.conda
+  sha256: 2c007a74ec5d1ee991e8960b527fab8e67dfc81a3676e41adf03acde75a6565b
+  md5: d8801e13476c0ae89e410307fbc5a612
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6325759
+  timestamp: 1732315239998
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py310h1ec8c79_0.conda
+  sha256: 5c47cabe3da23a791b6163acbc6ff8c4b4debd6a72e41f9f4f5294738bc3b321
+  md5: 478874a4b6f52f275e71641284343488
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6513869
+  timestamp: 1730588869612
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py311h35ffc71_0.conda
+  sha256: 09b0b580e5c4e2eb5dd1b5c44487a274a444d7cc44caced61324a65a8cfa2741
+  md5: aa627d29d5d1ed4192e70cd5a6cb1f4f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7659216
+  timestamp: 1730588918527
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py312h49bc9c5_0.conda
+  sha256: f7e6648e2e55de450c8022008eb86158c55786f360aacc91fe3a5a53ba52d5d8
+  md5: 4d03cad3ea6c6cc575f1fd811691432f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6965471
+  timestamp: 1730589010831
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py313hee8cc43_0.conda
   sha256: 79b8493c839cd4cc22e2a7024f289067b029ef2b09212973a98a39e5bbeecc03
   md5: 083a90ad306f544f6eeb9ad00c4d9879
   depends:
@@ -17134,12 +13532,7 @@ packages:
   license_family: BSD
   size: 7072965
   timestamp: 1730588905304
-- kind: conda
-  name: openjdk
-  version: 23.0.1
-  build: h4c11d01_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjdk-23.0.1-h4c11d01_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-23.0.1-h4c11d01_0.conda
   sha256: 6bd635175fa826c9365b6a74fccc14921cf741770a07ba4fafaad675e07ed1e2
   md5: c40dda22ec391102c2bc24dd92f1f663
   depends:
@@ -17168,12 +13561,16 @@ packages:
   license_family: GPL
   size: 190125540
   timestamp: 1732940800722
-- kind: conda
-  name: openjdk
-  version: 23.0.1
-  build: hc1507ef_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openjdk-23.0.1-hc1507ef_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-23.0.1-he29190c_0.conda
+  sha256: c1813f1d876bbc66578d289fb96c600e435604667f55785bb79fd59cb11b2d82
+  md5: a6f466c1e3ee0f9a118e2d51abd66a9b
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  license: GPL-2.0-or-later WITH Classpath-exception-2.0
+  license_family: GPL
+  size: 183347721
+  timestamp: 1732937466938
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjdk-23.0.1-hc1507ef_0.conda
   sha256: e5c473f1bfe05cac075e83d6b1c9927d95c30af6485a83b772b25c6f64c35236
   md5: 7f8a50dbb0d5da8dbac71f6f0e25d9c1
   depends:
@@ -17183,26 +13580,32 @@ packages:
   license_family: GPL
   size: 183398849
   timestamp: 1732937753464
-- kind: conda
-  name: openjdk
-  version: 23.0.1
-  build: he29190c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-23.0.1-he29190c_0.conda
-  sha256: c1813f1d876bbc66578d289fb96c600e435604667f55785bb79fd59cb11b2d82
-  md5: a6f466c1e3ee0f9a118e2d51abd66a9b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
   depends:
-  - libzlib >=1.3.1,<2.0a0
-  license: GPL-2.0-or-later WITH Classpath-exception-2.0
-  license_family: GPL
-  size: 183347721
-  timestamp: 1732937466938
-- kind: conda
-  name: openjpeg
-  version: 2.5.2
-  build: h3d672ee_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 341592
+  timestamp: 1709159244431
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+  md5: 5029846003f0bc14414b9128a1f7c84b
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316603
+  timestamp: 1709159627299
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
   sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
   md5: 7e7099ad94ac3b599808950cec30ad4e
   depends:
@@ -17216,48 +13619,7 @@ packages:
   license_family: BSD
   size: 237974
   timestamp: 1709159764160
-- kind: conda
-  name: openjpeg
-  version: 2.5.2
-  build: h488ebb8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
-  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
-  md5: 7f2e286780f072ed750df46dc2631138
-  depends:
-  - libgcc-ng >=12
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.8.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 341592
-  timestamp: 1709159244431
-- kind: conda
-  name: openjpeg
-  version: 2.5.2
-  build: h9f1df11_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
-  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
-  md5: 5029846003f0bc14414b9128a1f7c84b
-  depends:
-  - libcxx >=16
-  - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 316603
-  timestamp: 1709159627299
-- kind: conda
-  name: openml
-  version: 0.14.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/openml-0.14.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/openml-0.14.2-pyhd8ed1ab_0.conda
   sha256: 8e778dfb13f04ab65cc67d043db1a9051f1fbbded988197b7ff5cd1b5cc5fdd2
   md5: f66579391a70ec56dfdb07c8a6f6d6fe
   depends:
@@ -17276,28 +13638,36 @@ packages:
   license_family: BSD
   size: 119232
   timestamp: 1723822072821
-- kind: conda
-  name: openmp
-  version: 5.0.0
-  build: vc14_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
   sha256: 05c19170938b589f59049679d4e0679c98160fecc6fd1bf721b0f4980bd235dd
   md5: 8284c925330fa53668ade00db3c9e787
   depends:
   - llvm-meta 5.0.0|5.0.0.*
   - vc 14.*
-  arch: x86_64
-  platform: win
   license: NCSA
   size: 590466
-- kind: conda
-  name: openssl
-  version: 3.4.0
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2947466
+  timestamp: 1731377666602
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
+  md5: df307bbc703324722df0293c9ca2e418
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2935176
+  timestamp: 1731377561525
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
   sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
   md5: d0d805d9b5524a14efb51b3bff965e83
   depends:
@@ -17309,86 +13679,7 @@ packages:
   license_family: Apache
   size: 8491156
   timestamp: 1731379715927
-- kind: conda
-  name: openssl
-  version: 3.4.0
-  build: h39f12f2_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
-  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
-  md5: df307bbc703324722df0293c9ca2e418
-  depends:
-  - __osx >=11.0
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 2935176
-  timestamp: 1731377561525
-- kind: conda
-  name: openssl
-  version: 3.4.0
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
-  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
-  md5: 23cc74f77eb99315c0360ec3533147a9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc >=13
-  license: Apache-2.0
-  license_family: Apache
-  size: 2947466
-  timestamp: 1731377666602
-- kind: conda
-  name: orc
-  version: 2.0.3
-  build: h121fd32_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
-  sha256: 4759fd0c3f06c035146100e22ee36a312c9a8226654bd2973e9ca9ac5de5cf1f
-  md5: 39995f7406b949c1bef74f0c7277afb3
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.1,<1.3.0a0
-  - tzdata
-  - zstd >=1.5.6,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 438254
-  timestamp: 1731665228473
-- kind: conda
-  name: orc
-  version: 2.0.3
-  build: h34659fe_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
-  sha256: 8baa71790c9899bd7bc0d028ec0dab8180330cb12ecd6600d2b7e0cb78a79a2c
-  md5: 7d0f9831258c59c73b1dcf00b05e8785
-  depends:
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.1,<1.3.0a0
-  - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.6,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 896875
-  timestamp: 1731665181736
-- kind: conda
-  name: orc
-  version: 2.0.3
-  build: he039a57_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
   sha256: 9657ae19d6541fe67a61ef0c26ba1012ec508920b49afa897962c7d4b263ba35
   md5: 052499acd6d6b79952197a13b23e2600
   depends:
@@ -17405,13 +13696,40 @@ packages:
   license_family: Apache
   size: 1187593
   timestamp: 1731664886527
-- kind: conda
-  name: overrides
-  version: 7.7.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+  sha256: 4759fd0c3f06c035146100e22ee36a312c9a8226654bd2973e9ca9ac5de5cf1f
+  md5: 39995f7406b949c1bef74f0c7277afb3
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 438254
+  timestamp: 1731665228473
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+  sha256: 8baa71790c9899bd7bc0d028ec0dab8180330cb12ecd6600d2b7e0cb78a79a2c
+  md5: 7d0f9831258c59c73b1dcf00b05e8785
+  depends:
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896875
+  timestamp: 1731665181736
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
   md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
   depends:
@@ -17421,14 +13739,7 @@ packages:
   license_family: APACHE
   size: 30232
   timestamp: 1706394723472
-- kind: conda
-  name: packaging
-  version: '24.2'
-  build: pyhff2d567_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
   sha256: 74843f871e5cd8a1baf5ed8c406c571139c287141efe532f8ffbdafa3664d244
   md5: 8508b703977f4c4ada34d657d051972c
   depends:
@@ -17437,53 +13748,7 @@ packages:
   license_family: APACHE
   size: 60380
   timestamp: 1731802602808
-- kind: conda
-  name: pandas
-  version: 1.2.5
-  build: py39h2e25243_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-1.2.5-py39h2e25243_0.tar.bz2
-  sha256: 8f1176d78b32362b3da9409b630a3fb90bbb9ea08062321aa5ac5660c34fd83d
-  md5: c4240e4a4019e57927e4df01cf7c6eab
-  depends:
-  - numpy >=1.19.5,<2.0a0
-  - python >=3.9,<3.10.0a0
-  - python-dateutil >=2.7.3
-  - python_abi 3.9.* *_cp39
-  - pytz >=2017.2
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  - setuptools <60.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 10696174
-  timestamp: 1624391985589
-- kind: conda
-  name: pandas
-  version: 1.2.5
-  build: py39h7f752ed_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-1.2.5-py39h7f752ed_0.tar.bz2
-  sha256: b806f5eb4596b629c77a0c793bfd5b99f6bc12e3fa472f71909b89b9c379bba9
-  md5: 4977200d2cd94132bb65aedca5f73d71
-  depends:
-  - libcxx >=11.1.0
-  - numpy >=1.19.5,<2.0a0
-  - python >=3.9,<3.10.0a0
-  - python-dateutil >=2.7.3
-  - python_abi 3.9.* *_cp39
-  - pytz >=2017.2
-  - setuptools <60.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11135664
-  timestamp: 1624391707785
-- kind: conda
-  name: pandas
-  version: 1.2.5
-  build: py39hde0f152_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-1.2.5-py39hde0f152_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-1.2.5-py39hde0f152_0.tar.bz2
   sha256: 2998ce958a78129cc574ce2c19393dabe06b5b3582b8806f066d00a81c20dd9c
   md5: 6a0b9c53c7840b9ac468e46102157090
   depends:
@@ -17499,13 +13764,7 @@ packages:
   license_family: BSD
   size: 12649327
   timestamp: 1624391504087
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py310h5eaa309_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py310h5eaa309_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py310h5eaa309_1.conda
   sha256: d772223fd1ca882717ec6db55a13a6be9439c64ca3532231855ce7834599b8a5
   md5: e67778e1cac3bca3b3300f6164f7ffb9
   depends:
@@ -17523,61 +13782,7 @@ packages:
   license_family: BSD
   size: 13014228
   timestamp: 1726878893275
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py310hb4db72f_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py310hb4db72f_1.conda
-  sha256: 1fa40b4a351f1eb7a878d1f25f6bec71664699cd4a39c8ed5e2221f53ecca0c4
-  md5: 565b3f19282642a23e5ff9bbfb01569c
-  depends:
-  - numpy >=1.19,<3
-  - numpy >=1.22.4
-  - python >=3.10,<3.11.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.10.* *_cp310
-  - pytz >=2020.1,<2024.2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11810567
-  timestamp: 1726879420659
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py310hfd37619_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py310hfd37619_1.conda
-  sha256: f4e4c0016c56089d22850e16c44c7e912d6368fd43374a92d8de6a1da9a85b47
-  md5: 7bc53f11058c93444968c99f1600f73c
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - numpy >=1.19,<3
-  - numpy >=1.22.4
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.10.* *_cp310
-  - pytz >=2020.1,<2024.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 12024352
-  timestamp: 1726878958127
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py311h7db5c69_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
   sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
   md5: 643f8cb35133eb1be4919fb953f0a25f
   depends:
@@ -17595,109 +13800,7 @@ packages:
   license_family: BSD
   size: 15695466
   timestamp: 1726879158862
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py311h9cb3ce9_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
-  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
-  md5: 9ffa9dee175c76e68ea5de5aa1168d83
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - numpy >=1.19,<3
-  - numpy >=1.22.4
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.11.* *_cp311
-  - pytz >=2020.1,<2024.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14807397
-  timestamp: 1726879116250
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py311hcf9f919_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
-  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
-  md5: 5965b8926efba14e6fde98cc8713c083
-  depends:
-  - numpy >=1.19,<3
-  - numpy >=1.22.4
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.11.* *_cp311
-  - pytz >=2020.1,<2024.2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14587131
-  timestamp: 1726879538736
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py312h72972c8_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py312h72972c8_1.conda
-  sha256: dfd30e665b1ced1b783ca303799e250d8acc40943bcefb3a9b2bb13c3b17911c
-  md5: bf6f01c03e0688523d4b5cff8fe8c977
-  depends:
-  - numpy >=1.19,<3
-  - numpy >=1.22.4
-  - python >=3.12,<3.13.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.12.* *_cp312
-  - pytz >=2020.1,<2024.2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14218658
-  timestamp: 1726879426348
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py312hcd31e36_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py312hcd31e36_1.conda
-  sha256: ff0cb54b5d058c7987b4a0984066e893642d1865a7bb695294b6172e2fcdc457
-  md5: c68bfa69e6086c381c74e16fd72613a8
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - numpy >=1.19,<3
-  - numpy >=1.22.4
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.12.* *_cp312
-  - pytz >=2020.1,<2024.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14470437
-  timestamp: 1726878887799
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py312hf9745cd_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_1.conda
   sha256: ad275a83bfebfa8a8fee9b0569aaf6f513ada6a246b2f5d5b85903d8ca61887e
   md5: 8bce4f6caaf8c5448c7ac86d87e26b4b
   depends:
@@ -17715,85 +13818,7 @@ packages:
   license_family: BSD
   size: 15436913
   timestamp: 1726879054912
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py313h47b39a6_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py313h47b39a6_1.conda
-  sha256: b3ca1ad2ba2d43b964e804feeec9f6b737a2ecbe17b932ea6a954ff26a567b5c
-  md5: 59f9c74ce982d17b4534f10b6c1b3b1e
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - numpy >=1.21,<3
-  - numpy >=1.22.4
-  - python >=3.13.0rc2,<3.14.0a0
-  - python >=3.13.0rc2,<3.14.0a0 *_cp313
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.13.* *_cp313
-  - pytz >=2020.1,<2024.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14464446
-  timestamp: 1726878986761
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py313hf91d08e_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py313hf91d08e_1.conda
-  sha256: 8fb218382be188497cbf549eb9de2825195cb076946e1f9929f3758b3f3b4e88
-  md5: 9c6dab4d9b20463121faf04283b4d1a1
-  depends:
-  - numpy >=1.21,<3
-  - numpy >=1.22.4
-  - python >=3.13.0rc2,<3.14.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.13.* *_cp313
-  - pytz >=2020.1,<2024.2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14215159
-  timestamp: 1726879653675
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py39h2366fc2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py39h2366fc2_1.conda
-  sha256: 437444ed75474143f9b2c9ee266abb6ccf6f541c7410c3010b506650594daad4
-  md5: f7dbeb27d9cb9fdfa070b5616a07a6d7
-  depends:
-  - numpy >=1.19,<3
-  - numpy >=1.22.4
-  - python >=3.9,<3.10.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.9.* *_cp39
-  - pytz >=2020.1,<2024.2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11755072
-  timestamp: 1726879299575
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py39h3b40f6f_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py39h3b40f6f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py39h3b40f6f_1.conda
   sha256: 7d9958d3593a1812f439f608b64c776c3328977086c4d108a7a124cb6cf6316a
   md5: d07f482720066758dad87cf90b3de111
   depends:
@@ -17811,13 +13836,94 @@ packages:
   license_family: BSD
   size: 12914056
   timestamp: 1726878901237
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py39hc5ad87a_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py39hc5ad87a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-1.2.5-py39h7f752ed_0.tar.bz2
+  sha256: b806f5eb4596b629c77a0c793bfd5b99f6bc12e3fa472f71909b89b9c379bba9
+  md5: 4977200d2cd94132bb65aedca5f73d71
+  depends:
+  - libcxx >=11.1.0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7.3
+  - python_abi 3.9.* *_cp39
+  - pytz >=2017.2
+  - setuptools <60.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11135664
+  timestamp: 1624391707785
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py310hfd37619_1.conda
+  sha256: f4e4c0016c56089d22850e16c44c7e912d6368fd43374a92d8de6a1da9a85b47
+  md5: 7bc53f11058c93444968c99f1600f73c
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12024352
+  timestamp: 1726878958127
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py312hcd31e36_1.conda
+  sha256: ff0cb54b5d058c7987b4a0984066e893642d1865a7bb695294b6172e2fcdc457
+  md5: c68bfa69e6086c381c74e16fd72613a8
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.12.* *_cp312
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14470437
+  timestamp: 1726878887799
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py313h47b39a6_1.conda
+  sha256: b3ca1ad2ba2d43b964e804feeec9f6b737a2ecbe17b932ea6a954ff26a567b5c
+  md5: 59f9c74ce982d17b4534f10b6c1b3b1e
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.21,<3
+  - numpy >=1.22.4
+  - python >=3.13.0rc2,<3.14.0a0
+  - python >=3.13.0rc2,<3.14.0a0 *_cp313
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.13.* *_cp313
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14464446
+  timestamp: 1726878986761
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py39hc5ad87a_1.conda
   sha256: 627f0ad055d704ad684a1bc42cefa7cb7c5abf1470fd99e751342fb118a1f32e
   md5: 061c07106ef9a22640eecabd2fcf7192
   depends:
@@ -17835,49 +13941,134 @@ packages:
   license_family: BSD
   size: 12034805
   timestamp: 1726878981704
-- kind: conda
-  name: pandoc
-  version: '3.5'
-  build: h57928b3_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.5-h57928b3_0.conda
-  sha256: 2ef7593628529429ab0041128f90e7bb32eb447a05850c40ff178d9ad9df2e9b
-  md5: 2c4a6c475e0f1bbffac672b0943dc520
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 24950852
-  timestamp: 1728196799190
-- kind: conda
-  name: pandoc
-  version: '3.5'
-  build: ha770c72_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.5-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-1.2.5-py39h2e25243_0.tar.bz2
+  sha256: 8f1176d78b32362b3da9409b630a3fb90bbb9ea08062321aa5ac5660c34fd83d
+  md5: c4240e4a4019e57927e4df01cf7c6eab
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7.3
+  - python_abi 3.9.* *_cp39
+  - pytz >=2017.2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  - setuptools <60.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10696174
+  timestamp: 1624391985589
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py310hb4db72f_1.conda
+  sha256: 1fa40b4a351f1eb7a878d1f25f6bec71664699cd4a39c8ed5e2221f53ecca0c4
+  md5: 565b3f19282642a23e5ff9bbfb01569c
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11810567
+  timestamp: 1726879420659
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py312h72972c8_1.conda
+  sha256: dfd30e665b1ced1b783ca303799e250d8acc40943bcefb3a9b2bb13c3b17911c
+  md5: bf6f01c03e0688523d4b5cff8fe8c977
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.12,<3.13.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.12.* *_cp312
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14218658
+  timestamp: 1726879426348
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py313hf91d08e_1.conda
+  sha256: 8fb218382be188497cbf549eb9de2825195cb076946e1f9929f3758b3f3b4e88
+  md5: 9c6dab4d9b20463121faf04283b4d1a1
+  depends:
+  - numpy >=1.21,<3
+  - numpy >=1.22.4
+  - python >=3.13.0rc2,<3.14.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.13.* *_cp313
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14215159
+  timestamp: 1726879653675
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py39h2366fc2_1.conda
+  sha256: 437444ed75474143f9b2c9ee266abb6ccf6f541c7410c3010b506650594daad4
+  md5: f7dbeb27d9cb9fdfa070b5616a07a6d7
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.9.* *_cp39
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11755072
+  timestamp: 1726879299575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.5-ha770c72_0.conda
   sha256: 56df96c2707a5ac71b2e5d3b32e38521c0bac91006d0b8948c1d347dd5c12609
   md5: 2889e6b9c666c3a564ab90cedc5832fd
   license: GPL-2.0-or-later
   license_family: GPL
   size: 21003150
   timestamp: 1728196276862
-- kind: conda
-  name: pandoc
-  version: '3.5'
-  build: hce30654_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-3.5-hce30654_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-3.5-hce30654_0.conda
   sha256: c37b7f09893022343ab9bc936f37daf3f566131828011b94c35ae62e2d1459cb
   md5: 5c56b7bfbdad3334a09230d405b63564
   license: GPL-2.0-or-later
   license_family: GPL
   size: 22892672
   timestamp: 1728196385862
-- kind: conda
-  name: pandocfilters
-  version: 1.5.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.5-h57928b3_0.conda
+  sha256: 2ef7593628529429ab0041128f90e7bb32eb447a05850c40ff178d9ad9df2e9b
+  md5: 2c4a6c475e0f1bbffac672b0943dc520
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 24950852
+  timestamp: 1728196799190
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
   sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
   md5: 457c2c8c08e54905d6954e79cb5b5db9
   depends:
@@ -17886,13 +14077,7 @@ packages:
   license_family: BSD
   size: 11627
   timestamp: 1631603397334
-- kind: conda
-  name: parso
-  version: 0.8.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
   sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
   md5: 81534b420deb77da8833f2289b8d47ac
   depends:
@@ -17901,13 +14086,7 @@ packages:
   license_family: MIT
   size: 75191
   timestamp: 1712320447201
-- kind: conda
-  name: partd
-  version: 1.4.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
   sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
   md5: 0badf9c54e24cecfb0ad2f99d680c163
   depends:
@@ -17918,13 +14097,7 @@ packages:
   license_family: BSD
   size: 20884
   timestamp: 1715026639309
-- kind: conda
-  name: patsy
-  version: 1.0.1
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhff2d567_0.conda
   sha256: f1ec4bb1e70f18518f70df64728b162d0d5ef3c0ed68296d913c27f5bab7a84b
   md5: a97b9c7586cedcf4a0a158ef3479975c
   depends:
@@ -17934,13 +14107,7 @@ packages:
   license_family: BSD
   size: 186599
   timestamp: 1731432296481
-- kind: conda
-  name: pbr
-  version: 6.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.0-pyhd8ed1ab_0.conda
   sha256: 64dff059855c9fca4eb277cdce5b401f25debed7f7ca3dceb5048da2958bb68f
   md5: 5a166b998fd17cdaaaadaccdd71a363f
   depends:
@@ -17950,13 +14117,19 @@ packages:
   license_family: Apache
   size: 73891
   timestamp: 1724777732325
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h297a79d_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
+  md5: df359c09c41cd186fffb93a2d87aa6f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 952308
+  timestamp: 1723488734144
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
   sha256: 83153c7d8fd99cab33c92ce820aa7bfed0f1c94fc57010cf227b6e3c50cb7796
   md5: 147c83e5e44780c7492998acbacddf52
   depends:
@@ -17967,13 +14140,7 @@ packages:
   license_family: BSD
   size: 618973
   timestamp: 1723488853807
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h3d7b363_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
   sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
   md5: a3a3baddcfb8c80db84bec3cb7746fb8
   depends:
@@ -17986,31 +14153,7 @@ packages:
   license_family: BSD
   size: 820831
   timestamp: 1723489427046
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: hba22ea6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
-  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
-  md5: df359c09c41cd186fffb93a2d87aa6f5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 952308
-  timestamp: 1723488734144
-- kind: conda
-  name: pexpect
-  version: 4.9.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
   sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
   md5: 629f3203c99b32e0988910c93e77f3b6
   depends:
@@ -18019,14 +14162,7 @@ packages:
   license: ISC
   size: 53600
   timestamp: 1706113273252
-- kind: conda
-  name: pickleshare
-  version: 0.7.5
-  build: py_1003
-  build_number: 1003
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
   sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
   md5: 415f0ebb6198cc2801c73438a9fb5761
   depends:
@@ -18035,12 +14171,7 @@ packages:
   license_family: MIT
   size: 9332
   timestamp: 1602536313357
-- kind: conda
-  name: pillow
-  version: 11.0.0
-  build: py312h7b63e92_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py312h7b63e92_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py312h7b63e92_0.conda
   sha256: 13a464bea02c0df0199c20ef6bad24a6bc336aaf55bf8d6a133d0fe664463224
   md5: 385f46a4df6f97892503a841121a9acf
   depends:
@@ -18060,12 +14191,27 @@ packages:
   license: HPND
   size: 41948418
   timestamp: 1729065846594
-- kind: conda
-  name: pillow
-  version: 11.0.0
-  build: py312ha41cd45_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py312ha41cd45_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py312haf37ca6_0.conda
+  sha256: 727b4c3faecdb6f6809cf20c5f32d2df4af34e0d5b9146b7588383bcba7990e8
+  md5: dc9b51fbd2b6f7fea9b5123458864dbb
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41737424
+  timestamp: 1729065920347
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py312ha41cd45_0.conda
   sha256: 8802bcab3b587cec7dfa8e6a82e9851d16dffff64052282d993adf2d1cade0ef
   md5: 812f37d90c99f24705d2db3091c9c29c
   depends:
@@ -18086,38 +14232,7 @@ packages:
   license: HPND
   size: 41230881
   timestamp: 1729066337278
-- kind: conda
-  name: pillow
-  version: 11.0.0
-  build: py312haf37ca6_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py312haf37ca6_0.conda
-  sha256: 727b4c3faecdb6f6809cf20c5f32d2df4af34e0d5b9146b7588383bcba7990e8
-  md5: dc9b51fbd2b6f7fea9b5123458864dbb
-  depends:
-  - __osx >=11.0
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - tk >=8.6.13,<8.7.0a0
-  license: HPND
-  size: 41737424
-  timestamp: 1729065920347
-- kind: conda
-  name: pip
-  version: 24.3.1
-  build: pyh145f28c_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_0.conda
   sha256: fc305cfe1ad0d51c61dd42a33cf27e03a075992fd0070c173d7cad86c1a48f13
   md5: ca3afe2d7b893a8c8cdf489d30a2b1a3
   depends:
@@ -18126,13 +14241,7 @@ packages:
   license_family: MIT
   size: 1241228
   timestamp: 1730203795175
-- kind: conda
-  name: pip
-  version: 24.3.1
-  build: pyh8b19718_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
   sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
   md5: 5dd546fe99b44fda83963d15f84263b7
   depends:
@@ -18143,12 +14252,7 @@ packages:
   license_family: MIT
   size: 1243168
   timestamp: 1730203795600
-- kind: conda
-  name: pixman
-  version: 0.43.2
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
   sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
   md5: 71004cbf7924e19c02746ccde9fd7123
   depends:
@@ -18158,14 +14262,7 @@ packages:
   license_family: MIT
   size: 386826
   timestamp: 1706549500138
-- kind: conda
-  name: pkgutil-resolve-name
-  version: 1.3.10
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
   sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
   md5: 405678b942f2481cecdb3e010f4925d9
   depends:
@@ -18173,13 +14270,7 @@ packages:
   license: MIT AND PSF-2.0
   size: 10778
   timestamp: 1694617398467
-- kind: conda
-  name: platformdirs
-  version: 4.3.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
   sha256: c81bdeadc4adcda216b2c7b373f0335f5c78cc480d1d55d10f21823590d7e46f
   md5: fd8f2b18b65bbf62e8f653100690c8d2
   depends:
@@ -18188,13 +14279,7 @@ packages:
   license_family: MIT
   size: 20625
   timestamp: 1726613611845
-- kind: conda
-  name: pluggy
-  version: 1.5.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
   sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
   md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
   depends:
@@ -18203,13 +14288,7 @@ packages:
   license_family: MIT
   size: 23815
   timestamp: 1713667175451
-- kind: conda
-  name: pre-commit
-  version: 4.0.1
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_0.conda
   sha256: 2490b18ec802d8f085f2de8298a3d275451f7db17769353080dfb121fe386675
   md5: 5971cc64048943605f352f7f8612de6c
   depends:
@@ -18223,12 +14302,7 @@ packages:
   license_family: MIT
   size: 194633
   timestamp: 1728420305558
-- kind: conda
-  name: proj
-  version: 9.5.0
-  build: h12925eb_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
   sha256: 936de8754054d97223e87cc87b72641d2c7582d536ee9eee4b0443fa66e2733f
   md5: 8c29983ebe50cc7e0998c34bc7614222
   depends:
@@ -18245,12 +14319,7 @@ packages:
   license_family: MIT
   size: 3093445
   timestamp: 1726489083290
-- kind: conda
-  name: proj
-  version: 9.5.0
-  build: h61a8e3e_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
   sha256: df44f24dc325fff7480f20fb404dad03015b9e646aa25e0eb24d1edd3930164e
   md5: 7b9888f46634eb49eece8fa6e16406d6
   depends:
@@ -18266,12 +14335,7 @@ packages:
   license_family: MIT
   size: 2732379
   timestamp: 1726489115567
-- kind: conda
-  name: proj
-  version: 9.5.0
-  build: hd9569ee_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
   sha256: ebd1fee2834cf5971a08dfb665606f775302aa22e98d5d893d35323805311419
   md5: 4cfbffd1cd2bbff30e975a71b1769597
   depends:
@@ -18288,13 +14352,7 @@ packages:
   license_family: MIT
   size: 2709612
   timestamp: 1726489723807
-- kind: conda
-  name: prometheus_client
-  version: 0.21.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
   sha256: 01f0c3dd00081637ed920a922b17bcc8ed49608404ee466ced806856e671f6b9
   md5: 07e9550ddff45150bfc7da146268e165
   depends:
@@ -18303,13 +14361,7 @@ packages:
   license_family: Apache
   size: 49024
   timestamp: 1726902073034
-- kind: conda
-  name: prompt-toolkit
-  version: 3.0.48
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
   sha256: 44e4e6108d425a666856a52d1523e5d70890256a8920bb0dcd3d55cc750f3207
   md5: 4c05134c48b6a74f33bbb9938e4a115e
   depends:
@@ -18321,12 +14373,7 @@ packages:
   license_family: BSD
   size: 270271
   timestamp: 1727341744544
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py310ha75aee5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py310ha75aee5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py310ha75aee5_0.conda
   sha256: d51ffcb07e820b281723d4c0838764faef4061ec1ec306d4f091796bf9411987
   md5: a42a2ed94df11c5cfa5348a317e1f197
   depends:
@@ -18338,12 +14385,103 @@ packages:
   license_family: BSD
   size: 368823
   timestamp: 1729847140562
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py310ha8f682b_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py310ha8f682b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
+  md5: 0ffc1f53106a38f059b151c465891ed3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505408
+  timestamp: 1729847169876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py312h66e93f0_0.conda
+  sha256: 0f309b435174e037d5cfe5ed26c1c5ad8152c68cfe61af17709ec31ec3d9f096
+  md5: 0524eb91d3d78d76d671c6e3cd7cee82
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 488462
+  timestamp: 1729847159916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py39h8cd3c5a_0.conda
+  sha256: 057765763fc2b7cc8d429e055240209ae83ae6631c80060bad590bbbc8f01f22
+  md5: ef257b7ce1e1cb152639ced6bc653475
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 364598
+  timestamp: 1729847230720
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py310hf9df320_0.conda
+  sha256: 6c6254f879a4f587565a7cb53475f4072ea65de1fcd453da994ab3a8f222c9a4
+  md5: 6f375d878663d0aa31f85c88b4298c38
+  depends:
+  - __osx >=11.0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 376431
+  timestamp: 1729847288915
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
+  md5: e226eba0c52ecd6786e73c8ad7f41e79
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514316
+  timestamp: 1729847396776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py312h0bf5046_0.conda
+  sha256: 143a40f9c72d803744ebd6a60801c5cd17af152b293f8d59e90111ce62b53569
+  md5: 61566f5c6e1d29d1d12882eb93e28532
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 493431
+  timestamp: 1729847279283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py313h63a2874_0.conda
+  sha256: 06bc9b6eda080fea24e7948ace631b358a9994a6a84394a6c1cd14f1615ebbf4
+  md5: 6f4dae78857fd194485497ed0a6762ab
+  depends:
+  - __osx >=11.0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 501427
+  timestamp: 1729847280285
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py39h57695bc_0.conda
+  sha256: 7caa6892871b78fd609fa24136005a2b34e711076c35abaa70a873aa1ce27fde
+  md5: 7521b2d7f1337893b7b9a513a264caa1
+  depends:
+  - __osx >=11.0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372272
+  timestamp: 1729847358451
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py310ha8f682b_0.conda
   sha256: ef77ead9f21fed3de1e71b7af9c19198683454526ddc6ff62045fdbe0042723f
   md5: 4e5ed46bab4ca903c94ef4775ec0da68
   depends:
@@ -18356,63 +14494,7 @@ packages:
   license_family: BSD
   size: 385936
   timestamp: 1729847558125
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py310hf9df320_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py310hf9df320_0.conda
-  sha256: 6c6254f879a4f587565a7cb53475f4072ea65de1fcd453da994ab3a8f222c9a4
-  md5: 6f375d878663d0aa31f85c88b4298c38
-  depends:
-  - __osx >=11.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 376431
-  timestamp: 1729847288915
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py311h9ecbd09_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
-  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
-  md5: 0ffc1f53106a38f059b151c465891ed3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 505408
-  timestamp: 1729847169876
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py311hae2e1ce_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
-  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
-  md5: e226eba0c52ecd6786e73c8ad7f41e79
-  depends:
-  - __osx >=11.0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 514316
-  timestamp: 1729847396776
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py311he736701_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
   sha256: 303c988247c4b1638f1cc90cd40465f5c74ca0ecfd83114033af637654dc2b6b
   md5: 307267e6a028bca3382d98e06a372ebf
   depends:
@@ -18425,29 +14507,7 @@ packages:
   license_family: BSD
   size: 521434
   timestamp: 1729847606018
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py312h0bf5046_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py312h0bf5046_0.conda
-  sha256: 143a40f9c72d803744ebd6a60801c5cd17af152b293f8d59e90111ce62b53569
-  md5: 61566f5c6e1d29d1d12882eb93e28532
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 493431
-  timestamp: 1729847279283
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py312h4389bb4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py312h4389bb4_0.conda
   sha256: 49640ecea25367e46c89d7ee8556a1d96a0c2b82240b303415b39a29aaec7163
   md5: ef327db3af50ec234214c3e7566510eb
   depends:
@@ -18460,46 +14520,7 @@ packages:
   license_family: BSD
   size: 503151
   timestamp: 1729847947592
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py312h66e93f0_0.conda
-  sha256: 0f309b435174e037d5cfe5ed26c1c5ad8152c68cfe61af17709ec31ec3d9f096
-  md5: 0524eb91d3d78d76d671c6e3cd7cee82
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 488462
-  timestamp: 1729847159916
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py313h63a2874_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py313h63a2874_0.conda
-  sha256: 06bc9b6eda080fea24e7948ace631b358a9994a6a84394a6c1cd14f1615ebbf4
-  md5: 6f4dae78857fd194485497ed0a6762ab
-  depends:
-  - __osx >=11.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 501427
-  timestamp: 1729847280285
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py313ha7868ed_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py313ha7868ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py313ha7868ed_0.conda
   sha256: d58defe84d46da1a7e80283e165d6a9d09378fd830b48917751a318ab5a5d4ce
   md5: d13841485f9159f317a4e8bb974e9c8e
   depends:
@@ -18512,46 +14533,7 @@ packages:
   license_family: BSD
   size: 508489
   timestamp: 1729847497486
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py39h57695bc_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py39h57695bc_0.conda
-  sha256: 7caa6892871b78fd609fa24136005a2b34e711076c35abaa70a873aa1ce27fde
-  md5: 7521b2d7f1337893b7b9a513a264caa1
-  depends:
-  - __osx >=11.0
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 372272
-  timestamp: 1729847358451
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py39h8cd3c5a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py39h8cd3c5a_0.conda
-  sha256: 057765763fc2b7cc8d429e055240209ae83ae6631c80060bad590bbbc8f01f22
-  md5: ef257b7ce1e1cb152639ced6bc653475
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 364598
-  timestamp: 1729847230720
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py39ha55e580_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py39ha55e580_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py39ha55e580_0.conda
   sha256: 9b0b6c692e4fd9d6ece2b78340987913ae741b5a5486308d00b87f1a507bed9b
   md5: 9e44ffa0f1a6bc810c6e948919a473e8
   depends:
@@ -18564,13 +14546,26 @@ packages:
   license_family: BSD
   size: 380522
   timestamp: 1729847576400
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: h0e40799_1002
-  build_number: 1002
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
   sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
   md5: 3c8f2573569bb816483e5cf57efbbe29
   depends:
@@ -18581,44 +14576,7 @@ packages:
   license_family: MIT
   size: 9389
   timestamp: 1726802555076
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hb9d3cd8_1002
-  build_number: 1002
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
-  md5: b3c17d95b5a10c6e64a21fa17573e70e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 8252
-  timestamp: 1726802366959
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hd74edd7_1002
-  build_number: 1002
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
-  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
-  md5: 415816daf82e0b23a736a069a75e9da7
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 8381
-  timestamp: 1726802424786
-- kind: conda
-  name: ptyprocess
-  version: 0.7.0
-  build: pyhd3deb0d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
   sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
   md5: 359eeb6536da0e687af562ed265ec263
   depends:
@@ -18626,13 +14584,7 @@ packages:
   license: ISC
   size: 16546
   timestamp: 1609419417991
-- kind: conda
-  name: pure_eval
-  version: 0.2.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
   sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
   md5: 0f051f09d992e0d08941706ad519ee0e
   depends:
@@ -18641,52 +14593,7 @@ packages:
   license_family: MIT
   size: 16551
   timestamp: 1721585805256
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py310h5588dad_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py310h5588dad_0.conda
-  sha256: 3ac8f4f39ee66a4c478e3d8f622c026075dd093c8d3576e34ad2f0d0f3bde2e4
-  md5: 0a9a667f2223be8615637cc24d0049d8
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25680
-  timestamp: 1732652490895
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py310hb6292c7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py310hb6292c7_0.conda
-  sha256: 5b7af521c075b706c9ec4df7f68e368daa015b4e0790c8b1deddca3ffaed5475
-  md5: 753691b585ec3e968cc803aa599e204c
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25411
-  timestamp: 1732611138365
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py310hff52083_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py310hff52083_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py310hff52083_0.conda
   sha256: 2cc58382b4f03b7b13cde2478f274393679a90b2b9ae53ede5e1d8d6fca8b725
   md5: b1bf2dce4ffc87e1d551d725e8f57e07
   depends:
@@ -18701,32 +14608,7 @@ packages:
   license_family: APACHE
   size: 25169
   timestamp: 1732610724262
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py311h1ea47a8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
-  sha256: 78e88b5ee2d80622091e24ba74d35f425060648735f5156ac388b1fd87169958
-  md5: 3577ae265ed894dc105829e4e0a4f40c
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25662
-  timestamp: 1732651904499
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py311h38be061_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
   sha256: 9cfd158a1bb76c4af1a51237a5c5db4a36b2e83bad625ddf6c2b65ee232c16ba
   md5: 47b8624012486e05e66f6acf7267aa22
   depends:
@@ -18741,72 +14623,7 @@ packages:
   license_family: APACHE
   size: 25199
   timestamp: 1732610760700
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py311ha1ab1f8_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
-  sha256: c93f3ede66be0502b5b9afc5bc3fde50d6f8c3863d29b138ff5f536a116457f3
-  md5: 7a3b822fa6abb937651bee20878f087a
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25322
-  timestamp: 1732611121491
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py312h1f38498_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py312h1f38498_0.conda
-  sha256: 06c0e208d5bf15051874097366c8e8e5db176dffba38526f227a34e80cc8e9bc
-  md5: 3710616b880b31d0c8afd8ae7e12392a
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25375
-  timestamp: 1732610892198
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py312h2e8e312_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py312h2e8e312_0.conda
-  sha256: 0a4fc6d41b3f3b9613d6f0c2ebdd669c8d83d3d08cf5164e72dd88a8c9997cfc
-  md5: fce236a0a475e7fd7944288eb0081c78
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25624
-  timestamp: 1732651935370
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py312h7900ff3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py312h7900ff3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py312h7900ff3_0.conda
   sha256: 46a61c29375d3bf1933eae61c7861394c168898915d59fc99bf05e46de2ff5ad
   md5: ac65b70df28687c6af4270923c020bdd
   depends:
@@ -18821,92 +14638,7 @@ packages:
   license_family: APACHE
   size: 25213
   timestamp: 1732610785600
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py313h39782a4_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py313h39782a4_0.conda
-  sha256: 42e11215b42f13bbe33a72fe969d1cfb5fafed63c46eb7f82d527930a8d7acf8
-  md5: 7dad16f34b6a89314f4fe0579ca818c5
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25382
-  timestamp: 1732610762219
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py313hfa70ccb_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py313hfa70ccb_0.conda
-  sha256: c2ed96992b6d5e7ae3b9e568fc552862815295c67c33241ca497984337cf1a1a
-  md5: dbdc2bd4f139731cc0ecdb892ab072b8
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25682
-  timestamp: 1732651828354
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py39hcbf5309_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py39hcbf5309_0.conda
-  sha256: 45d3318d8f3bd54691ed9ceb92997e6c4f7fca44a8e5fdabd774838aaa442dc5
-  md5: 308ff4dddfc34032dedfe9834ae213f7
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25640
-  timestamp: 1732651935028
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py39hdf13c20_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py39hdf13c20_0.conda
-  sha256: 80ab99b6407a96620b426e5d228e189e16091fe560ee5f3f52d92c2824e26f7c
-  md5: b07f61d8365036685cb1aa4f3c9729e9
-  depends:
-  - libarrow-acero 18.1.0.*
-  - libarrow-dataset 18.1.0.*
-  - libarrow-substrait 18.1.0.*
-  - libparquet 18.1.0.*
-  - pyarrow-core 18.1.0 *_0_*
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: Apache-2.0
-  license_family: APACHE
-  size: 25295
-  timestamp: 1732610936076
-- kind: conda
-  name: pyarrow
-  version: 18.1.0
-  build: py39hf3d152e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py39hf3d152e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py39hf3d152e_0.conda
   sha256: 9e9978f798e1eaad694d8566e2eed3ec918754084ee9f69dc1108ddae654d3f6
   md5: cfff42031bb076cce283d182c04e4ce1
   depends:
@@ -18921,35 +14653,157 @@ packages:
   license_family: APACHE
   size: 25150
   timestamp: 1732610836745
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py310h399dd74_0_cpu
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py310h399dd74_0_cpu.conda
-  sha256: 4e2c58e5123c3c63e32710ed8809347866d9f8e90b76427ccfa8c92cae673bdb
-  md5: 45d9ee9d0b92d4fbbbfe7db44d84d2fe
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py310hb6292c7_0.conda
+  sha256: 5b7af521c075b706c9ec4df7f68e368daa015b4e0790c8b1deddca3ffaed5475
+  md5: 753691b585ec3e968cc803aa599e204c
   depends:
-  - libarrow 18.1.0.* *cpu
-  - libzlib >=1.3.1,<2.0a0
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - apache-arrow-proc =*=cpu
-  - numpy >=1.21,<3
   license: Apache-2.0
   license_family: APACHE
-  size: 3425932
-  timestamp: 1732651827572
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py310hac404ae_0_cpu
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py310hac404ae_0_cpu.conda
+  size: 25411
+  timestamp: 1732611138365
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
+  sha256: c93f3ede66be0502b5b9afc5bc3fde50d6f8c3863d29b138ff5f536a116457f3
+  md5: 7a3b822fa6abb937651bee20878f087a
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25322
+  timestamp: 1732611121491
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py312h1f38498_0.conda
+  sha256: 06c0e208d5bf15051874097366c8e8e5db176dffba38526f227a34e80cc8e9bc
+  md5: 3710616b880b31d0c8afd8ae7e12392a
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25375
+  timestamp: 1732610892198
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py313h39782a4_0.conda
+  sha256: 42e11215b42f13bbe33a72fe969d1cfb5fafed63c46eb7f82d527930a8d7acf8
+  md5: 7dad16f34b6a89314f4fe0579ca818c5
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25382
+  timestamp: 1732610762219
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py39hdf13c20_0.conda
+  sha256: 80ab99b6407a96620b426e5d228e189e16091fe560ee5f3f52d92c2824e26f7c
+  md5: b07f61d8365036685cb1aa4f3c9729e9
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25295
+  timestamp: 1732610936076
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py310h5588dad_0.conda
+  sha256: 3ac8f4f39ee66a4c478e3d8f622c026075dd093c8d3576e34ad2f0d0f3bde2e4
+  md5: 0a9a667f2223be8615637cc24d0049d8
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25680
+  timestamp: 1732652490895
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
+  sha256: 78e88b5ee2d80622091e24ba74d35f425060648735f5156ac388b1fd87169958
+  md5: 3577ae265ed894dc105829e4e0a4f40c
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25662
+  timestamp: 1732651904499
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py312h2e8e312_0.conda
+  sha256: 0a4fc6d41b3f3b9613d6f0c2ebdd669c8d83d3d08cf5164e72dd88a8c9997cfc
+  md5: fce236a0a475e7fd7944288eb0081c78
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25624
+  timestamp: 1732651935370
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py313hfa70ccb_0.conda
+  sha256: c2ed96992b6d5e7ae3b9e568fc552862815295c67c33241ca497984337cf1a1a
+  md5: dbdc2bd4f139731cc0ecdb892ab072b8
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25682
+  timestamp: 1732651828354
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py39hcbf5309_0.conda
+  sha256: 45d3318d8f3bd54691ed9ceb92997e6c4f7fca44a8e5fdabd774838aaa442dc5
+  md5: 308ff4dddfc34032dedfe9834ae213f7
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25640
+  timestamp: 1732651935028
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py310hac404ae_0_cpu.conda
   sha256: 48981393e1b392ecdad11a5f17a8a1e0325a53c1007a3e37d5ad85db0a354678
   md5: 9a961ac46dd84a82ab3f3fa31833f062
   depends:
@@ -18967,35 +14821,7 @@ packages:
   license_family: APACHE
   size: 4544985
   timestamp: 1732610569678
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py310hc17921c_0_cpu
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py310hc17921c_0_cpu.conda
-  sha256: 6ad8406767ea99b8540577587a22855ddc1c98940b10c5b209d7f2959a88b91d
-  md5: 71e33ee4b08ae1087a039e116e158fb6
-  depends:
-  - __osx >=11.0
-  - libarrow 18.1.0.* *cpu
-  - libcxx >=18
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - numpy >=1.21,<3
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3881631
-  timestamp: 1732611103866
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py311h4854187_0_cpu
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
   sha256: db147a0cc22b55ea3c35553b39336eb0392c33371f6efd7f9fb4efed2b728e34
   md5: 830a64ee7a65e588c7ea615be84db2e3
   depends:
@@ -19013,58 +14839,7 @@ packages:
   license_family: APACHE
   size: 4562010
   timestamp: 1732610600424
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py311hdea38fa_0_cpu
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
-  sha256: 436fc748241421e39ea72c8fcfebdad20c5c39a7dfc1d9c16dda03b97b7c317d
-  md5: 3603acae16694ed5cd689e6980eb0703
-  depends:
-  - libarrow 18.1.0.* *cpu
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - numpy >=1.21,<3
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3498372
-  timestamp: 1732651886220
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py311he04fa90_0_cpu
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
-  sha256: 4563e2d4f41b3874b89e8e2bdebf42588c1c819bd050ae858200f60e30bae860
-  md5: 09b4a27f615d22f194466d8c274ef13e
-  depends:
-  - __osx >=11.0
-  - libarrow 18.1.0.* *cpu
-  - libcxx >=18
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - numpy >=1.21,<3
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3974075
-  timestamp: 1732611073316
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py312h01725c0_0_cpu
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py312h01725c0_0_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py312h01725c0_0_cpu.conda
   sha256: 948a4161c56f846d374a3721a657e58ddbc992a29b3b3e7a6411975c30361d94
   md5: ee80934a6c280ff8635f8db5dec11e04
   depends:
@@ -19082,127 +14857,7 @@ packages:
   license_family: APACHE
   size: 4612916
   timestamp: 1732610377259
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py312h6a9c419_0_cpu
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py312h6a9c419_0_cpu.conda
-  sha256: f43d3f1b99cb67200d5a5824bad15186fec7dfa22a9868901de4480b15ce255c
-  md5: c34e65aee24686fa6b101d4df25d9e28
-  depends:
-  - libarrow 18.1.0.* *cpu
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - apache-arrow-proc =*=cpu
-  - numpy >=1.21,<3
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3416553
-  timestamp: 1732651918640
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py312hc40f475_0_cpu
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py312hc40f475_0_cpu.conda
-  sha256: 063eb168a29d4ce6d9ed865e9e1ad3b6e141712189955a79e06b24ddc0cbbc9c
-  md5: 9859e7c4b94bbf69772dbf0511101cec
-  depends:
-  - __osx >=11.0
-  - libarrow 18.1.0.* *cpu
-  - libcxx >=18
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy >=1.21,<3
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3909116
-  timestamp: 1732610863261
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py313he812468_0_cpu
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py313he812468_0_cpu.conda
-  sha256: f8f3152398a16065a5279c16ec5df8f72e87ecd9d48ebd077df897ea7c620029
-  md5: 3f5b0ed1b2dc7eb76528778dac017f3a
-  depends:
-  - libarrow 18.1.0.* *cpu
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - numpy >=1.21,<3
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3411909
-  timestamp: 1732651804838
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py313hf9431ad_0_cpu
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py313hf9431ad_0_cpu.conda
-  sha256: ed7c0e6b4337dccddc364d4a409df321254a939229180e987141c3c2a5e6a649
-  md5: 80ca5c8e519a960167756716318738cd
-  depends:
-  - __osx >=11.0
-  - libarrow 18.1.0.* *cpu
-  - libcxx >=18
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - numpy >=1.21,<3
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3904587
-  timestamp: 1732610733881
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py39h35f5be7_0_cpu
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py39h35f5be7_0_cpu.conda
-  sha256: 4d1127c94a38bb3dd7013076ecef571225afc0035b3635c99d6c6e8b2f8a26ee
-  md5: 3e6fa3b56461f2af0c3f88c8507bb497
-  depends:
-  - __osx >=11.0
-  - libarrow 18.1.0.* *cpu
-  - libcxx >=18
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  constrains:
-  - numpy >=1.21,<3
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3882841
-  timestamp: 1732610891038
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py39h6117c73_0_cpu
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py39h6117c73_0_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py39h6117c73_0_cpu.conda
   sha256: 179572fbd8f206003fba06d6fb327126e85ba6114c614389631e2dd7df44aaac
   md5: d405b293bb138de778261b93de3737c8
   depends:
@@ -19220,12 +14875,169 @@ packages:
   license_family: APACHE
   size: 4531509
   timestamp: 1732610579225
-- kind: conda
-  name: pyarrow-core
-  version: 18.1.0
-  build: py39h7a8928a_0_cpu
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py39h7a8928a_0_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py310hc17921c_0_cpu.conda
+  sha256: 6ad8406767ea99b8540577587a22855ddc1c98940b10c5b209d7f2959a88b91d
+  md5: 71e33ee4b08ae1087a039e116e158fb6
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3881631
+  timestamp: 1732611103866
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
+  sha256: 4563e2d4f41b3874b89e8e2bdebf42588c1c819bd050ae858200f60e30bae860
+  md5: 09b4a27f615d22f194466d8c274ef13e
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3974075
+  timestamp: 1732611073316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py312hc40f475_0_cpu.conda
+  sha256: 063eb168a29d4ce6d9ed865e9e1ad3b6e141712189955a79e06b24ddc0cbbc9c
+  md5: 9859e7c4b94bbf69772dbf0511101cec
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3909116
+  timestamp: 1732610863261
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py313hf9431ad_0_cpu.conda
+  sha256: ed7c0e6b4337dccddc364d4a409df321254a939229180e987141c3c2a5e6a649
+  md5: 80ca5c8e519a960167756716318738cd
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3904587
+  timestamp: 1732610733881
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py39h35f5be7_0_cpu.conda
+  sha256: 4d1127c94a38bb3dd7013076ecef571225afc0035b3635c99d6c6e8b2f8a26ee
+  md5: 3e6fa3b56461f2af0c3f88c8507bb497
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3882841
+  timestamp: 1732610891038
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py310h399dd74_0_cpu.conda
+  sha256: 4e2c58e5123c3c63e32710ed8809347866d9f8e90b76427ccfa8c92cae673bdb
+  md5: 45d9ee9d0b92d4fbbbfe7db44d84d2fe
+  depends:
+  - libarrow 18.1.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3425932
+  timestamp: 1732651827572
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
+  sha256: 436fc748241421e39ea72c8fcfebdad20c5c39a7dfc1d9c16dda03b97b7c317d
+  md5: 3603acae16694ed5cd689e6980eb0703
+  depends:
+  - libarrow 18.1.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3498372
+  timestamp: 1732651886220
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py312h6a9c419_0_cpu.conda
+  sha256: f43d3f1b99cb67200d5a5824bad15186fec7dfa22a9868901de4480b15ce255c
+  md5: c34e65aee24686fa6b101d4df25d9e28
+  depends:
+  - libarrow 18.1.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3416553
+  timestamp: 1732651918640
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py313he812468_0_cpu.conda
+  sha256: f8f3152398a16065a5279c16ec5df8f72e87ecd9d48ebd077df897ea7c620029
+  md5: 3f5b0ed1b2dc7eb76528778dac017f3a
+  depends:
+  - libarrow 18.1.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3411909
+  timestamp: 1732651804838
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py39h7a8928a_0_cpu.conda
   sha256: 0b4782b0e3c60139bbbbe588e5fd8d3630e8dbebd45fd17f78204d059d777a5c
   md5: 2eec0814240f062c5bffd50135e64489
   depends:
@@ -19243,13 +15055,7 @@ packages:
   license_family: APACHE
   size: 3433446
   timestamp: 1732651918845
-- kind: conda
-  name: pycodestyle
-  version: 2.12.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.12.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.12.1-pyhd8ed1ab_0.conda
   sha256: ca548aa380edcc1a6e96893c0d870de9e22a7b0d4619ffa426875e6443a2044f
   md5: 72453e39709f38d0494d096bb5f678b7
   depends:
@@ -19258,13 +15064,7 @@ packages:
   license_family: MIT
   size: 34215
   timestamp: 1722846854518
-- kind: conda
-  name: pycparser
-  version: '2.22'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   md5: 844d9eb3b43095b031874477f7d70088
   depends:
@@ -19273,48 +15073,7 @@ packages:
   license_family: BSD
   size: 105098
   timestamp: 1711811634025
-- kind: conda
-  name: pycryptodome
-  version: 3.21.0
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pycryptodome-3.21.0-py312h4389bb4_0.conda
-  sha256: 2308688ec96a464b68860e410747dafef79b6809ce3cbe06f9085c5371dcaeaf
-  md5: 3440c4e1f4a1ea7fa534a036ef540d82
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1687506
-  timestamp: 1729876855331
-- kind: conda
-  name: pycryptodome
-  version: 3.21.0
-  build: py312h4cf456b_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pycryptodome-3.21.0-py312h4cf456b_0.conda
-  sha256: f415fb59d61061c9add4758111c3069136d1cffea1176eb2c7898947579eabbe
-  md5: eebeb6063d7c9392d862d68f7040c7bd
-  depends:
-  - __osx >=11.0
-  - gmp >=6.3.0,<7.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1629078
-  timestamp: 1729876586115
-- kind: conda
-  name: pycryptodome
-  version: 3.21.0
-  build: py312h6368725_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pycryptodome-3.21.0-py312h6368725_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pycryptodome-3.21.0-py312h6368725_0.conda
   sha256: e178bd0a4ec8fd48a062a82e0961a805c746c7d0925ee4e8a7d8368261b0cf6c
   md5: 6fbba77365b12896b0df4c583bf9131e
   depends:
@@ -19327,13 +15086,33 @@ packages:
   license_family: BSD
   size: 1645627
   timestamp: 1729876387419
-- kind: conda
-  name: pygments
-  version: 2.18.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycryptodome-3.21.0-py312h4cf456b_0.conda
+  sha256: f415fb59d61061c9add4758111c3069136d1cffea1176eb2c7898947579eabbe
+  md5: eebeb6063d7c9392d862d68f7040c7bd
+  depends:
+  - __osx >=11.0
+  - gmp >=6.3.0,<7.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1629078
+  timestamp: 1729876586115
+- conda: https://conda.anaconda.org/conda-forge/win-64/pycryptodome-3.21.0-py312h4389bb4_0.conda
+  sha256: 2308688ec96a464b68860e410747dafef79b6809ce3cbe06f9085c5371dcaeaf
+  md5: 3440c4e1f4a1ea7fa534a036ef540d82
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1687506
+  timestamp: 1729876855331
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
   sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
   md5: b7f5c092b8f9800150d998a71b76d5a1
   depends:
@@ -19342,13 +15121,7 @@ packages:
   license_family: BSD
   size: 879295
   timestamp: 1714846885370
-- kind: conda
-  name: pyobjc-core
-  version: 10.3.1
-  build: py312hd24fc31_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py312hd24fc31_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py312hd24fc31_1.conda
   sha256: e3311a9b7e843e3fb2b814bf0a0a901db8d2c21d72bacf246a95867c2628ca25
   md5: 1533727287f098e669d75f9c54dc1601
   depends:
@@ -19362,13 +15135,7 @@ packages:
   license_family: MIT
   size: 490928
   timestamp: 1725739760349
-- kind: conda
-  name: pyobjc-framework-cocoa
-  version: 10.3.1
-  build: py312hd24fc31_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py312hd24fc31_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py312hd24fc31_1.conda
   sha256: 799aa68d1d9abe00f3574d7763e91f86007a938ab8f5dff63ae3e1f22d0d634d
   md5: b1c63f8abafc9530a9259e0d6a70e984
   depends:
@@ -19382,13 +15149,7 @@ packages:
   license_family: MIT
   size: 381079
   timestamp: 1725875188776
-- kind: conda
-  name: pyogrio
-  version: 0.10.0
-  build: py312h02b19dd_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.10.0-py312h02b19dd_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.10.0-py312h02b19dd_1.conda
   sha256: b1a2754f1ddda7f098dc1f6712153c8a184bf31e11e71ee8b6ca95d9791c2147
   md5: 6ebb12bd1833a52e08e63297b8621903
   depends:
@@ -19404,35 +15165,7 @@ packages:
   license_family: MIT
   size: 640043
   timestamp: 1732013500715
-- kind: conda
-  name: pyogrio
-  version: 0.10.0
-  build: py312h6e88f47_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.10.0-py312h6e88f47_1.conda
-  sha256: 89f022cc08f03d3ada5114859bd8849e4d12feeb447e125c3fd817651d11a82b
-  md5: 42fcbe51e1dfd9f1420d1a7b5a806aff
-  depends:
-  - libgdal-core >=3.10.0,<3.11.0a0
-  - numpy
-  - packaging
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 806696
-  timestamp: 1732013939781
-- kind: conda
-  name: pyogrio
-  version: 0.10.0
-  build: py312hfd5e53c_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.10.0-py312hfd5e53c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.10.0-py312hfd5e53c_1.conda
   sha256: af738bd24e6f2fcf763a0dbc22fb088222e7f52b99b7b5f49333d9da1320c8ea
   md5: 19550465d36f2f513be5c62def9edfd9
   depends:
@@ -19448,14 +15181,23 @@ packages:
   license_family: MIT
   size: 564110
   timestamp: 1732013713458
-- kind: conda
-  name: pyparsing
-  version: 3.2.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.10.0-py312h6e88f47_1.conda
+  sha256: 89f022cc08f03d3ada5114859bd8849e4d12feeb447e125c3fd817651d11a82b
+  md5: 42fcbe51e1dfd9f1420d1a7b5a806aff
+  depends:
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - numpy
+  - packaging
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 806696
+  timestamp: 1732013939781
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
   sha256: b846e3965cd106438cf0b9dc0de8d519670ac065f822a7d66862e9423e0229cb
   md5: 035c17fbf099f50ff60bf2eb303b0a83
   depends:
@@ -19464,12 +15206,21 @@ packages:
   license_family: MIT
   size: 92444
   timestamp: 1728880549923
-- kind: conda
-  name: pyproj
-  version: 3.7.0
-  build: py312h1ab748d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py312h1ab748d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py312he630544_0.conda
+  sha256: 713d38f8f4fce141eec5c282e333b145a1359c1c6cc34f506d03b164497e6a74
+  md5: 427799f15b36751761941f4cbd7d780f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - libgcc >=13
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  size: 555468
+  timestamp: 1727795528667
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py312h1ab748d_0.conda
   sha256: a6e5eda9365adcb3900338ddc809ecb9df2520871de14113675e50fddfebabbe
   md5: 62be0440197cfa89eb76846895198bab
   depends:
@@ -19483,12 +15234,7 @@ packages:
   license_family: MIT
   size: 494511
   timestamp: 1727795574712
-- kind: conda
-  name: pyproj
-  version: 3.7.0
-  build: py312ha24589b_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.0-py312ha24589b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.0-py312ha24589b_0.conda
   sha256: 8530fe6b44cebaf5ce57c13c7144760058b8f0b83b940b178b52fd8aa9fb82db
   md5: 1f0cacc6f721d87faa12ef1ce66d112d
   depends:
@@ -19503,33 +15249,7 @@ packages:
   license_family: MIT
   size: 748941
   timestamp: 1727795870023
-- kind: conda
-  name: pyproj
-  version: 3.7.0
-  build: py312he630544_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py312he630544_0.conda
-  sha256: 713d38f8f4fce141eec5c282e333b145a1359c1c6cc34f506d03b164497e6a74
-  md5: 427799f15b36751761941f4cbd7d780f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - certifi
-  - libgcc >=13
-  - proj >=9.5.0,<9.6.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 555468
-  timestamp: 1727795528667
-- kind: conda
-  name: pysocks
-  version: 1.7.1
-  build: pyh0701188_6
-  build_number: 6
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
   sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
   md5: 56cd9fe388baac0e90c7149cfac95b60
   depends:
@@ -19540,14 +15260,7 @@ packages:
   license_family: BSD
   size: 19348
   timestamp: 1661605138291
-- kind: conda
-  name: pysocks
-  version: 1.7.1
-  build: pyha2e5f31_6
-  build_number: 6
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
   sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
   md5: 2a7de29fb590ca14b5243c4c812c8025
   depends:
@@ -19557,13 +15270,7 @@ packages:
   license_family: BSD
   size: 18981
   timestamp: 1661604969727
-- kind: conda
-  name: pytest
-  version: 8.3.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_0.conda
   sha256: 254256beab3dcf29907fbdccee6fbbb3371e9ac3782d2b1b5864596a0317818e
   md5: ff8f2ef7f2636906b3781d0cf92388d0
   depends:
@@ -19579,13 +15286,7 @@ packages:
   license: MIT
   size: 259634
   timestamp: 1733087755165
-- kind: conda
-  name: pytest-xdist
-  version: 3.6.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
   sha256: c9f27ed55352bee2c9f7cc2fdaf12b322ee280b1989d7e763b4540d4fe7ec995
   md5: b39568655c127a9c4a44d178ac99b6d0
   depends:
@@ -19598,96 +15299,8 @@ packages:
   license_family: MIT
   size: 38320
   timestamp: 1718138508765
-- kind: conda
-  name: python
-  version: 3.9.20
-  build: h13acc7a_1_cpython
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.20-h13acc7a_1_cpython.conda
-  sha256: 6a30aa8df1745eded1e5c24d167cb10e6f379e75d2f2fa2a212e6dab76030698
-  md5: 951cff166a5f170e27908811917165f8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libffi >=3.4,<4.0a0
-  - libgcc >=13
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.9.* *_cp39
-  license: Python-2.0
-  size: 23684398
-  timestamp: 1727719528404
-- kind: conda
-  name: python
-  version: 3.9.20
-  build: h9e33284_1_cpython
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.20-h9e33284_1_cpython.conda
-  sha256: d6c272faa05fb7524aaf59718fa27629b1875e5dfb2fa74100547e8564cce4bc
-  md5: 708bd3a3616e42becb50d77313def984
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.9.* *_cp39
-  license: Python-2.0
-  size: 11826087
-  timestamp: 1727718700429
-- kind: conda
-  name: python
-  version: 3.9.20
-  build: hfaddaf0_1_cpython
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.9.20-hfaddaf0_1_cpython.conda
-  sha256: c4ef6a17c8065d8c653fc69cfa17b2a1b0d9a2ca1360ba67a514b450c8797fd9
-  md5: 445389d1d311435a90def248c814ddd6
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.9.* *_cp39
-  license: Python-2.0
-  size: 17024927
-  timestamp: 1727718943163
-- kind: conda
-  name: python
-  version: 3.10.15
-  build: h4a871b0_2_cpython
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.15-h4a871b0_2_cpython.conda
   build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.15-h4a871b0_2_cpython.conda
   sha256: c1e5e93b887d8cd1aa31d24b9620cb7eb6645c08c97b15ffc844fd6c29051420
   md5: 98059097f62e97be9aed7ec904055825
   depends:
@@ -19712,92 +15325,8 @@ packages:
   license: Python-2.0
   size: 25321141
   timestamp: 1729042931665
-- kind: conda
-  name: python
-  version: 3.10.15
-  build: hdce6c4c_2_cpython
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.15-hdce6c4c_2_cpython.conda
-  sha256: 50dbbcc5efacaa05906cdc6b42bbdda17cee7910386bef8d737edffe7f5a7f2f
-  md5: b6a5e688170f1301a858f6001c32822d
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.10.* *_cp310
-  license: Python-2.0
-  size: 12411616
-  timestamp: 1729042103758
-- kind: conda
-  name: python
-  version: 3.10.15
-  build: hfaddaf0_2_cpython
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.10.15-hfaddaf0_2_cpython.conda
-  sha256: ee5af019e5d7140ad2d40b5f772fcd68ded056853a478a2b54f417855977e99b
-  md5: 52a45ce756c062994b25738288c8ab62
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.10.* *_cp310
-  license: Python-2.0
-  size: 15933377
-  timestamp: 1729041771524
-- kind: conda
-  name: python
-  version: 3.11.10
-  build: hc51fdd5_3_cpython
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
   build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
-  sha256: 95a2c487176867ded825e23eab1e581398f75c5323da0cb7577c3cff3d2f955b
-  md5: 2a47a0061d7d3030e45b66d23f01d101
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.11.* *_cp311
-  license: Python-2.0
-  size: 14598065
-  timestamp: 1729042279642
-- kind: conda
-  name: python
-  version: 3.11.10
-  build: hc5c86c4_3_cpython
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
   sha256: b7fa3bd48e3a3d30f65608e07759cefd27885c6388b3f612af85ce40282e6936
   md5: 9e1ad55c87368e662177661a998feed5
   depends:
@@ -19823,65 +15352,7 @@ packages:
   license: Python-2.0
   size: 30543977
   timestamp: 1729043512711
-- kind: conda
-  name: python
-  version: 3.11.10
-  build: hce54a09_3_cpython
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
-  sha256: 3931c546219d069918389e4dbe12057af4cc68a1060577a04014c6b5fc618aa0
-  md5: 5d54d429c0eb2273d1cc69763de6edaf
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.11.* *_cp311
-  license: Python-2.0
-  size: 18206702
-  timestamp: 1729041779073
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: h739c21a_0_cpython
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
-  sha256: 45d7ca2074aa92594bd2f91a9003b338cc1df8a46b9492b7fc8167110783c3ef
-  md5: e0d82e57ebb456077565e6d82cd4a323
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 12975439
-  timestamp: 1728057819519
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: hc5c86c4_0_cpython
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
   sha256: 674be31ff152d9f0e0fe16959a45e3803a730fc4f54d87df6a9ac4e6a698c41d
   md5: 0515111a9cdf69f83278f7c197db9807
   depends:
@@ -19907,39 +15378,98 @@ packages:
   license: Python-2.0
   size: 31574780
   timestamp: 1728059777603
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: hce54a09_0_cpython
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.7-hce54a09_0_cpython.conda
-  sha256: 2308cfa9ec563360d29ced7fd13a6b60b9a7b3cf8961a95c78c69f486211d018
-  md5: 21f1f7c6ccf6b747c5086d2422c230e1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.20-h13acc7a_1_cpython.conda
+  build_number: 1
+  sha256: 6a30aa8df1745eded1e5c24d167cb10e6f379e75d2f2fa2a212e6dab76030698
+  md5: 951cff166a5f170e27908811917165f8
   depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  size: 23684398
+  timestamp: 1727719528404
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.15-hdce6c4c_2_cpython.conda
+  build_number: 2
+  sha256: 50dbbcc5efacaa05906cdc6b42bbdda17cee7910386bef8d737edffe7f5a7f2f
+  md5: b6a5e688170f1301a858f6001c32822d
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 12411616
+  timestamp: 1729042103758
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+  build_number: 3
+  sha256: 95a2c487176867ded825e23eab1e581398f75c5323da0cb7577c3cff3d2f955b
+  md5: 2a47a0061d7d3030e45b66d23f01d101
+  depends:
+  - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.6.3,<3.0a0
   - libffi >=3.4,<4.0a0
   - libsqlite >=3.46.1,<4.0a0
   - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
   - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14598065
+  timestamp: 1729042279642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
+  sha256: 45d7ca2074aa92594bd2f91a9003b338cc1df8a46b9492b7fc8167110783c3ef
+  md5: e0d82e57ebb456077565e6d82cd4a323
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
   - xz >=5.2.6,<6.0a0
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 15987537
-  timestamp: 1728057382072
-- kind: conda
-  name: python
-  version: 3.13.0
-  build: hbbac1ca_101_cp313
+  size: 12975439
+  timestamp: 1728057819519
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.0-hbbac1ca_101_cp313.conda
   build_number: 101
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.0-hbbac1ca_101_cp313.conda
   sha256: 742544a4cf9a10cf2c16d35d96fb696c27d58b9df0cc29fbef5629283aeca941
   md5: e972e146a1e0cfb1f26da42cb6f6648c
   depends:
@@ -19960,13 +15490,93 @@ packages:
   license: Python-2.0
   size: 12806496
   timestamp: 1732735488999
-- kind: conda
-  name: python
-  version: 3.13.0
-  build: hf5aa216_101_cp313
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.20-h9e33284_1_cpython.conda
+  build_number: 1
+  sha256: d6c272faa05fb7524aaf59718fa27629b1875e5dfb2fa74100547e8564cce4bc
+  md5: 708bd3a3616e42becb50d77313def984
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  size: 11826087
+  timestamp: 1727718700429
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.15-hfaddaf0_2_cpython.conda
+  build_number: 2
+  sha256: ee5af019e5d7140ad2d40b5f772fcd68ded056853a478a2b54f417855977e99b
+  md5: 52a45ce756c062994b25738288c8ab62
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 15933377
+  timestamp: 1729041771524
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+  build_number: 3
+  sha256: 3931c546219d069918389e4dbe12057af4cc68a1060577a04014c6b5fc618aa0
+  md5: 5d54d429c0eb2273d1cc69763de6edaf
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18206702
+  timestamp: 1729041779073
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.7-hce54a09_0_cpython.conda
+  sha256: 2308cfa9ec563360d29ced7fd13a6b60b9a7b3cf8961a95c78c69f486211d018
+  md5: 21f1f7c6ccf6b747c5086d2422c230e1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  size: 15987537
+  timestamp: 1728057382072
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.0-hf5aa216_101_cp313.conda
   build_number: 101
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.13.0-hf5aa216_101_cp313.conda
   sha256: b8eba57bd86c7890b27e67b477b52b5bd547946c354f29b9dbbc70ad83f2863b
   md5: 158d6077a635cf0c0c23bec3955a4833
   depends:
@@ -19987,13 +15597,28 @@ packages:
   license: Python-2.0
   size: 16697406
   timestamp: 1732734725404
-- kind: conda
-  name: python-dateutil
-  version: 2.9.0.post0
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.9.20-hfaddaf0_1_cpython.conda
+  build_number: 1
+  sha256: c4ef6a17c8065d8c653fc69cfa17b2a1b0d9a2ca1360ba67a514b450c8797fd9
+  md5: 445389d1d311435a90def248c814ddd6
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  size: 17024927
+  timestamp: 1727718943163
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
   sha256: 3888012c5916efaef45d503e3e544bbcc571b84426c1bb9577799ada9efefb54
   md5: b6dfd90a2141e573e4b6a81630b56df5
   depends:
@@ -20003,13 +15628,7 @@ packages:
   license_family: APACHE
   size: 221925
   timestamp: 1731919374686
-- kind: conda
-  name: python-fastjsonschema
-  version: 2.21.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.0-pyhd8ed1ab_0.conda
   sha256: 09ae0acccbfc325b9b65946795c0055e0a40374e4e73b264f3b7e8cd8ae0a95a
   md5: 4c849126120d1b3d61cf0eac8120ea70
   depends:
@@ -20018,13 +15637,7 @@ packages:
   license_family: BSD
   size: 225949
   timestamp: 1732805566866
-- kind: conda
-  name: python-json-logger
-  version: 2.0.7
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
   sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
   md5: a61bf9ec79426938ff785eb69dbb1960
   depends:
@@ -20033,13 +15646,7 @@ packages:
   license_family: BSD
   size: 13383
   timestamp: 1677079727691
-- kind: conda
-  name: python-tzdata
-  version: '2024.2'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
   sha256: fe3f62ce2bc714bdaa222ab3f0344a2815ad9e853c6df38d15c9f25de8a3a6d4
   md5: 986287f89929b2d629bd6ef6497dc307
   depends:
@@ -20048,58 +15655,8 @@ packages:
   license_family: APACHE
   size: 142527
   timestamp: 1727140688093
-- kind: conda
-  name: python_abi
-  version: '3.9'
-  build: 5_cp39
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-5_cp310.conda
   build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-5_cp39.conda
-  sha256: 019e2f8bca1d1f1365fbb9965cd95bb395c92c89ddd03165db82f5ae89a20812
-  md5: 40363a30db350596b5f225d0d5a33328
-  constrains:
-  - python 3.9.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6193
-  timestamp: 1723823354399
-- kind: conda
-  name: python_abi
-  version: '3.9'
-  build: 5_cp39
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.9-5_cp39.conda
-  sha256: a942c019a98f4c89bc3a73a6a583f65d1c8fc560ccfdbdd9cba9f5ef719026fb
-  md5: 1ca4a5e8290873da8963182d9673299d
-  constrains:
-  - python 3.9.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6326
-  timestamp: 1723823464252
-- kind: conda
-  name: python_abi
-  version: '3.9'
-  build: 5_cp39
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.9-5_cp39.conda
-  sha256: ee9471759ba567d5a4922d4fae95f58a0070db7616cba72e3bfb22cd5c50e37a
-  md5: 86ba1bbcf9b259d1592201f3c345c810
-  constrains:
-  - python 3.9.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6706
-  timestamp: 1723823197703
-- kind: conda
-  name: python_abi
-  version: '3.10'
-  build: 5_cp310
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-5_cp310.conda
   sha256: 074d2f0b31f0333b7e553042b17ea54714b74263f8adda9a68a4bd8c7e219971
   md5: 2921c34715e74b3587b4cff4d36844f9
   constrains:
@@ -20108,43 +15665,8 @@ packages:
   license_family: BSD
   size: 6227
   timestamp: 1723823165457
-- kind: conda
-  name: python_abi
-  version: '3.10'
-  build: 5_cp310
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
   build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-5_cp310.conda
-  sha256: 15a1e37da3e52c9250eac103858aad494ce23501d72fb78f5a2126046c9a9e2d
-  md5: e33836c9096802b29d28981765becbee
-  constrains:
-  - python 3.10.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6324
-  timestamp: 1723823147856
-- kind: conda
-  name: python_abi
-  version: '3.10'
-  build: 5_cp310
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-5_cp310.conda
-  sha256: 0671bea4d5c5b8618ee7e2b1117d5a90901348ac459db57b654007f1644fa087
-  md5: 3c510f4c4383f5fbdb12fdd971b30d49
-  constrains:
-  - python 3.10.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6715
-  timestamp: 1723823141288
-- kind: conda
-  name: python_abi
-  version: '3.11'
-  build: 5_cp311
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
   sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
   md5: 139a8d40c8a2f430df31048949e450de
   constrains:
@@ -20153,43 +15675,8 @@ packages:
   license_family: BSD
   size: 6211
   timestamp: 1723823324668
-- kind: conda
-  name: python_abi
-  version: '3.11'
-  build: 5_cp311
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
   build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
-  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
-  md5: 3b855e3734344134cb56c410f729c340
-  constrains:
-  - python 3.11.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6308
-  timestamp: 1723823096865
-- kind: conda
-  name: python_abi
-  version: '3.11'
-  build: 5_cp311
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
-  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
-  md5: 895b873644c11ccc0ab7dba2d8513ae6
-  constrains:
-  - python 3.11.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6707
-  timestamp: 1723823225752
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
   sha256: d10e93d759931ffb6372b45d65ff34d95c6000c61a07e298d162a3bc2accebb0
   md5: 0424ae29b104430108f5218a66db7260
   constrains:
@@ -20198,13 +15685,38 @@ packages:
   license_family: BSD
   size: 6238
   timestamp: 1723823388266
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-5_cp39.conda
   build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+  sha256: 019e2f8bca1d1f1365fbb9965cd95bb395c92c89ddd03165db82f5ae89a20812
+  md5: 40363a30db350596b5f225d0d5a33328
+  constrains:
+  - python 3.9.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6193
+  timestamp: 1723823354399
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-5_cp310.conda
+  build_number: 5
+  sha256: 15a1e37da3e52c9250eac103858aad494ce23501d72fb78f5a2126046c9a9e2d
+  md5: e33836c9096802b29d28981765becbee
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6324
+  timestamp: 1723823147856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  build_number: 5
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+  build_number: 5
   sha256: 49d624e4b809c799d2bf257b22c23cf3fc4460f5570d9a58e7ad86350aeaa1f4
   md5: b76f9b1c862128e56ac7aa8cd2333de9
   constrains:
@@ -20213,28 +15725,8 @@ packages:
   license_family: BSD
   size: 6278
   timestamp: 1723823099686
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.13-5_cp313.conda
   build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
-  sha256: 9486662af81a219e96d343449eff242f38d7c5128ced5ce5acf85857265058d6
-  md5: e8681f534453af7afab4cd2bc1423eec
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6730
-  timestamp: 1723823139725
-- kind: conda
-  name: python_abi
-  version: '3.13'
-  build: 5_cp313
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.13-5_cp313.conda
   sha256: 4437198eae80310f40b23ae2f8a9e0a7e5c2b9ae411a8621eb03d87273666199
   md5: b8e82d0a5c1664638f87f63cc5d241fb
   constrains:
@@ -20243,13 +15735,48 @@ packages:
   license_family: BSD
   size: 6322
   timestamp: 1723823058879
-- kind: conda
-  name: python_abi
-  version: '3.13'
-  build: 5_cp313
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.9-5_cp39.conda
   build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.13-5_cp313.conda
+  sha256: a942c019a98f4c89bc3a73a6a583f65d1c8fc560ccfdbdd9cba9f5ef719026fb
+  md5: 1ca4a5e8290873da8963182d9673299d
+  constrains:
+  - python 3.9.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6326
+  timestamp: 1723823464252
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-5_cp310.conda
+  build_number: 5
+  sha256: 0671bea4d5c5b8618ee7e2b1117d5a90901348ac459db57b654007f1644fa087
+  md5: 3c510f4c4383f5fbdb12fdd971b30d49
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6715
+  timestamp: 1723823141288
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  build_number: 5
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
+  build_number: 5
+  sha256: 9486662af81a219e96d343449eff242f38d7c5128ced5ce5acf85857265058d6
+  md5: e8681f534453af7afab4cd2bc1423eec
+  constrains:
+  - python 3.12.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6730
+  timestamp: 1723823139725
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.13-5_cp313.conda
+  build_number: 5
   sha256: 0c12cc1b84962444002c699ed21e815fb9f686f950d734332a1b74d07db97756
   md5: 44b4fe6f22b57103afb2299935c8b68e
   constrains:
@@ -20258,13 +15785,17 @@ packages:
   license_family: BSD
   size: 6716
   timestamp: 1723823166911
-- kind: conda
-  name: pytz
-  version: '2024.1'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.9-5_cp39.conda
+  build_number: 5
+  sha256: ee9471759ba567d5a4922d4fae95f58a0070db7616cba72e3bfb22cd5c50e37a
+  md5: 86ba1bbcf9b259d1592201f3c345c810
+  constrains:
+  - python 3.9.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6706
+  timestamp: 1723823197703
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
   sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
   md5: 3eeeeb9e4827ace8c0c1419c85d590ad
   depends:
@@ -20273,13 +15804,7 @@ packages:
   license_family: MIT
   size: 188538
   timestamp: 1706886944988
-- kind: conda
-  name: pytz
-  version: '2024.2'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_0.conda
   sha256: 81c16d9183bb4a6780366ce874e567ee5fc903722f85b2f8d1d9479ef1dafcc9
   md5: 260009d03c9d5c0f111904d851f053dc
   depends:
@@ -20288,13 +15813,7 @@ packages:
   license_family: MIT
   size: 186995
   timestamp: 1726055625738
-- kind: conda
-  name: pywin32
-  version: '307'
-  build: py312h275cf98_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py312h275cf98_3.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py312h275cf98_3.conda
   sha256: 68f8781b83942b91dbc0df883f9edfd1a54a1e645ae2a97c48203ff6c2919de3
   md5: 1747fbbdece8ab4358b584698b19c44d
   depends:
@@ -20307,13 +15826,7 @@ packages:
   license_family: PSF
   size: 6032183
   timestamp: 1728636767192
-- kind: conda
-  name: pywin32
-  version: '307'
-  build: py313h5813708_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py313h5813708_3.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py313h5813708_3.conda
   sha256: 0a68b324ea47ae720c62522c5d0bb5ea3e4987e1c5870d6490c7f954fbe14cbe
   md5: 7113bd6cfe34e80d8211f7c019d14357
   depends:
@@ -20326,12 +15839,7 @@ packages:
   license_family: PSF
   size: 6060096
   timestamp: 1728636763526
-- kind: conda
-  name: pywinpty
-  version: 2.0.14
-  build: py312h275cf98_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py312h275cf98_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py312h275cf98_0.conda
   sha256: 20bc64c412b659b387ed12d73ca9138e4487abcfb3f1547b6d4cdb68753035e9
   md5: 0e0aac13d306f0b016f4c85cbfbf87be
   depends:
@@ -20345,13 +15853,20 @@ packages:
   license_family: MIT
   size: 210034
   timestamp: 1729202671199
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py312h024a12e_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h024a12e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
+  sha256: a60705971e958724168f2ebbb8ed4853067f1d3f7059843df3903e3092bbcffa
+  md5: 549e5930e768548a89c23f595dac5a95
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206553
+  timestamp: 1725456256213
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h024a12e_1.conda
   sha256: b06f1c15fb39695bbf707ae8fb554b9a77519af577b5556784534c7db10b52e3
   md5: 1ee23620cf46cb15900f70a1300bae55
   depends:
@@ -20364,13 +15879,20 @@ packages:
   license_family: MIT
   size: 187143
   timestamp: 1725456547263
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py312h4389bb4_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py312h4389bb4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py313h20a7fcf_1.conda
+  sha256: f9fbafcf30cfab591c67f7550c0fd58e2bff394b53864dcdc658f5abd27ce5d6
+  md5: bf2ddf70a9ce8f899b1082d17cbb3d1d
+  depends:
+  - __osx >=11.0
+  - python >=3.13.0rc1,<3.14.0a0
+  - python >=3.13.0rc1,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187550
+  timestamp: 1725456463634
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py312h4389bb4_1.conda
   sha256: fa3ede1fa2ed6ea0a51095aeea398f6f0f54af036c4bc525726107cfb49229d5
   md5: afb7809721516919c276b45f847c085f
   depends:
@@ -20384,51 +15906,7 @@ packages:
   license_family: MIT
   size: 181227
   timestamp: 1725456516473
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py312h66e93f0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
-  sha256: a60705971e958724168f2ebbb8ed4853067f1d3f7059843df3903e3092bbcffa
-  md5: 549e5930e768548a89c23f595dac5a95
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 206553
-  timestamp: 1725456256213
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py313h20a7fcf_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py313h20a7fcf_1.conda
-  sha256: f9fbafcf30cfab591c67f7550c0fd58e2bff394b53864dcdc658f5abd27ce5d6
-  md5: bf2ddf70a9ce8f899b1082d17cbb3d1d
-  depends:
-  - __osx >=11.0
-  - python >=3.13.0rc1,<3.14.0a0
-  - python >=3.13.0rc1,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 187550
-  timestamp: 1725456463634
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py313ha7868ed_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py313ha7868ed_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py313ha7868ed_1.conda
   sha256: ffa21c4715aa139d20c96ae7274fbb7de12a546f3332eb8d07cc794741fcbde6
   md5: c1743e5c4c7402a14b515cf276778e59
   depends:
@@ -20442,13 +15920,7 @@ packages:
   license_family: MIT
   size: 181722
   timestamp: 1725456802746
-- kind: conda
-  name: pyzmq
-  version: 26.2.0
-  build: py312hbf22597_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py312hbf22597_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py312hbf22597_3.conda
   sha256: bc303f9b11e04a515f79cd5ad3bfa0e84b9dfec76552626d6263b38789fe6678
   md5: 746ce19f0829ec3e19c93007b1a224d3
   depends:
@@ -20463,34 +15935,7 @@ packages:
   license_family: BSD
   size: 378126
   timestamp: 1728642454632
-- kind: conda
-  name: pyzmq
-  version: 26.2.0
-  build: py312hd7027bb_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py312hd7027bb_3.conda
-  sha256: 46a645f9482c9ca55716644dae85f6d3cf771b696379d1dd86841ca6007ee409
-  md5: 1ff97de0753654c02e5195a710bbf05c
-  depends:
-  - libsodium >=1.0.20,<1.0.21.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zeromq >=4.3.5,<4.3.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 360217
-  timestamp: 1728642895644
-- kind: conda
-  name: pyzmq
-  version: 26.2.0
-  build: py312hf8a1cbd_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py312hf8a1cbd_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py312hf8a1cbd_3.conda
   sha256: 2e0ca1bb9ab3af5d1f9b38548d65be7097ba0246e7e63c908c9b1323df3f45b5
   md5: 7bdaa4c2a84b744ef26c8b2ba65c3d0e
   depends:
@@ -20505,13 +15950,7 @@ packages:
   license_family: BSD
   size: 361674
   timestamp: 1728642457661
-- kind: conda
-  name: pyzmq
-  version: 26.2.0
-  build: py313h0e8b002_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py313h0e8b002_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py313h0e8b002_3.conda
   sha256: 0fbe80ac4e6d110e82f84fb2466ceace16ba4b9cb175d5945cb9055454b3c06a
   md5: 9fb8f1294d8c5a300c2f76e46f830b01
   depends:
@@ -20526,13 +15965,22 @@ packages:
   license_family: BSD
   size: 365164
   timestamp: 1728642544605
-- kind: conda
-  name: pyzmq
-  version: 26.2.0
-  build: py313h2100fd5_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py313h2100fd5_3.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py312hd7027bb_3.conda
+  sha256: 46a645f9482c9ca55716644dae85f6d3cf771b696379d1dd86841ca6007ee409
+  md5: 1ff97de0753654c02e5195a710bbf05c
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 360217
+  timestamp: 1728642895644
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py313h2100fd5_3.conda
   sha256: 971bea2fd92920327f4a44e69393643193b435c37e7528d93c32071e531fc9ba
   md5: d0ce06d0a38f8ad0dc9b71e14137deee
   depends:
@@ -20547,28 +15995,7 @@ packages:
   license_family: BSD
   size: 367463
   timestamp: 1728643113504
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: h420ef59_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
-  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
-  md5: 6483b1f59526e05d7d894e466b5b6924
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: LicenseRef-Qhull
-  size: 516376
-  timestamp: 1720814307311
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: h434a139_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
   sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
   md5: 353823361b1d27eb3960efb076dfcaf6
   depends:
@@ -20578,13 +16005,16 @@ packages:
   license: LicenseRef-Qhull
   size: 552937
   timestamp: 1720813982144
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: hc790b64_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
   sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
   md5: 854fbdff64b572b5c0b470f334d34c11
   depends:
@@ -20594,26 +16024,23 @@ packages:
   license: LicenseRef-Qhull
   size: 1377020
   timestamp: 1720814433486
-- kind: conda
-  name: rav1e
-  version: 0.6.6
-  build: h69fbcac_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.6.6-h69fbcac_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+  sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
+  md5: 77d9955b4abddb811cb8ab1aa7d743e4
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15423721
+  timestamp: 1694329261357
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.6.6-h69fbcac_2.conda
   sha256: be6174970193cb4d0ffa7d731a93a4c9542881dbc7ab24e74b460ef312161169
   md5: e309ae86569b1cd55a0285fa4e939844
   license: BSD-2-Clause
   license_family: BSD
   size: 1526706
   timestamp: 1694329743011
-- kind: conda
-  name: rav1e
-  version: 0.6.6
-  build: h975169c_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/rav1e-0.6.6-h975169c_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/rav1e-0.6.6-h975169c_2.conda
   sha256: 3193451440e5ac737b7d5d2a79f9e012d426c0c53e41e60df4992150bfc39565
   md5: bd32cc2ed62374932f9d57a2e3eb2863
   depends:
@@ -20624,28 +16051,7 @@ packages:
   license_family: BSD
   size: 1523119
   timestamp: 1694330157594
-- kind: conda
-  name: rav1e
-  version: 0.6.6
-  build: he8a937b_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
-  sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
-  md5: 77d9955b4abddb811cb8ab1aa7d743e4
-  depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 15423721
-  timestamp: 1694329261357
-- kind: conda
-  name: re2
-  version: 2024.07.02
-  build: h77b4e00_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
   sha256: c1721cb80f7201652fc9801f49c214c88aee835d957f2376e301bd40a8415742
   md5: 01093ff37c1b5e6bf9f17c0116747d11
   depends:
@@ -20654,13 +16060,7 @@ packages:
   license_family: BSD
   size: 26665
   timestamp: 1728778975855
-- kind: conda
-  name: re2
-  version: 2024.07.02
-  build: hcd0e937_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
   sha256: eebddde6cb10b146507810b701ef6df122d5309cd5151a39d0828aa44dc53725
   md5: 19e29f2ccc9168eb0a39dc40c04c0e21
   depends:
@@ -20669,13 +16069,7 @@ packages:
   license_family: BSD
   size: 26860
   timestamp: 1728779123653
-- kind: conda
-  name: re2
-  version: 2024.07.02
-  build: hd3b24a8_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
   sha256: 5ac1c50d731c323bb52c78113792a71c5f8f060e5767c0a202120a948e0fc85b
   md5: b4abdc84c969587219e7e759116a3e8b
   depends:
@@ -20684,13 +16078,7 @@ packages:
   license_family: BSD
   size: 214858
   timestamp: 1728779526745
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8228510_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   md5: 47d31b792659ce70f470b5c82fdfb7a4
   depends:
@@ -20700,13 +16088,7 @@ packages:
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h92ec313_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
   sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
   md5: 8cbb776a2f641b943d413b3e19df71f4
   depends:
@@ -20715,13 +16097,7 @@ packages:
   license_family: GPL
   size: 250351
   timestamp: 1679532511311
-- kind: conda
-  name: referencing
-  version: 0.35.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
   sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
   md5: 0fc8b52192a8898627c3efae1003e9f6
   depends:
@@ -20732,13 +16108,7 @@ packages:
   license_family: MIT
   size: 42210
   timestamp: 1714619625532
-- kind: conda
-  name: requests
-  version: 2.32.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
   md5: 5ede4753180c7a550a443c430dc8ab52
   depends:
@@ -20753,13 +16123,7 @@ packages:
   license_family: APACHE
   size: 58810
   timestamp: 1717057174842
-- kind: conda
-  name: rfc3339-validator
-  version: 0.1.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
   sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
   md5: fed45fc5ea0813240707998abe49f520
   depends:
@@ -20769,13 +16133,7 @@ packages:
   license_family: MIT
   size: 8064
   timestamp: 1638811838081
-- kind: conda
-  name: rfc3986-validator
-  version: 0.1.1
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
   sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
   md5: 912a71cc01012ee38e6b90ddd561e36f
   depends:
@@ -20784,12 +16142,7 @@ packages:
   license_family: MIT
   size: 7818
   timestamp: 1598024297745
-- kind: conda
-  name: rpds-py
-  version: 0.21.0
-  build: py312h12e396e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py312h12e396e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py312h12e396e_0.conda
   sha256: 6a2c3808b0922e453b450cc092f5e5da9d2466f48acce224da90432a94146c12
   md5: 37f4ad7cb4214c799f32e5f411c6c69f
   depends:
@@ -20803,30 +16156,7 @@ packages:
   license_family: MIT
   size: 336759
   timestamp: 1730922756033
-- kind: conda
-  name: rpds-py
-  version: 0.21.0
-  build: py312h2615798_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.21.0-py312h2615798_0.conda
-  sha256: 5c7492080f1db9a6def75193d8b296af50adb5ae390835432c095bc515cd19cc
-  md5: 6e9c028c46dddcbf97d6fc6f7b854811
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 210974
-  timestamp: 1730923229667
-- kind: conda
-  name: rpds-py
-  version: 0.21.0
-  build: py312hcd83bfe_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.21.0-py312hcd83bfe_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.21.0-py312hcd83bfe_0.conda
   sha256: a3d885b49b03259ff7306855466933f9ba06e3f4c327cd0122e9a43b68910555
   md5: 8ea53395d5403ae5ec1adabb1a74719a
   depends:
@@ -20840,12 +16170,20 @@ packages:
   license_family: MIT
   size: 295817
   timestamp: 1730922974629
-- kind: conda
-  name: ruff
-  version: 0.8.1
-  build: py312h2156523_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.8.1-py312h2156523_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.21.0-py312h2615798_0.conda
+  sha256: 5c7492080f1db9a6def75193d8b296af50adb5ae390835432c095bc515cd19cc
+  md5: 6e9c028c46dddcbf97d6fc6f7b854811
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 210974
+  timestamp: 1730923229667
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.8.1-py312h2156523_0.conda
   sha256: 8491e2095d5c0d92d63458fccc222a94e3892c463dd8503dc35e5096917c080a
   md5: 2722627efb013e97b624001c391fc5cc
   depends:
@@ -20860,30 +16198,7 @@ packages:
   license_family: MIT
   size: 7862629
   timestamp: 1732870126500
-- kind: conda
-  name: ruff
-  version: 0.8.1
-  build: py313h331c231_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.8.1-py313h331c231_0.conda
-  sha256: 385d9fc0abbdd66dd68c0a71e8a9a3d57a4b1a069bcb452c991d51bde3781e21
-  md5: 6faa6c22f03f4d1f769f42fed9602d1e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 6892876
-  timestamp: 1732870841177
-- kind: conda
-  name: ruff
-  version: 0.8.1
-  build: py313heab95af_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.8.1-py313heab95af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.8.1-py313heab95af_0.conda
   sha256: 0f4b82f2cb83af93c2b4a7964749b82799e51a126db4fd81a72574f8b661c6cb
   md5: 2ac10bad59722af27f61b12c26106e01
   depends:
@@ -20898,12 +16213,20 @@ packages:
   license_family: MIT
   size: 6949768
   timestamp: 1732870522684
-- kind: conda
-  name: s2n
-  version: 1.5.9
-  build: h0fd0ee4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.8.1-py313h331c231_0.conda
+  sha256: 385d9fc0abbdd66dd68c0a71e8a9a3d57a4b1a069bcb452c991d51bde3781e21
+  md5: 6faa6c22f03f4d1f769f42fed9602d1e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 6892876
+  timestamp: 1732870841177
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
   sha256: f2c8e55d6caa8d87a482b1f133963c184de1ccb2303b77cc8ca86c794253f151
   md5: f472432f3753c5ca763d2497e2ea30bf
   depends:
@@ -20914,60 +16237,7 @@ packages:
   license_family: Apache
   size: 355568
   timestamp: 1731541963573
-- kind: conda
-  name: scikit-learn
-  version: 0.24.2
-  build: py39h12ba089_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-0.24.2-py39h12ba089_1.tar.bz2
-  sha256: a34652d487a061350ff57ae232d039806a7ac2400a2f8a8dff4cf4b9c43d8e47
-  md5: e41b669fcb495f295ddadc6803ee95cb
-  depends:
-  - joblib >=0.11
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=11.1.0
-  - llvm-openmp >=11.1.0
-  - llvm-openmp >=12.0.1
-  - numpy >=1.19.5,<2.0a0
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - scipy
-  - threadpoolctl
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6931407
-  timestamp: 1630911078026
-- kind: conda
-  name: scikit-learn
-  version: 0.24.2
-  build: py39h74df8f2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-0.24.2-py39h74df8f2_1.tar.bz2
-  sha256: d42a2f91fc5caf5a9ac5883965b3367c6245e11acdfed75a39cb259cd24c9208
-  md5: 3fa27118f8b88a911e273c20e704433e
-  depends:
-  - joblib >=0.11
-  - libcblas >=3.8.0,<4.0a0
-  - numpy >=1.19.5,<2.0a0
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - scipy
-  - threadpoolctl
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6868691
-  timestamp: 1630911558980
-- kind: conda
-  name: scikit-learn
-  version: 0.24.2
-  build: py39h7c5d8c9_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-0.24.2-py39h7c5d8c9_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-0.24.2-py39h7c5d8c9_1.tar.bz2
   sha256: cf66d75643cbf9c03d0ba40f39305089c3ec4fa41a7aa32b2fab95c021369f68
   md5: 8c1d89936633846d1ac698aa06767475
   depends:
@@ -20984,37 +16254,7 @@ packages:
   license_family: BSD
   size: 7934018
   timestamp: 1630911052191
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py310h0b94ddc_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py310h0b94ddc_1.conda
-  sha256: ae5d1cf85a76412fd2f0c2dfabecf9db957025d10b3dc2be8b9f95cdb54eae96
-  md5: 50ee5d123b77195763c096d712b77a0e
-  depends:
-  - __osx >=11.0
-  - joblib >=1.2.0
-  - libcxx >=17
-  - llvm-openmp >=17.0.6
-  - numpy >=1.19,<3
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - scipy
-  - threadpoolctl >=3.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8467233
-  timestamp: 1726083300521
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py310h27f47ee_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py310h27f47ee_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py310h27f47ee_1.conda
   sha256: 777580d5ba89c5382fa63807a7981ae2261784258e84f5a9e747f5bd3d3428f3
   md5: 374383a1c0d197bdc1eee7c4973b732d
   depends:
@@ -21032,36 +16272,7 @@ packages:
   license_family: BSD
   size: 9234551
   timestamp: 1726083285129
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py310hf2a6c47_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py310hf2a6c47_1.conda
-  sha256: 2beccd9ca490ece4cc9a3915b2c2d499885b5b21ecbf2236511268befccbdd7e
-  md5: bef8985d120ce63d9d68c3799fb9d10c
-  depends:
-  - joblib >=1.2.0
-  - numpy >=1.19,<3
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - scipy
-  - threadpoolctl >=3.1.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8255129
-  timestamp: 1726083798915
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py311h57cc02b_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py311h57cc02b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py311h57cc02b_1.conda
   sha256: b6489f65911847d1f9807e254e9af0815548454b911df4d0b5019f9ab16fe530
   md5: d1b6d7a73364d9fe20d2863bd2c43e3a
   depends:
@@ -21079,84 +16290,7 @@ packages:
   license_family: BSD
   size: 10596895
   timestamp: 1726083362968
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py311h9e23f0f_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py311h9e23f0f_1.conda
-  sha256: cc9f8c3f12ef7cce384285c11e76e981349771542edf14ba069b8b2f22744b5e
-  md5: ad77674e1f893b3ffe27ffa532e2724f
-  depends:
-  - __osx >=11.0
-  - joblib >=1.2.0
-  - libcxx >=17
-  - llvm-openmp >=17.0.6
-  - numpy >=1.19,<3
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  - scipy
-  - threadpoolctl >=3.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9729967
-  timestamp: 1726083178729
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py311hdcb8d17_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py311hdcb8d17_1.conda
-  sha256: 3f23a54f327af0227115b1ac3a8d6b32926e87bfe0097e3c906bd205bb9340b7
-  md5: c3e550b20baa56f911022f6304c8f547
-  depends:
-  - joblib >=1.2.0
-  - numpy >=1.19,<3
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - scipy
-  - threadpoolctl >=3.1.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9491082
-  timestamp: 1726083711620
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py312h387f99c_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py312h387f99c_1.conda
-  sha256: 9a5b51f8699d233a87d67c200aceb5a4b1bd9a899596c2eb958fddc6c2ddb60b
-  md5: 7a6a47b8182f8c5bdabdc772f1357e01
-  depends:
-  - __osx >=11.0
-  - joblib >=1.2.0
-  - libcxx >=17
-  - llvm-openmp >=17.0.6
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - scipy
-  - threadpoolctl >=3.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9581309
-  timestamp: 1726083218204
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py312h7a48858_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py312h7a48858_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py312h7a48858_1.conda
   sha256: 3118b687c7cfb4484cc5c65591b611d834e3ea2424cb75e1e0b0980d0de72afc
   md5: 6b5f4c68483bd0c22bca9094dafc606b
   depends:
@@ -21174,107 +16308,7 @@ packages:
   license_family: BSD
   size: 10393222
   timestamp: 1726083382159
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py312h816cc57_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py312h816cc57_1.conda
-  sha256: 7c64942d20339e965c22e27ceca72e0f0ff7d32962d9621903c3812714835f4f
-  md5: e2b5c3288bd3f8e89a46b98f8d9e8768
-  depends:
-  - joblib >=1.2.0
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - scipy
-  - threadpoolctl >=3.1.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9215977
-  timestamp: 1726083836746
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py313h14e4f8e_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py313h14e4f8e_1.conda
-  sha256: 495e6e736270c7f35fc9c08b8a3f442a23ca44e52a4c90cd18add74ff68644a4
-  md5: 42e10aaa08953fd0c29c86957eebb6d8
-  depends:
-  - __osx >=11.0
-  - joblib >=1.2.0
-  - libcxx >=17
-  - llvm-openmp >=17.0.6
-  - numpy >=1.21,<3
-  - python >=3.13.0rc2,<3.14.0a0
-  - python >=3.13.0rc2,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  - scipy
-  - threadpoolctl >=3.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9628543
-  timestamp: 1726083310026
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py313h4f67946_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py313h4f67946_1.conda
-  sha256: 63dce2c471565e5b679778332a48c47767d122c784b114847b337a182cad61e2
-  md5: dff3e2632fc7d3479f8152d1394ef2b1
-  depends:
-  - joblib >=1.2.0
-  - numpy >=1.21,<3
-  - python >=3.13.0rc2,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - scipy
-  - threadpoolctl >=3.1.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9331778
-  timestamp: 1726083562938
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py39h4704dc7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py39h4704dc7_1.conda
-  sha256: dee83177a3527497b5e60031502321c39700134a7a3d04f10918cd0e2386dbee
-  md5: 741da1d299a6a63d4a62200ccecaad56
-  depends:
-  - __osx >=11.0
-  - joblib >=1.2.0
-  - libcxx >=17
-  - llvm-openmp >=17.0.6
-  - numpy >=1.19,<3
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  - scipy
-  - threadpoolctl >=3.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8472821
-  timestamp: 1726083187925
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py39h4b7350c_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py39h4b7350c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py39h4b7350c_1.conda
   sha256: ff2b7cb7745899cad3d8093cb2d757c6ce472f8ff170b43cd43cfd60a7da94c6
   md5: ee5943d546a2b573f7975ea656e9f54e
   depends:
@@ -21292,13 +16326,200 @@ packages:
   license_family: BSD
   size: 9298226
   timestamp: 1726083274123
-- kind: conda
-  name: scikit-learn
-  version: 1.5.2
-  build: py39hdd013cc_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py39hdd013cc_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-0.24.2-py39h12ba089_1.tar.bz2
+  sha256: a34652d487a061350ff57ae232d039806a7ac2400a2f8a8dff4cf4b9c43d8e47
+  md5: e41b669fcb495f295ddadc6803ee95cb
+  depends:
+  - joblib >=0.11
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=11.1.0
+  - llvm-openmp >=11.1.0
+  - llvm-openmp >=12.0.1
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - scipy
+  - threadpoolctl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6931407
+  timestamp: 1630911078026
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py310h0b94ddc_1.conda
+  sha256: ae5d1cf85a76412fd2f0c2dfabecf9db957025d10b3dc2be8b9f95cdb54eae96
+  md5: 50ee5d123b77195763c096d712b77a0e
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
+  - numpy >=1.19,<3
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8467233
+  timestamp: 1726083300521
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py311h9e23f0f_1.conda
+  sha256: cc9f8c3f12ef7cce384285c11e76e981349771542edf14ba069b8b2f22744b5e
+  md5: ad77674e1f893b3ffe27ffa532e2724f
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9729967
+  timestamp: 1726083178729
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py312h387f99c_1.conda
+  sha256: 9a5b51f8699d233a87d67c200aceb5a4b1bd9a899596c2eb958fddc6c2ddb60b
+  md5: 7a6a47b8182f8c5bdabdc772f1357e01
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9581309
+  timestamp: 1726083218204
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py313h14e4f8e_1.conda
+  sha256: 495e6e736270c7f35fc9c08b8a3f442a23ca44e52a4c90cd18add74ff68644a4
+  md5: 42e10aaa08953fd0c29c86957eebb6d8
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
+  - numpy >=1.21,<3
+  - python >=3.13.0rc2,<3.14.0a0
+  - python >=3.13.0rc2,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9628543
+  timestamp: 1726083310026
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py39h4704dc7_1.conda
+  sha256: dee83177a3527497b5e60031502321c39700134a7a3d04f10918cd0e2386dbee
+  md5: 741da1d299a6a63d4a62200ccecaad56
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
+  - numpy >=1.19,<3
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8472821
+  timestamp: 1726083187925
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-0.24.2-py39h74df8f2_1.tar.bz2
+  sha256: d42a2f91fc5caf5a9ac5883965b3367c6245e11acdfed75a39cb259cd24c9208
+  md5: 3fa27118f8b88a911e273c20e704433e
+  depends:
+  - joblib >=0.11
+  - libcblas >=3.8.0,<4.0a0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - scipy
+  - threadpoolctl
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6868691
+  timestamp: 1630911558980
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py310hf2a6c47_1.conda
+  sha256: 2beccd9ca490ece4cc9a3915b2c2d499885b5b21ecbf2236511268befccbdd7e
+  md5: bef8985d120ce63d9d68c3799fb9d10c
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.19,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - scipy
+  - threadpoolctl >=3.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8255129
+  timestamp: 1726083798915
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py311hdcb8d17_1.conda
+  sha256: 3f23a54f327af0227115b1ac3a8d6b32926e87bfe0097e3c906bd205bb9340b7
+  md5: c3e550b20baa56f911022f6304c8f547
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9491082
+  timestamp: 1726083711620
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py312h816cc57_1.conda
+  sha256: 7c64942d20339e965c22e27ceca72e0f0ff7d32962d9621903c3812714835f4f
+  md5: e2b5c3288bd3f8e89a46b98f8d9e8768
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - scipy
+  - threadpoolctl >=3.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9215977
+  timestamp: 1726083836746
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py313h4f67946_1.conda
+  sha256: 63dce2c471565e5b679778332a48c47767d122c784b114847b337a182cad61e2
+  md5: dff3e2632fc7d3479f8152d1394ef2b1
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.21,<3
+  - python >=3.13.0rc2,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - scipy
+  - threadpoolctl >=3.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9331778
+  timestamp: 1726083562938
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py39hdd013cc_1.conda
   sha256: 10c7e2dc206783347c6749b71d57e8c7ada5bf2f8c10320007a5d90211fb63a1
   md5: ce25c8a70746ea2926e52464b46c1115
   depends:
@@ -21315,142 +16536,7 @@ packages:
   license_family: BSD
   size: 8206755
   timestamp: 1726083727445
-- kind: conda
-  name: scipy
-  version: 1.7.3
-  build: py39h18313fe_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.7.3-py39h18313fe_1.tar.bz2
-  sha256: ec1b18630bfbdef4efd3237fcf63c95c7cf9a47964d7d7142a6ba2d643b5f32f
-  md5: 46e153da83ee818e5acd8f1a07ab1939
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=14.0.4
-  - libgfortran 5.*
-  - libgfortran5 >=11.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.20.3,<1.23
-  - numpy >=1.20.3,<2.0a0
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  constrains:
-  - libopenblas <0.3.26
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19944955
-  timestamp: 1667962299423
-- kind: conda
-  name: scipy
-  version: 1.7.3
-  build: py39hddc5342_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.7.3-py39hddc5342_1.tar.bz2
-  sha256: 745b360ec84da64cfa5981cea061e1b0dac058ddfbb44b6a38066b4db967049e
-  md5: 59fb7e846c538c76112e6c19becd9f58
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=10.4.0
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - numpy >=1.20.3,<1.23
-  - numpy >=1.20.3,<2.0a0
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  constrains:
-  - libopenblas <0.3.26
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 24110689
-  timestamp: 1667961377164
-- kind: conda
-  name: scipy
-  version: 1.7.3
-  build: py39hfbf2dce_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.7.3-py39hfbf2dce_1.tar.bz2
-  sha256: 21c34bdc35f7342a8767af5d23c10e85fd45b2a97c6a62f33c425c99583ceeb2
-  md5: ad858f6408806fe93861a6eee631f436
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - m2w64-gcc-libs
-  - numpy >=1.20.3,<1.23
-  - numpy >=1.20.3,<2.0a0
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
-  constrains:
-  - libopenblas <0.3.26
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25290512
-  timestamp: 1667962165145
-- kind: conda
-  name: scipy
-  version: 1.13.1
-  build: py39h1a10956_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.1-py39h1a10956_0.conda
-  sha256: dc694e034d1223266de3224c3fe60d36865eebd2f7e43cb1cf06dfdf983f7f3e
-  md5: 9f8e571406af04d2f5fdcbecec704505
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.22.4,<2.3
-  - numpy >=1.19,<3
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14854560
-  timestamp: 1716472552464
-- kind: conda
-  name: scipy
-  version: 1.13.1
-  build: py39h3d5391c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.13.1-py39h3d5391c_0.conda
-  sha256: 757850d99c81df9b5a36b201ee1ef850298669facb4e475f1d77cd3e8b10092d
-  md5: 29a07d75356ca619b3cfc8304a9ce6e5
-  depends:
-  - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.22.4,<2.3
-  - numpy >=1.19,<3
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14699719
-  timestamp: 1716472126212
-- kind: conda
-  name: scipy
-  version: 1.13.1
-  build: py39haf93ffa_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.1-py39haf93ffa_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.1-py39haf93ffa_0.conda
   sha256: 55becd997688a9a499aa553e9e61eb28038ca068929c23f0a973ab9a01ac9eac
   md5: 492a2cd65862d16a4aaf535ae9ccb761
   depends:
@@ -21469,65 +16555,7 @@ packages:
   license_family: BSD
   size: 16523290
   timestamp: 1716471188947
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py310hbd0dde3_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py310hbd0dde3_1.conda
-  sha256: 6ba7d1ab0cc549931bb5979c5230d3fa64791a23a23dd8142813da9759ba2b1a
-  md5: 40856f1a065530263c38af13fe7d8f25
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy <2.3
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15353009
-  timestamp: 1729482895418
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py310hc05a576_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py310hc05a576_1.conda
-  sha256: 14014398bd36591fc173bbf71e4673119eac69468cca26b43fa897e5bf2099b1
-  md5: ed7fe288f8210a19a86dc8c00abe5f65
-  depends:
-  - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=17
-  - libgfortran 5.*
-  - libgfortran5 >=13.2.0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy <2.3
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14146255
-  timestamp: 1729481983023
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py310hfcf56fc_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py310hfcf56fc_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py310hfcf56fc_1.conda
   sha256: df95244cd5faf7ede8560081db49892cb8ae99e202044d9eb00e4792d9d29af0
   md5: d9b1b75a227dbc42f3fe0e8bc852b805
   depends:
@@ -21548,13 +16576,7 @@ packages:
   license_family: BSD
   size: 16856618
   timestamp: 1729481945376
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py311he9a78e4_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
   sha256: 59482b974c36c375fdfd0bc3e5a3003ea2d2ae72b64b8f3deaeef5a851dbc91d
   md5: 49ba89bf4d8a995efb99517d1c7aeb1e
   depends:
@@ -21575,117 +16597,7 @@ packages:
   license_family: BSD
   size: 17592106
   timestamp: 1729481734425
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py311hf16d85f_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
-  sha256: bd3c3ec5ba203143818fa3ca300060a459d78da566049b49ed2ef20e04ea5b96
-  md5: b7c132408b0ee7408dcfa998ef6f7939
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy <2.3
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15858505
-  timestamp: 1729482598163
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py311hf1db568_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
-  sha256: 082a72e5f197aefb59e9f40176df835407e5f71ec832541ba14d4326d3686552
-  md5: 1163490da89fd85d00d29b4d4be7cf0c
-  depends:
-  - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=17
-  - libgfortran 5.*
-  - libgfortran5 >=13.2.0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy <2.3
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15242433
-  timestamp: 1729481958579
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py312h20deb59_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py312h20deb59_1.conda
-  sha256: 1a4d655609bad7dbdbe9f44ba37fd100d01fb8e4e7060dfaed3c4a044ab40052
-  md5: c60ad657cccb6c2b97513f87ae27f47a
-  depends:
-  - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=17
-  - libgfortran 5.*
-  - libgfortran5 >=13.2.0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy <2.3
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15132713
-  timestamp: 1729481799441
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py312h337df96_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py312h337df96_1.conda
-  sha256: d0a8b9e849ae53af5c8373d1429464e071fda3ee35accb77775757b330e0d340
-  md5: 7d85322084d7262008c49c85d3079c50
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy <2.3
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 16143541
-  timestamp: 1729482531384
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py312h62794b6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py312h62794b6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py312h62794b6_1.conda
   sha256: d069a64edade554261672d8febf4756aeb56a6cb44bd91844eaa944e5d9f4eb9
   md5: b43233a9e2f62fb94affe5607ea79473
   depends:
@@ -21706,38 +16618,112 @@ packages:
   license_family: BSD
   size: 17622722
   timestamp: 1729481826601
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py313h16bbbb2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py313h16bbbb2_1.conda
-  sha256: 99c6985ab40b8e4706da29e32eeb4bc30ce39edfe7417eb30cd894e693850ac1
-  md5: 8d7c8f97de9570c2344ac17b7647e016
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.7.3-py39hddc5342_1.tar.bz2
+  sha256: 745b360ec84da64cfa5981cea061e1b0dac058ddfbb44b6a38066b4db967049e
+  md5: 59fb7e846c538c76112e6c19becd9f58
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=10.4.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy <2.4
-  - numpy >=1.21,<3
-  - numpy >=1.23.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - libstdcxx-ng >=12
+  - numpy >=1.20.3,<1.23
+  - numpy >=1.20.3,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - libopenblas <0.3.26
   license: BSD-3-Clause
   license_family: BSD
-  size: 16018018
-  timestamp: 1729482196516
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py313hb3ee861_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py313hb3ee861_1.conda
+  size: 24110689
+  timestamp: 1667961377164
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.13.1-py39h3d5391c_0.conda
+  sha256: 757850d99c81df9b5a36b201ee1ef850298669facb4e475f1d77cd3e8b10092d
+  md5: 29a07d75356ca619b3cfc8304a9ce6e5
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.22.4,<2.3
+  - numpy >=1.19,<3
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14699719
+  timestamp: 1716472126212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py310hc05a576_1.conda
+  sha256: 14014398bd36591fc173bbf71e4673119eac69468cca26b43fa897e5bf2099b1
+  md5: ed7fe288f8210a19a86dc8c00abe5f65
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14146255
+  timestamp: 1729481983023
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+  sha256: 082a72e5f197aefb59e9f40176df835407e5f71ec832541ba14d4326d3686552
+  md5: 1163490da89fd85d00d29b4d4be7cf0c
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15242433
+  timestamp: 1729481958579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py312h20deb59_1.conda
+  sha256: 1a4d655609bad7dbdbe9f44ba37fd100d01fb8e4e7060dfaed3c4a044ab40052
+  md5: c60ad657cccb6c2b97513f87ae27f47a
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15132713
+  timestamp: 1729481799441
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py313hb3ee861_1.conda
   sha256: 83f3ab4c5a07ae387f8f0732df6b69acba003087c569b0b434f1c56dea5f987c
   md5: 0a7222016eccf2b60420e3080b2eff66
   depends:
@@ -21758,13 +16744,143 @@ packages:
   license_family: BSD
   size: 15266204
   timestamp: 1729481942884
-- kind: conda
-  name: send2trash
-  version: 1.8.3
-  build: pyh0d859eb_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.7.3-py39h18313fe_1.tar.bz2
+  sha256: ec1b18630bfbdef4efd3237fcf63c95c7cf9a47964d7d7142a6ba2d643b5f32f
+  md5: 46e153da83ee818e5acd8f1a07ab1939
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=14.0.4
+  - libgfortran 5.*
+  - libgfortran5 >=11.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.20.3,<1.23
+  - numpy >=1.20.3,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19944955
+  timestamp: 1667962299423
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.1-py39h1a10956_0.conda
+  sha256: dc694e034d1223266de3224c3fe60d36865eebd2f7e43cb1cf06dfdf983f7f3e
+  md5: 9f8e571406af04d2f5fdcbecec704505
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.22.4,<2.3
+  - numpy >=1.19,<3
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14854560
+  timestamp: 1716472552464
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py310hbd0dde3_1.conda
+  sha256: 6ba7d1ab0cc549931bb5979c5230d3fa64791a23a23dd8142813da9759ba2b1a
+  md5: 40856f1a065530263c38af13fe7d8f25
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15353009
+  timestamp: 1729482895418
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+  sha256: bd3c3ec5ba203143818fa3ca300060a459d78da566049b49ed2ef20e04ea5b96
+  md5: b7c132408b0ee7408dcfa998ef6f7939
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15858505
+  timestamp: 1729482598163
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py312h337df96_1.conda
+  sha256: d0a8b9e849ae53af5c8373d1429464e071fda3ee35accb77775757b330e0d340
+  md5: 7d85322084d7262008c49c85d3079c50
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16143541
+  timestamp: 1729482531384
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py313h16bbbb2_1.conda
+  sha256: 99c6985ab40b8e4706da29e32eeb4bc30ce39edfe7417eb30cd894e693850ac1
+  md5: 8d7c8f97de9570c2344ac17b7647e016
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.4
+  - numpy >=1.21,<3
+  - numpy >=1.23.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16018018
+  timestamp: 1729482196516
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.7.3-py39hfbf2dce_1.tar.bz2
+  sha256: 21c34bdc35f7342a8767af5d23c10e85fd45b2a97c6a62f33c425c99583ceeb2
+  md5: ad858f6408806fe93861a6eee631f436
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - m2w64-gcc-libs
+  - numpy >=1.20.3,<1.23
+  - numpy >=1.20.3,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25290512
+  timestamp: 1667962165145
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
   sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
   md5: 778594b20097b5a948c59e50ae42482a
   depends:
@@ -21774,13 +16890,7 @@ packages:
   license_family: BSD
   size: 22868
   timestamp: 1712585140895
-- kind: conda
-  name: send2trash
-  version: 1.8.3
-  build: pyh31c8845_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
   sha256: f911307db932c92510da6c3c15b461aef935720776643a1fbf3683f61001068b
   md5: c3cb67fc72fb38020fe7923dbbcf69b0
   depends:
@@ -21791,13 +16901,7 @@ packages:
   license_family: BSD
   size: 23165
   timestamp: 1712585504123
-- kind: conda
-  name: send2trash
-  version: 1.8.3
-  build: pyh5737063_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
   sha256: d8aa230501a33250af2deee03006a2579f0335e7240a9c7286834788dcdcfaa8
   md5: 5a86a21050ca3831ec7f77fb302f1132
   depends:
@@ -21808,13 +16912,26 @@ packages:
   license_family: BSD
   size: 23319
   timestamp: 1712585816346
-- kind: conda
-  name: setuptools
-  version: 59.8.0
-  build: py39h2804cbe_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/setuptools-59.8.0-py39h2804cbe_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/setuptools-59.8.0-py39hf3d152e_1.tar.bz2
+  sha256: ec8146799fabb0edfd0b2622fdd05413c9a2fcd13dfa846958214f9909ab3435
+  md5: 4252d0c211566a9f65149ba7f6e87aa4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: MIT
+  license_family: MIT
+  size: 1047880
+  timestamp: 1648692025516
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+  sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
+  md5: fc80f7995e396cbaeabd23cf46c413dc
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 774252
+  timestamp: 1732632769210
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/setuptools-59.8.0-py39h2804cbe_1.tar.bz2
   sha256: 7c02e55039e0514184cb4debd2fadedf5223bf0ac9a5eae2ff49bf6e1e314285
   md5: 27c3effc9a6ae935378b603157461239
   depends:
@@ -21825,13 +16942,7 @@ packages:
   license_family: MIT
   size: 1042646
   timestamp: 1648692212113
-- kind: conda
-  name: setuptools
-  version: 59.8.0
-  build: py39hcbf5309_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/setuptools-59.8.0-py39hcbf5309_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/setuptools-59.8.0-py39hcbf5309_1.tar.bz2
   sha256: b2b313ae0aefc404cf3288562b2bf0eb90548865de3a3d4253adfc056bbf61e9
   md5: 47c36361b12024db7cbd86e28435bc3c
   depends:
@@ -21841,45 +16952,7 @@ packages:
   license_family: MIT
   size: 1046653
   timestamp: 1648692663198
-- kind: conda
-  name: setuptools
-  version: 59.8.0
-  build: py39hf3d152e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/setuptools-59.8.0-py39hf3d152e_1.tar.bz2
-  sha256: ec8146799fabb0edfd0b2622fdd05413c9a2fcd13dfa846958214f9909ab3435
-  md5: 4252d0c211566a9f65149ba7f6e87aa4
-  depends:
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: MIT
-  license_family: MIT
-  size: 1047880
-  timestamp: 1648692025516
-- kind: conda
-  name: setuptools
-  version: 75.6.0
-  build: pyhff2d567_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
-  sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
-  md5: fc80f7995e396cbaeabd23cf46c413dc
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 774252
-  timestamp: 1732632769210
-- kind: conda
-  name: setuptools-scm
-  version: 8.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
   sha256: 3f7b45c90eaa1c9e7ef974d3995a98a37f7672b40e002455baf0fce256e7f202
   md5: ba9f7f0ec4f2a18de3e7bce67c4a431e
   depends:
@@ -21892,13 +16965,35 @@ packages:
   license_family: MIT
   size: 37824
   timestamp: 1715083339319
-- kind: conda
-  name: shapely
-  version: 2.0.6
-  build: py312h0c580ee_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.6-py312h0c580ee_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.6-py312h391bc85_2.conda
+  sha256: f8668874427468e53e08f33903c8040415807fd9efb09c92b4592778654d6027
+  md5: eb476b4975ea28ac12ff469063a71f5d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 571386
+  timestamp: 1727273539771
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.6-py312h3a6007a_2.conda
+  sha256: d59f5dec101acd385408997d198053e4aca79193620598d37a750f6f3a9bbd9e
+  md5: 3461871a3cde1bf6ab3564b2dce32655
+  depends:
+  - __osx >=11.0
+  - geos >=3.13.0,<3.13.1.0a0
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 532284
+  timestamp: 1727273795356
+- conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.6-py312h0c580ee_2.conda
   sha256: ab01255f62a50bffd1060b4eccb744812cfdb17d2e881af3d00fc94b0bb1bbe5
   md5: 47e5eab5c53da52540d057b8d73ac49a
   depends:
@@ -21913,52 +17008,7 @@ packages:
   license_family: BSD
   size: 534759
   timestamp: 1727274378841
-- kind: conda
-  name: shapely
-  version: 2.0.6
-  build: py312h391bc85_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.6-py312h391bc85_2.conda
-  sha256: f8668874427468e53e08f33903c8040415807fd9efb09c92b4592778654d6027
-  md5: eb476b4975ea28ac12ff469063a71f5d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - libgcc >=13
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 571386
-  timestamp: 1727273539771
-- kind: conda
-  name: shapely
-  version: 2.0.6
-  build: py312h3a6007a_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.6-py312h3a6007a_2.conda
-  sha256: d59f5dec101acd385408997d198053e4aca79193620598d37a750f6f3a9bbd9e
-  md5: 3461871a3cde1bf6ab3564b2dce32655
-  depends:
-  - __osx >=11.0
-  - geos >=3.13.0,<3.13.1.0a0
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 532284
-  timestamp: 1727273795356
-- kind: conda
-  name: sigtool
-  version: 0.1.3
-  build: h44b9a77_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
   sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
   md5: 4a2cac04f86a4540b8c9b8d8f597848f
   depends:
@@ -21967,13 +17017,7 @@ packages:
   license_family: MIT
   size: 210264
   timestamp: 1643442231687
-- kind: conda
-  name: six
-  version: 1.16.0
-  build: pyh6c4a22f_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
   sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
   md5: e5f25f8dbc060e9a8d912e432202afc2
   depends:
@@ -21982,12 +17026,27 @@ packages:
   license_family: MIT
   size: 14259
   timestamp: 1620240338595
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: h23299a8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
   sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
   md5: 7635a408509e20dcfc7653ca305ad799
   depends:
@@ -21998,43 +17057,7 @@ packages:
   license_family: BSD
   size: 59350
   timestamp: 1720004197144
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: ha2e4443_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
-  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
-  md5: 6b7dcc7349efd123d493d2dbe85a045f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 42465
-  timestamp: 1720003704360
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: hd02b534_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
-  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
-  md5: 69d0f9694f3294418ee935da3d5f7272
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 35708
-  timestamp: 1720003794374
-- kind: conda
-  name: sniffio
-  version: 1.3.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
   sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
   md5: 490730480d76cf9c8f8f2849719c6e2b
   depends:
@@ -22043,13 +17066,7 @@ packages:
   license_family: Apache
   size: 15064
   timestamp: 1708953086199
-- kind: conda
-  name: snowballstemmer
-  version: 2.2.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
   sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
   md5: 4d22a9315e78c6827f806065957d566e
   depends:
@@ -22058,13 +17075,7 @@ packages:
   license_family: BSD
   size: 58824
   timestamp: 1637143137377
-- kind: conda
-  name: sortedcontainers
-  version: 2.4.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
   sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
   md5: 6d6552722448103793743dabfbda532d
   depends:
@@ -22073,14 +17084,7 @@ packages:
   license_family: APACHE
   size: 26314
   timestamp: 1621217159824
-- kind: conda
-  name: soupsieve
-  version: '2.5'
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
   sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   md5: 3f144b2c34f8cb5a9abd9ed23a39c561
   depends:
@@ -22089,14 +17093,7 @@ packages:
   license_family: MIT
   size: 36754
   timestamp: 1693929424267
-- kind: conda
-  name: sparse
-  version: 0.15.4
-  build: pyh267e887_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.15.4-pyh267e887_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sparse-0.15.4-pyh267e887_1.conda
   sha256: d6698bdf9411daf3f79f3745b687b18df47b5201e3d1e486fac62722cbe0bc32
   md5: 40d80cd9fa4cc759c6dba19ea96642db
   depends:
@@ -22109,13 +17106,7 @@ packages:
   license_family: BSD
   size: 98181
   timestamp: 1727687215683
-- kind: conda
-  name: sphinx
-  version: 8.1.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-8.1.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-8.1.3-pyhd8ed1ab_0.conda
   sha256: e9e3eaa7277934ba20314ffb92c941c4ec12c0c440e608b7b495c5ce579af1f7
   md5: 05706dd5a145a9c91861495cd435409a
   depends:
@@ -22141,13 +17132,7 @@ packages:
   license_family: BSD
   size: 1401233
   timestamp: 1728874101851
-- kind: conda
-  name: sphinx_rtd_theme
-  version: 3.0.1
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx_rtd_theme-3.0.1-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinx_rtd_theme-3.0.1-pyha770c72_0.conda
   sha256: b81e8b0a66dcff33f308909940c9127e51536b99a51167f3e7266e65e3473f7d
   md5: 740536f8a54250b1964e494c0bf5c9c3
   depends:
@@ -22159,14 +17144,7 @@ packages:
   license_family: MIT
   size: 4630230
   timestamp: 1730015354284
-- kind: conda
-  name: sphinxcontrib-apidoc
-  version: 0.3.0
-  build: py_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-apidoc-0.3.0-py_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-apidoc-0.3.0-py_1.tar.bz2
   sha256: 6dd136a86576c400b0bdbfffbdba4a35015846a0a7eb1129a1401a17d4f60b19
   md5: 855b087883443abb10f5faf6eef40860
   depends:
@@ -22176,13 +17154,7 @@ packages:
   license_family: BSD
   size: 10555
   timestamp: 1553967001880
-- kind: conda
-  name: sphinxcontrib-applehelp
-  version: 2.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_0.conda
   sha256: 8ac476358cf26098e3a360b2a9037bd809243f72934c103953e25f4fda4b9f31
   md5: 9075bd8c033f0257122300db914e49c9
   depends:
@@ -22192,13 +17164,7 @@ packages:
   license_family: BSD
   size: 29617
   timestamp: 1722244567894
-- kind: conda
-  name: sphinxcontrib-devhelp
-  version: 2.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_0.conda
   sha256: 6790efe55f168816dfc9c14235054d5156e5150d28546c5baf2ff4973eff8f6b
   md5: b3bcc38c471ebb738854f52a36059b48
   depends:
@@ -22208,13 +17174,7 @@ packages:
   license_family: BSD
   size: 24138
   timestamp: 1722245127289
-- kind: conda
-  name: sphinxcontrib-htmlhelp
-  version: 2.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_0.conda
   sha256: 55e14b77ed786ab6ff752b8d75f8448536f385ed250f432bd408d2eff5ea4a9e
   md5: e25640d692c02e8acfff0372f547e940
   depends:
@@ -22224,13 +17184,7 @@ packages:
   license_family: BSD
   size: 32798
   timestamp: 1722248429933
-- kind: conda
-  name: sphinxcontrib-jquery
-  version: '4.1'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jquery-4.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jquery-4.1-pyhd8ed1ab_0.conda
   sha256: 2e5f16a2d58f9a31443ffbb8ce3852cfccf533a6349045828cd2e994ef0679ca
   md5: 914897066d5873acfb13e75705276ad1
   depends:
@@ -22239,13 +17193,7 @@ packages:
   license: 0BSD AND MIT
   size: 112985
   timestamp: 1678809100921
-- kind: conda
-  name: sphinxcontrib-jsmath
-  version: 1.0.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
   sha256: d4337d83b8edba688547766fc80f1ac86d6ec86ceeeda93f376acc04079c5ce2
   md5: da1d979339e2714c30a8e806a33ec087
   depends:
@@ -22254,13 +17202,7 @@ packages:
   license_family: BSD
   size: 10431
   timestamp: 1691604844204
-- kind: conda
-  name: sphinxcontrib-qthelp
-  version: 2.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_0.conda
   sha256: 7ae639b729844de2ec74dbaf1acccc14843868a82fa46cd2ceb735bc8266af5b
   md5: d6e5ea5fe00164ac6c2dcc5d76a42192
   depends:
@@ -22270,13 +17212,7 @@ packages:
   license_family: BSD
   size: 26794
   timestamp: 1722245959953
-- kind: conda
-  name: sphinxcontrib-serializinghtml
-  version: 1.1.10
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_0.conda
   sha256: bf80e4c0ff97d5e8e5f6db0831ba60007e820a3a438e8f1afd868aa516d67d6f
   md5: e507335cb4ca9cff4c3d0fa9cdab255e
   depends:
@@ -22286,13 +17222,7 @@ packages:
   license_family: BSD
   size: 28776
   timestamp: 1705118378942
-- kind: conda
-  name: sphinxext-altair
-  version: 0.1.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxext-altair-0.1.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxext-altair-0.1.1-pyhd8ed1ab_0.conda
   sha256: 8fdde251de6e57b2c82fc0272154466a499a5ee7655b08c7660ad83dd0d42ea6
   md5: 2425fb9b75fd47b38008f08c45a4bd91
   depends:
@@ -22306,30 +17236,7 @@ packages:
   license_family: BSD
   size: 13465
   timestamp: 1684135593910
-- kind: conda
-  name: sqlite
-  version: 3.47.0
-  build: h2466b09_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
-  sha256: bc2a5ab86dbe2352790d1742265b3b6ae9a7aa5cf80345a37f26ec3e04cf9b4a
-  md5: 93084a590e8b7d2b62b7d5b1763d5bde
-  depends:
-  - libsqlite 3.47.0 h2466b09_1
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Unlicense
-  size: 914686
-  timestamp: 1730208443157
-- kind: conda
-  name: sqlite
-  version: 3.47.0
-  build: h9eae976_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
   sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
   md5: 53abf1ef70b9ae213b22caa5350f97a9
   depends:
@@ -22342,13 +17249,7 @@ packages:
   license: Unlicense
   size: 883666
   timestamp: 1730208056779
-- kind: conda
-  name: sqlite
-  version: 3.47.0
-  build: hcd14bea_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
   sha256: f9975914a78d600182ec68c963a98c6c0a07eda9b9eee7d6e8bdac9310858ad2
   md5: ca42c22ab1d212895e58fee9ba32875f
   depends:
@@ -22360,13 +17261,18 @@ packages:
   license: Unlicense
   size: 840459
   timestamp: 1730208324005
-- kind: conda
-  name: stack_data
-  version: 0.6.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+  sha256: bc2a5ab86dbe2352790d1742265b3b6ae9a7aa5cf80345a37f26ec3e04cf9b4a
+  md5: 93084a590e8b7d2b62b7d5b1763d5bde
+  depends:
+  - libsqlite 3.47.0 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 914686
+  timestamp: 1730208443157
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
   sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
   md5: e7df0fdd404616638df5ece6e69ba7af
   depends:
@@ -22378,33 +17284,7 @@ packages:
   license_family: MIT
   size: 26205
   timestamp: 1669632203115
-- kind: conda
-  name: statsmodels
-  version: 0.14.1
-  build: py39h373d45f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.1-py39h373d45f_0.conda
-  sha256: 48b66893df0eeda32975caed8381b1e88c785a5b94bf71dae3305b89b149ca1c
-  md5: b6f3a40c7a26a2813a98f4e3d5786b22
-  depends:
-  - numpy >=1.22.4,<2.0a0
-  - packaging >=21.3
-  - pandas >=1.0,!=2.1.0
-  - patsy >=0.5.4
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  - scipy >=1.4,!=1.9.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 10477859
-  timestamp: 1702576514902
-- kind: conda
-  name: statsmodels
-  version: 0.14.1
-  build: py39h44dd56e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.1-py39h44dd56e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.1-py39h44dd56e_0.conda
   sha256: 94cf29cc1e163820d81d5a9d69544d42095b9a6c0c8c58b1a6a48e7d983959f0
   md5: dc565186b972bd87e49b9c35390ddd8c
   depends:
@@ -22420,35 +17300,95 @@ packages:
   license_family: BSD
   size: 10945332
   timestamp: 1702575894032
-- kind: conda
-  name: statsmodels
-  version: 0.14.1
-  build: py39hd88c2e4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.1-py39hd88c2e4_0.conda
-  sha256: 3cb35c93c5dd56989d09175c0dafdac7db65569d665604664e8f541d51fce736
-  md5: b51565db0ed851e9031da82171d0e02f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py310hf462985_0.conda
+  sha256: a060f9b7e9bff3cae075a00e278089893c20cc0663ced09f9c4d92522ce76a21
+  md5: 636d3c500d8a851e377360e88ec95372
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy <3,>=1.22.3
+  - numpy >=1.19,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10864201
+  timestamp: 1727987212366
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py311h9f3472d_0.conda
+  sha256: b5925165bdd694f2d22f4d367c31faeb5a43861b0e3fce575e459038a5f42f62
+  md5: 81e81b5b7a744fcb279e98aa6d2e6683
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy <3,>=1.22.3
+  - numpy >=1.19,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12291537
+  timestamp: 1727987151832
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py312hc0a28a1_0.conda
+  sha256: 6cc65ba902b32207e8a697b0e0408a28d6cc166be04f1882c40739a86a253d22
+  md5: 97dc960f3d9911964d73c2cf240baea5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy <3,>=1.22.3
+  - numpy >=1.19,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12103203
+  timestamp: 1727987129263
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py39hf3d9206_0.conda
+  sha256: 66f635c2b341b12bc9e36687a93c6576426de600177bf110c52daec3b2ec82a5
+  md5: f633ed7c19e120b9e6c0efb79f20a53f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy <3,>=1.22.3
+  - numpy >=1.19,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10853209
+  timestamp: 1727987220763
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.1-py39h373d45f_0.conda
+  sha256: 48b66893df0eeda32975caed8381b1e88c785a5b94bf71dae3305b89b149ca1c
+  md5: b6f3a40c7a26a2813a98f4e3d5786b22
   depends:
   - numpy >=1.22.4,<2.0a0
   - packaging >=21.3
   - pandas >=1.0,!=2.1.0
   - patsy >=0.5.4
   - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
   - python_abi 3.9.* *_cp39
   - scipy >=1.4,!=1.9.2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 10380509
-  timestamp: 1702576555452
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py310hae04be4_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py310hae04be4_0.conda
+  size: 10477859
+  timestamp: 1702576514902
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py310hae04be4_0.conda
   sha256: 5edac65a2cb03221679fb9061b97c19b6004a26b4128161f9cf683f01424289f
   md5: 894d26a0ed4da5c2dbc0e1f99e5e2875
   depends:
@@ -22466,12 +17406,97 @@ packages:
   license_family: BSD
   size: 10461482
   timestamp: 1727987163602
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py310hb0944cc_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py310hb0944cc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py311h0f07fe1_0.conda
+  sha256: d5b2eb917d36d78b9cd40a52d6237a7f0f69fee816bab38a822048bfa9420364
+  md5: 3cfb17c13747050ab5bc606548530420
+  depends:
+  - __osx >=11.0
+  - numpy <3,>=1.22.3
+  - numpy >=1.19,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11976331
+  timestamp: 1727987205204
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py312h755e627_0.conda
+  sha256: 986f858bc1061a3eac019ccdbb9692cc1dedcacaf4f547a7a55a3c9cfa97b308
+  md5: d9455b9eb18d4bda352265b42c142685
+  depends:
+  - __osx >=11.0
+  - numpy <3,>=1.22.3
+  - numpy >=1.19,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11832944
+  timestamp: 1727987114241
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py313h93df234_0.conda
+  sha256: bd04f71d376946f21729e5b920c5722138cb12e01098ce8a3ff67e6c7bdb880c
+  md5: 5cfb535304bfc73990e5d50184b63f0a
+  depends:
+  - __osx >=11.0
+  - numpy <3,>=1.22.3
+  - numpy >=1.21,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.13.0rc2,<3.14.0a0
+  - python >=3.13.0rc2,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11901433
+  timestamp: 1727987142433
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py39h914ef23_0.conda
+  sha256: 870fc906b5c0fae35ddc52627153e50e516dededfc01a385e992181f47460707
+  md5: 0b0651df9945b8cb9805aa08f03acfb3
+  depends:
+  - __osx >=11.0
+  - numpy <3,>=1.22.3
+  - numpy >=1.19,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10489122
+  timestamp: 1727987132056
+- conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.1-py39hd88c2e4_0.conda
+  sha256: 3cb35c93c5dd56989d09175c0dafdac7db65569d665604664e8f541d51fce736
+  md5: b51565db0ed851e9031da82171d0e02f
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.0,!=2.1.0
+  - patsy >=0.5.4
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - scipy >=1.4,!=1.9.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10380509
+  timestamp: 1702576555452
+- conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py310hb0944cc_0.conda
   sha256: 04ff6ffdbdc7c440c6d06a47fba90eee4b40df7cea93fdf05a94173279c5f5f3
   md5: a572e7b2a32f1c18b701ac9fe858c1f1
   depends:
@@ -22490,35 +17515,7 @@ packages:
   license_family: BSD
   size: 10374616
   timestamp: 1727987843955
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py310hf462985_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py310hf462985_0.conda
-  sha256: a060f9b7e9bff3cae075a00e278089893c20cc0663ced09f9c4d92522ce76a21
-  md5: 636d3c500d8a851e377360e88ec95372
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - numpy <3,>=1.22.3
-  - numpy >=1.19,<3
-  - packaging >=21.3
-  - pandas !=2.1.0,>=1.4
-  - patsy >=0.5.6
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - scipy !=1.9.2,>=1.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 10864201
-  timestamp: 1727987212366
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py311h0a17f05_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py311h0a17f05_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py311h0a17f05_0.conda
   sha256: 466335deb611de3d6606662867cfbf10bbe8c5e57a9c390baa9f4bdc08885066
   md5: 37a4c113a8cbf7bdf01f2351e59757cb
   depends:
@@ -22537,58 +17534,7 @@ packages:
   license_family: BSD
   size: 11707520
   timestamp: 1727987622635
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py311h0f07fe1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py311h0f07fe1_0.conda
-  sha256: d5b2eb917d36d78b9cd40a52d6237a7f0f69fee816bab38a822048bfa9420364
-  md5: 3cfb17c13747050ab5bc606548530420
-  depends:
-  - __osx >=11.0
-  - numpy <3,>=1.22.3
-  - numpy >=1.19,<3
-  - packaging >=21.3
-  - pandas !=2.1.0,>=1.4
-  - patsy >=0.5.6
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  - scipy !=1.9.2,>=1.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11976331
-  timestamp: 1727987205204
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py311h9f3472d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py311h9f3472d_0.conda
-  sha256: b5925165bdd694f2d22f4d367c31faeb5a43861b0e3fce575e459038a5f42f62
-  md5: 81e81b5b7a744fcb279e98aa6d2e6683
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - numpy <3,>=1.22.3
-  - numpy >=1.19,<3
-  - packaging >=21.3
-  - pandas !=2.1.0,>=1.4
-  - patsy >=0.5.6
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - scipy !=1.9.2,>=1.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 12291537
-  timestamp: 1727987151832
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py312h1a27103_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py312h1a27103_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py312h1a27103_0.conda
   sha256: f4324d64753363e31b673379de0f6a6223f6b2d52d30b5b5993392c1b96ac8ee
   md5: 328f5cc12ebb18fb7739478c33285b03
   depends:
@@ -22607,58 +17553,7 @@ packages:
   license_family: BSD
   size: 11693380
   timestamp: 1727987685496
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py312h755e627_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py312h755e627_0.conda
-  sha256: 986f858bc1061a3eac019ccdbb9692cc1dedcacaf4f547a7a55a3c9cfa97b308
-  md5: d9455b9eb18d4bda352265b42c142685
-  depends:
-  - __osx >=11.0
-  - numpy <3,>=1.22.3
-  - numpy >=1.19,<3
-  - packaging >=21.3
-  - pandas !=2.1.0,>=1.4
-  - patsy >=0.5.6
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - scipy !=1.9.2,>=1.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11832944
-  timestamp: 1727987114241
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py312hc0a28a1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py312hc0a28a1_0.conda
-  sha256: 6cc65ba902b32207e8a697b0e0408a28d6cc166be04f1882c40739a86a253d22
-  md5: 97dc960f3d9911964d73c2cf240baea5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - numpy <3,>=1.22.3
-  - numpy >=1.19,<3
-  - packaging >=21.3
-  - pandas !=2.1.0,>=1.4
-  - patsy >=0.5.6
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - scipy !=1.9.2,>=1.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 12103203
-  timestamp: 1727987129263
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py313h8e081ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py313h8e081ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py313h8e081ca_0.conda
   sha256: 30c5731c81f8de663bf42e4ffc3b9508eabeceefaec17a997057e21c15327ec6
   md5: 8ab38d75ca4ad6855d029da04bffd5cb
   depends:
@@ -22677,35 +17572,7 @@ packages:
   license_family: BSD
   size: 11727420
   timestamp: 1727987445149
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py313h93df234_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py313h93df234_0.conda
-  sha256: bd04f71d376946f21729e5b920c5722138cb12e01098ce8a3ff67e6c7bdb880c
-  md5: 5cfb535304bfc73990e5d50184b63f0a
-  depends:
-  - __osx >=11.0
-  - numpy <3,>=1.22.3
-  - numpy >=1.21,<3
-  - packaging >=21.3
-  - pandas !=2.1.0,>=1.4
-  - patsy >=0.5.6
-  - python >=3.13.0rc2,<3.14.0a0
-  - python >=3.13.0rc2,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  - scipy !=1.9.2,>=1.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11901433
-  timestamp: 1727987142433
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py39h4b0a98a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py39h4b0a98a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.4-py39h4b0a98a_0.conda
   sha256: bb54f268a31d1a71101e5d1a921b58a1fd3405cc741d0e5e072afe53157117fc
   md5: 7458967303ba82180a285fc2932d3ba5
   depends:
@@ -22724,58 +17591,7 @@ packages:
   license_family: BSD
   size: 10323515
   timestamp: 1727987643924
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py39h914ef23_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.4-py39h914ef23_0.conda
-  sha256: 870fc906b5c0fae35ddc52627153e50e516dededfc01a385e992181f47460707
-  md5: 0b0651df9945b8cb9805aa08f03acfb3
-  depends:
-  - __osx >=11.0
-  - numpy <3,>=1.22.3
-  - numpy >=1.19,<3
-  - packaging >=21.3
-  - pandas !=2.1.0,>=1.4
-  - patsy >=0.5.6
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  - scipy !=1.9.2,>=1.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 10489122
-  timestamp: 1727987132056
-- kind: conda
-  name: statsmodels
-  version: 0.14.4
-  build: py39hf3d9206_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py39hf3d9206_0.conda
-  sha256: 66f635c2b341b12bc9e36687a93c6576426de600177bf110c52daec3b2ec82a5
-  md5: f633ed7c19e120b9e6c0efb79f20a53f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - numpy <3,>=1.22.3
-  - numpy >=1.19,<3
-  - packaging >=21.3
-  - pandas !=2.1.0,>=1.4
-  - patsy >=0.5.6
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - scipy !=1.9.2,>=1.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 10853209
-  timestamp: 1727987220763
-- kind: conda
-  name: svt-av1
-  version: 2.3.0
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
   sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
   md5: 355898d24394b2af353eb96358db9fdd
   depends:
@@ -22786,12 +17602,17 @@ packages:
   license_family: BSD
   size: 2746291
   timestamp: 1730246036363
-- kind: conda
-  name: svt-av1
-  version: 2.3.0
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
+  sha256: ab876ed8bdd20e22a868dcb8d03e9ce9bbba7762d7e652d49bfff6af768a5b8f
+  md5: 114c33e9eec335a379c9ee6c498bb807
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1387330
+  timestamp: 1730246134730
+- conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
   sha256: c25bf68ef411d41ee29f353acc698c482fdd087426a77398b7b41ce9d968519e
   md5: ac11ae1da661e573b71870b1191ce079
   depends:
@@ -22802,27 +17623,7 @@ packages:
   license_family: BSD
   size: 1845727
   timestamp: 1730246453216
-- kind: conda
-  name: svt-av1
-  version: 2.3.0
-  build: hf24288c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
-  sha256: ab876ed8bdd20e22a868dcb8d03e9ce9bbba7762d7e652d49bfff6af768a5b8f
-  md5: 114c33e9eec335a379c9ee6c498bb807
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1387330
-  timestamp: 1730246134730
-- kind: conda
-  name: symlink-exe-runtime
-  version: '1.0'
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/symlink-exe-runtime-1.0-hcfcfb64_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/symlink-exe-runtime-1.0-hcfcfb64_0.tar.bz2
   sha256: 4a7096df38cf8c7e5ee965ea957c0fadf8b5e1140f5b2da625075cc6d7a22bf7
   md5: 2b03b51163e311e87a6d4a4e9776b24b
   depends:
@@ -22833,14 +17634,7 @@ packages:
   license_family: BSD
   size: 11597
   timestamp: 1666792984220
-- kind: conda
-  name: sysroot_linux-64
-  version: '2.17'
-  build: h4a8ded7_18
-  build_number: 18
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
   sha256: 23c7ab371c1b74d01a187e05aa7240e3f5654599e364a9adff7f0b02e26f471f
   md5: 0ea96f90a10838f58412aa84fdd9df09
   depends:
@@ -22850,36 +17644,7 @@ packages:
   license_family: GPL
   size: 15500960
   timestamp: 1729794510631
-- kind: conda
-  name: tabmat
-  version: 4.0.1
-  build: py39h2366fc2_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.0.1-py39h2366fc2_2.conda
-  sha256: b4c5d235f0d184809f4479a0c45e257d35d2ef8564c00d8d3c5205eba03e2aaa
-  md5: 942d17032472d85f24810cef012e0374
-  depends:
-  - formulaic >=0.6
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - scipy
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 439389
-  timestamp: 1726897227268
-- kind: conda
-  name: tabmat
-  version: 4.0.1
-  build: py39h3b40f6f_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.0.1-py39h3b40f6f_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.0.1-py39h3b40f6f_2.conda
   sha256: 186811e748c9a4d4058e51a180d1eba56cb03e9e3b28234a3d0a316b77028861
   md5: 99793f5177bd3686d1e287e26ce42b8d
   depends:
@@ -22898,37 +17663,7 @@ packages:
   license_family: BSD
   size: 619425
   timestamp: 1726896798549
-- kind: conda
-  name: tabmat
-  version: 4.0.1
-  build: py39he9a93b6_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.0.1-py39he9a93b6_2.conda
-  sha256: 6f971d7818b5bf0349ef03fc341f02af3ee5b01bc320d1c75633e4595e489c3f
-  md5: 77eb6f890e2b07fc243df30079d87323
-  depends:
-  - __osx >=11.0
-  - formulaic >=0.6
-  - libcxx >=17
-  - libjemalloc-local >=5.3.0
-  - llvm-openmp >=17.0.6
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  - scipy
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 498503
-  timestamp: 1726896853951
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py310h5eaa309_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.1.0-py310h5eaa309_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.1.0-py310h5eaa309_0.conda
   sha256: 743d936268ed2867216dfa07cbb4cec63b981825e5b63aca92a4164286bb5eb2
   md5: 5a7443d3bfb96c718c4bfcf424abf3c8
   depends:
@@ -22948,60 +17683,7 @@ packages:
   license_family: BSD
   size: 620338
   timestamp: 1731394776903
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py310hb4db72f_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py310hb4db72f_0.conda
-  sha256: ded9094ef23c445a0b161773bfd2c7c3771c6a946791efecedc534dfdef69dbb
-  md5: 3d6c597b51c30ee47e533700f74465d3
-  depends:
-  - formulaic >=0.6
-  - narwhals
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - scipy
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 441028
-  timestamp: 1731395021676
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py310hf4d25ef_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py310hf4d25ef_0.conda
-  sha256: c833b956443f7ebbd6134ed96a6b1151197e163cf45d36a4560ec9ebe8d3ecc3
-  md5: 5980dfb62aae9247d8dea80067650d12
-  depends:
-  - __osx >=11.0
-  - formulaic >=0.6
-  - libcxx >=18
-  - libjemalloc-local >=5.3.0
-  - llvm-openmp >=18.1.8
-  - narwhals
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - scipy
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 502389
-  timestamp: 1731394944237
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py311h7db5c69_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.1.0-py311h7db5c69_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.1.0-py311h7db5c69_0.conda
   sha256: 80960cae5eb472f261364d470e2f38f210ec97783d7737473ee05e73b0d2f3e4
   md5: 6431ff8c43b7c4d3c097b763b6f2bb13
   depends:
@@ -23021,108 +17703,7 @@ packages:
   license_family: BSD
   size: 646735
   timestamp: 1731394724472
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py311ha5f7bf9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py311ha5f7bf9_0.conda
-  sha256: 446a1cceb8ae9c3c84dd4b4467db42400f0e63f6e094214260016b15245f8533
-  md5: 47c15008e53f253c9a4af107c5fb7890
-  depends:
-  - __osx >=11.0
-  - formulaic >=0.6
-  - libcxx >=18
-  - libjemalloc-local >=5.3.0
-  - llvm-openmp >=18.1.8
-  - narwhals
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  - scipy
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 516869
-  timestamp: 1731395019205
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py311hcf9f919_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py311hcf9f919_0.conda
-  sha256: 19a7bc6e2b3e1a0874efd637a2792cda5346b9c3fcee896120697ca76dbf6be4
-  md5: f04f52bfe2838b34421e9120489ebb28
-  depends:
-  - formulaic >=0.6
-  - narwhals
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - scipy
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 472146
-  timestamp: 1731394960497
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py312h72972c8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py312h72972c8_0.conda
-  sha256: 5c8e3c9a6ce2227c7f624f64034abe83b0d2c9c46fb9339cdf187f79a7a8692f
-  md5: f162eda8bd9167921fdce1f17ec6c5cc
-  depends:
-  - formulaic >=0.6
-  - narwhals
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - scipy
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 465327
-  timestamp: 1731395037932
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py312hb2fcc66_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py312hb2fcc66_0.conda
-  sha256: 57445fb3c18c3b74838535ad380715fbeba3bb6dffa70bb1cca65eaac8a45020
-  md5: fbdb11aa34b102d9fe423fa1869aa68b
-  depends:
-  - __osx >=11.0
-  - formulaic >=0.6
-  - libcxx >=18
-  - libjemalloc-local >=5.3.0
-  - llvm-openmp >=18.1.8
-  - narwhals
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - scipy
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 521155
-  timestamp: 1731394856
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py312hf9745cd_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.1.0-py312hf9745cd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.1.0-py312hf9745cd_0.conda
   sha256: 9996f74c820da1fd88ddb30249fcf29c5db4eced4a8fce4db13af65f6d637f7e
   md5: cf406234d6a3e6c2ec3a0a26deeccea2
   depends:
@@ -23142,83 +17723,7 @@ packages:
   license_family: BSD
   size: 628827
   timestamp: 1731394712691
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py313h16da6fe_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py313h16da6fe_0.conda
-  sha256: a6d7a0207b74dd2941891e003cf65b7f5f04b79c186d6c65e15886dc713f3366
-  md5: 0ef8f3e00572cc89f3b069c0b63fdda1
-  depends:
-  - __osx >=11.0
-  - formulaic >=0.6
-  - libcxx >=18
-  - libjemalloc-local >=5.3.0
-  - llvm-openmp >=18.1.8
-  - narwhals
-  - numpy >=1.21,<3
-  - pandas
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  - scipy
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 530635
-  timestamp: 1731394861619
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py313hf91d08e_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py313hf91d08e_0.conda
-  sha256: 40a2d533de609ad3f9acedd6a0bca0aa311e282db5d6d362130fb7719c4877d1
-  md5: d0b005c5706bb4cbeae1af582000842f
-  depends:
-  - formulaic >=0.6
-  - narwhals
-  - numpy >=1.21,<3
-  - pandas
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - scipy
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 463009
-  timestamp: 1731395099873
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py39h2366fc2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py39h2366fc2_0.conda
-  sha256: 59cffd1125d08c9719475286fd4af00acacd1ed31e372a56d28431db99d15f04
-  md5: fc51a82800a528da1ef38c18ee323068
-  depends:
-  - formulaic >=0.6
-  - narwhals
-  - numpy >=1.19,<3
-  - pandas
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - scipy
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 442922
-  timestamp: 1731395099894
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py39h3b40f6f_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.1.0-py39h3b40f6f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tabmat-4.1.0-py39h3b40f6f_0.conda
   sha256: cbfb33c5c2fd6e4ff8bf0947c2bf7436e7b9690f841ee3c4895081cf068d910a
   md5: b954c0ebde78315a0dc3f15c93f3a8a9
   depends:
@@ -23238,12 +17743,106 @@ packages:
   license_family: BSD
   size: 621937
   timestamp: 1731394764351
-- kind: conda
-  name: tabmat
-  version: 4.1.0
-  build: py39hd2a9f30_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py39hd2a9f30_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.0.1-py39he9a93b6_2.conda
+  sha256: 6f971d7818b5bf0349ef03fc341f02af3ee5b01bc320d1c75633e4595e489c3f
+  md5: 77eb6f890e2b07fc243df30079d87323
+  depends:
+  - __osx >=11.0
+  - formulaic >=0.6
+  - libcxx >=17
+  - libjemalloc-local >=5.3.0
+  - llvm-openmp >=17.0.6
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498503
+  timestamp: 1726896853951
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py310hf4d25ef_0.conda
+  sha256: c833b956443f7ebbd6134ed96a6b1151197e163cf45d36a4560ec9ebe8d3ecc3
+  md5: 5980dfb62aae9247d8dea80067650d12
+  depends:
+  - __osx >=11.0
+  - formulaic >=0.6
+  - libcxx >=18
+  - libjemalloc-local >=5.3.0
+  - llvm-openmp >=18.1.8
+  - narwhals
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502389
+  timestamp: 1731394944237
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py311ha5f7bf9_0.conda
+  sha256: 446a1cceb8ae9c3c84dd4b4467db42400f0e63f6e094214260016b15245f8533
+  md5: 47c15008e53f253c9a4af107c5fb7890
+  depends:
+  - __osx >=11.0
+  - formulaic >=0.6
+  - libcxx >=18
+  - libjemalloc-local >=5.3.0
+  - llvm-openmp >=18.1.8
+  - narwhals
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 516869
+  timestamp: 1731395019205
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py312hb2fcc66_0.conda
+  sha256: 57445fb3c18c3b74838535ad380715fbeba3bb6dffa70bb1cca65eaac8a45020
+  md5: fbdb11aa34b102d9fe423fa1869aa68b
+  depends:
+  - __osx >=11.0
+  - formulaic >=0.6
+  - libcxx >=18
+  - libjemalloc-local >=5.3.0
+  - llvm-openmp >=18.1.8
+  - narwhals
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521155
+  timestamp: 1731394856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py313h16da6fe_0.conda
+  sha256: a6d7a0207b74dd2941891e003cf65b7f5f04b79c186d6c65e15886dc713f3366
+  md5: 0ef8f3e00572cc89f3b069c0b63fdda1
+  depends:
+  - __osx >=11.0
+  - formulaic >=0.6
+  - libcxx >=18
+  - libjemalloc-local >=5.3.0
+  - llvm-openmp >=18.1.8
+  - narwhals
+  - numpy >=1.21,<3
+  - pandas
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 530635
+  timestamp: 1731394861619
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tabmat-4.1.0-py39hd2a9f30_0.conda
   sha256: 298854f0964871be4139a573412135318167b77e8e9171379e25dece5055605f
   md5: 3bdfa559993637468a833af532f368e0
   depends:
@@ -23263,14 +17862,114 @@ packages:
   license_family: BSD
   size: 503501
   timestamp: 1731395000511
-- kind: conda
-  name: tabulate
-  version: 0.9.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.0.1-py39h2366fc2_2.conda
+  sha256: b4c5d235f0d184809f4479a0c45e257d35d2ef8564c00d8d3c5205eba03e2aaa
+  md5: 942d17032472d85f24810cef012e0374
+  depends:
+  - formulaic >=0.6
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - scipy
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 439389
+  timestamp: 1726897227268
+- conda: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py310hb4db72f_0.conda
+  sha256: ded9094ef23c445a0b161773bfd2c7c3771c6a946791efecedc534dfdef69dbb
+  md5: 3d6c597b51c30ee47e533700f74465d3
+  depends:
+  - formulaic >=0.6
+  - narwhals
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - scipy
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 441028
+  timestamp: 1731395021676
+- conda: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py311hcf9f919_0.conda
+  sha256: 19a7bc6e2b3e1a0874efd637a2792cda5346b9c3fcee896120697ca76dbf6be4
+  md5: f04f52bfe2838b34421e9120489ebb28
+  depends:
+  - formulaic >=0.6
+  - narwhals
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 472146
+  timestamp: 1731394960497
+- conda: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py312h72972c8_0.conda
+  sha256: 5c8e3c9a6ce2227c7f624f64034abe83b0d2c9c46fb9339cdf187f79a7a8692f
+  md5: f162eda8bd9167921fdce1f17ec6c5cc
+  depends:
+  - formulaic >=0.6
+  - narwhals
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - scipy
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 465327
+  timestamp: 1731395037932
+- conda: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py313hf91d08e_0.conda
+  sha256: 40a2d533de609ad3f9acedd6a0bca0aa311e282db5d6d362130fb7719c4877d1
+  md5: d0b005c5706bb4cbeae1af582000842f
+  depends:
+  - formulaic >=0.6
+  - narwhals
+  - numpy >=1.21,<3
+  - pandas
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - scipy
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 463009
+  timestamp: 1731395099873
+- conda: https://conda.anaconda.org/conda-forge/win-64/tabmat-4.1.0-py39h2366fc2_0.conda
+  sha256: 59cffd1125d08c9719475286fd4af00acacd1ed31e372a56d28431db99d15f04
+  md5: fc51a82800a528da1ef38c18ee323068
+  depends:
+  - formulaic >=0.6
+  - narwhals
+  - numpy >=1.19,<3
+  - pandas
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - scipy
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 442922
+  timestamp: 1731395099894
+- conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
   sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
   md5: 4759805cce2d914c38472f70bf4d8bcb
   depends:
@@ -23279,12 +17978,7 @@ packages:
   license_family: MIT
   size: 35912
   timestamp: 1665138565317
-- kind: conda
-  name: tapi
-  version: 1300.6.5
-  build: h03f4b80_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
   sha256: 37cd4f62ec023df8a6c6f9f6ffddde3d6620a83cbcab170a8fff31ef944402e5
   md5: b703bc3e6cba5943acf0e5f987b5d0e2
   depends:
@@ -23295,30 +17989,7 @@ packages:
   license_family: MIT
   size: 207679
   timestamp: 1725491499758
-- kind: conda
-  name: tbb
-  version: 2021.13.0
-  build: h62715c5_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
-  sha256: 03cc5442046485b03dd1120d0f49d35a7e522930a2ab82f275e938e17b07b302
-  md5: 9190dd0a23d925f7602f9628b3aed511
-  depends:
-  - libhwloc >=2.11.2,<2.11.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  size: 151460
-  timestamp: 1732982860332
-- kind: conda
-  name: tbb
-  version: 2021.13.0
-  build: hceb3a55_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-hceb3a55_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-hceb3a55_1.conda
   sha256: 65463732129899770d54b1fbf30e1bb82fdebda9d7553caf08d23db4590cd691
   md5: ba7726b8df7b9d34ea80e82b097a4893
   depends:
@@ -23329,13 +18000,18 @@ packages:
   license: Apache-2.0
   size: 175954
   timestamp: 1732982638805
-- kind: conda
-  name: tblib
-  version: 3.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+  sha256: 03cc5442046485b03dd1120d0f49d35a7e522930a2ab82f275e938e17b07b302
+  md5: 9190dd0a23d925f7602f9628b3aed511
+  depends:
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  size: 151460
+  timestamp: 1732982860332
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
   sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
   md5: 04eedddeb68ad39871c8127dd1c21f4f
   depends:
@@ -23344,13 +18020,7 @@ packages:
   license_family: BSD
   size: 17386
   timestamp: 1702066480361
-- kind: conda
-  name: terminado
-  version: 0.18.1
-  build: pyh0d859eb_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
   sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
   md5: efba281bbdae5f6b0a1d53c6d4a97c93
   depends:
@@ -23362,13 +18032,7 @@ packages:
   license_family: BSD
   size: 22452
   timestamp: 1710262728753
-- kind: conda
-  name: terminado
-  version: 0.18.1
-  build: pyh31c8845_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
   sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
   md5: 00b54981b923f5aefcd5e8547de056d5
   depends:
@@ -23380,13 +18044,7 @@ packages:
   license_family: BSD
   size: 22717
   timestamp: 1710265922593
-- kind: conda
-  name: terminado
-  version: 0.18.1
-  build: pyh5737063_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
   sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
   md5: 4abd500577430a942a995fd0d09b76a2
   depends:
@@ -23398,13 +18056,7 @@ packages:
   license_family: BSD
   size: 22883
   timestamp: 1710262943966
-- kind: conda
-  name: threadpoolctl
-  version: 3.5.0
-  build: pyhc1e730c_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
   sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
   md5: df68d78237980a159bd7149f33c0e8fd
   depends:
@@ -23413,13 +18065,7 @@ packages:
   license_family: BSD
   size: 23548
   timestamp: 1714400228771
-- kind: conda
-  name: tinycss2
-  version: 1.4.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
   sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
   md5: f1acf5fdefa8300de697982bcb1761c9
   depends:
@@ -23429,13 +18075,17 @@ packages:
   license_family: BSD
   size: 28285
   timestamp: 1729802975370
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h5083fa2_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
   sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
   md5: b50a57ba89c32b62428b71a875291c9b
   depends:
@@ -23444,13 +18094,7 @@ packages:
   license_family: BSD
   size: 3145523
   timestamp: 1699202432999
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h5226925_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
   sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
   md5: fc048363eb8f03cd1737600a5d08aafe
   depends:
@@ -23461,29 +18105,7 @@ packages:
   license_family: BSD
   size: 3503410
   timestamp: 1699202577803
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: noxft_h4845f30_101
-  build_number: 101
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  md5: d453b98d9c83e71da0741bb0ff4d76bc
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3318875
-  timestamp: 1699202167581
-- kind: conda
-  name: tokenize-rt
-  version: 6.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tokenize-rt-6.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tokenize-rt-6.1.0-pyhd8ed1ab_0.conda
   sha256: da774816b54759baed1ca569c5c506f7b1ee4a768698ec711ff79008e1008d29
   md5: e9877198e2fc93db07e4be58f7a6822f
   depends:
@@ -23492,13 +18114,7 @@ packages:
   license_family: MIT
   size: 11731
   timestamp: 1729593139681
-- kind: conda
-  name: toml
-  version: 0.10.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
   sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
   md5: f832c45a477c78bebd107098db465095
   depends:
@@ -23507,13 +18123,7 @@ packages:
   license_family: MIT
   size: 18433
   timestamp: 1604308660817
-- kind: conda
-  name: tomli
-  version: 2.2.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_0.conda
   sha256: 706f35327a1b433fb57bb99e9fef878e90317fd6ea8cbcd454fb4af1a2e3f035
   md5: ee8ab0fe4c8dfc5a6319f7f8246022fc
   depends:
@@ -23521,13 +18131,7 @@ packages:
   license: MIT
   size: 19129
   timestamp: 1732988289555
-- kind: conda
-  name: toolz
-  version: 1.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
   sha256: 6371cf3cf8292f2abdcc2bf783d6e70203d72f8ff0c1625f55a486711e276c75
   md5: 34feccdd4177f2d3d53c73fc44fd9a37
   depends:
@@ -23536,12 +18140,43 @@ packages:
   license_family: BSD
   size: 52623
   timestamp: 1728059623353
-- kind: conda
-  name: tornado
-  version: 6.4.2
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py312h4389bb4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py312h66e93f0_0.conda
+  sha256: 062a3a3a37fa8615ce57929ba7e982c76f5a5810bcebd435950f6d6c4147c310
+  md5: e417822cb989e80a0d2b1b576fdd1657
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  size: 840414
+  timestamp: 1732616043734
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py312hea69d52_0.conda
+  sha256: 964a2705a36c50040c967b18b45b9cc8de3c2aff4af546979a574e0b38e58e39
+  md5: fb0605888a475d6a380ae1d1a819d976
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  size: 842549
+  timestamp: 1732616081362
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py313h90d716c_0.conda
+  sha256: 33ef243265af82d7763c248fedd9196523210cc295b2caa512128202eda5e9e8
+  md5: 6790d50f184874a9ea298be6bcbc7710
+  depends:
+  - __osx >=11.0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 863363
+  timestamp: 1732616174714
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py312h4389bb4_0.conda
   sha256: e21f24e5d598d9a31c604f510c82fbe73d756696bc70a69f11811a2ea9dd5d95
   md5: f06104f71f496b0784b35b23e30e7990
   depends:
@@ -23554,63 +18189,7 @@ packages:
   license_family: Apache
   size: 844347
   timestamp: 1732616435803
-- kind: conda
-  name: tornado
-  version: 6.4.2
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py312h66e93f0_0.conda
-  sha256: 062a3a3a37fa8615ce57929ba7e982c76f5a5810bcebd435950f6d6c4147c310
-  md5: e417822cb989e80a0d2b1b576fdd1657
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  size: 840414
-  timestamp: 1732616043734
-- kind: conda
-  name: tornado
-  version: 6.4.2
-  build: py312hea69d52_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py312hea69d52_0.conda
-  sha256: 964a2705a36c50040c967b18b45b9cc8de3c2aff4af546979a574e0b38e58e39
-  md5: fb0605888a475d6a380ae1d1a819d976
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  size: 842549
-  timestamp: 1732616081362
-- kind: conda
-  name: tornado
-  version: 6.4.2
-  build: py313h90d716c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py313h90d716c_0.conda
-  sha256: 33ef243265af82d7763c248fedd9196523210cc295b2caa512128202eda5e9e8
-  md5: 6790d50f184874a9ea298be6bcbc7710
-  depends:
-  - __osx >=11.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 863363
-  timestamp: 1732616174714
-- kind: conda
-  name: tornado
-  version: 6.4.2
-  build: py313ha7868ed_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py313ha7868ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py313ha7868ed_0.conda
   sha256: 062e8b77b825463fc59f373d4033fae7cf65a4170e761814bcbf25cd0627bd1d
   md5: 3d63fe6a4757924a085ab10196049854
   depends:
@@ -23623,13 +18202,7 @@ packages:
   license_family: Apache
   size: 865881
   timestamp: 1732616355868
-- kind: conda
-  name: tqdm
-  version: 4.67.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
   sha256: 5673b7104350a6998cb86cccf1d0058217d86950e8d6c927d8530606028edb1d
   md5: 4085c9db273a148e149c03627350e22c
   depends:
@@ -23638,13 +18211,7 @@ packages:
   license: MPL-2.0 or MIT
   size: 89484
   timestamp: 1732497312317
-- kind: conda
-  name: traitlets
-  version: 5.14.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
   sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
   md5: 3df84416a021220d8b5700c613af2dc5
   depends:
@@ -23653,13 +18220,7 @@ packages:
   license_family: BSD
   size: 110187
   timestamp: 1713535244513
-- kind: conda
-  name: types-python-dateutil
-  version: 2.9.0.20241003
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
   sha256: 8489af986daebfbcd13d3748ba55431259206e37f184ab42a57e107fecd85e02
   md5: 3d326f8a2aa2d14d51d8c513426b5def
   depends:
@@ -23667,13 +18228,8 @@ packages:
   license: Apache-2.0 AND MIT
   size: 21765
   timestamp: 1727940339297
-- kind: conda
-  name: typing-extensions
-  version: 4.12.2
-  build: hd8ed1ab_0
-  subdir: noarch
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
   sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
   md5: 52d648bd608f5737b123f510bb5514b5
   depends:
@@ -23682,13 +18238,7 @@ packages:
   license_family: PSF
   size: 10097
   timestamp: 1717802659025
-- kind: conda
-  name: typing_extensions
-  version: 4.12.2
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
   sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
   md5: ebe6952715e1d5eb567eeebf25250fa7
   depends:
@@ -23697,13 +18247,7 @@ packages:
   license_family: PSF
   size: 39888
   timestamp: 1717802653893
-- kind: conda
-  name: typing_utils
-  version: 0.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
   sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
   md5: eb67e3cace64c66233e2d35949e20f92
   depends:
@@ -23712,25 +18256,13 @@ packages:
   license_family: APACHE
   size: 13829
   timestamp: 1622899345711
-- kind: conda
-  name: tzdata
-  version: 2024b
-  build: hc8b5060_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
   sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
   md5: 8ac3367aafb1cc0a068483c580af8015
   license: LicenseRef-Public-Domain
   size: 122354
   timestamp: 1728047496079
-- kind: conda
-  name: ucrt
-  version: 10.0.22621.0
-  build: h57928b3_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
   sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
   md5: 6797b005cd0f439c4c5c9ac565783700
   constrains:
@@ -23738,13 +18270,7 @@ packages:
   license: LicenseRef-MicrosoftWindowsSDK10
   size: 559710
   timestamp: 1728377334097
-- kind: conda
-  name: ukkonen
-  version: 1.0.1
-  build: py312h68727a3_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h68727a3_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h68727a3_5.conda
   sha256: 9fb020083a7f4fee41f6ece0f4840f59739b3e249f157c8a407bb374ffb733b5
   md5: f9664ee31aed96c85b7319ab0a693341
   depends:
@@ -23758,33 +18284,7 @@ packages:
   license_family: MIT
   size: 13904
   timestamp: 1725784191021
-- kind: conda
-  name: ukkonen
-  version: 1.0.1
-  build: py313h1ec8472_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py313h1ec8472_5.conda
-  sha256: 4f57f2eccd5584421f1b4d8c96c167c1008cba660d7fab5bdec1de212a0e0ff0
-  md5: 97337494471e4265a203327f9a194234
-  depends:
-  - cffi
-  - python >=3.13.0rc1,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 17210
-  timestamp: 1725784604368
-- kind: conda
-  name: ukkonen
-  version: 1.0.1
-  build: py313hf9c7212_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py313hf9c7212_5.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py313hf9c7212_5.conda
   sha256: 482eac475928c031948790647ae10c2cb1d4a779c2e8f35f5fd1925561b13203
   md5: 8ddba23e26957f0afe5fc9236c73124a
   depends:
@@ -23798,13 +18298,33 @@ packages:
   license_family: MIT
   size: 13689
   timestamp: 1725784235751
-- kind: conda
-  name: unicodedata2
-  version: 15.1.0
-  build: py312h0bf5046_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py312h0bf5046_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py313h1ec8472_5.conda
+  sha256: 4f57f2eccd5584421f1b4d8c96c167c1008cba660d7fab5bdec1de212a0e0ff0
+  md5: 97337494471e4265a203327f9a194234
+  depends:
+  - cffi
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 17210
+  timestamp: 1725784604368
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py312h66e93f0_1.conda
+  sha256: 1fcba6d363d901d9a06381e1aee2d5634f82389965dd7a339f19b3ae81ce6da0
+  md5: 588486a61153f94c7c13816f7069e440
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  size: 368550
+  timestamp: 1729704685856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py312h0bf5046_1.conda
   sha256: 236961004c088f190d8b27863b2898f1d43c2d5dc769f135abdacc644b033fab
   md5: eda2082df9c9c6259af246424b7f3db1
   depends:
@@ -23816,13 +18336,7 @@ packages:
   license_family: Apache
   size: 372492
   timestamp: 1729704995151
-- kind: conda
-  name: unicodedata2
-  version: 15.1.0
-  build: py312h4389bb4_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py312h4389bb4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py312h4389bb4_1.conda
   sha256: 92abc9d85c1cec3349db089a9942266a981cf347ac6a9ddbeaa3d3162958d81b
   md5: 9cf863b723d64077f74396cfe4d7c00c
   depends:
@@ -23835,31 +18349,7 @@ packages:
   license_family: Apache
   size: 365482
   timestamp: 1729705063982
-- kind: conda
-  name: unicodedata2
-  version: 15.1.0
-  build: py312h66e93f0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py312h66e93f0_1.conda
-  sha256: 1fcba6d363d901d9a06381e1aee2d5634f82389965dd7a339f19b3ae81ce6da0
-  md5: 588486a61153f94c7c13816f7069e440
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  size: 368550
-  timestamp: 1729704685856
-- kind: conda
-  name: uri-template
-  version: 1.3.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
   sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
   md5: 0944dc65cb4a9b5b68522c3bb585d41c
   depends:
@@ -23868,12 +18358,17 @@ packages:
   license_family: MIT
   size: 23999
   timestamp: 1688655976471
-- kind: conda
-  name: uriparser
-  version: 0.9.8
-  build: h00cdb27_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+  sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
+  md5: d71d3a66528853c0a1ac2c02d79a0284
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48270
+  timestamp: 1715010035325
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
   sha256: fa0bcbfb20a508ca9bf482236fe799581cbd0eab016e47a865e9fa44dbe3c512
   md5: e8ff9e11babbc8cd77af5a4258dc2802
   depends:
@@ -23883,12 +18378,7 @@ packages:
   license_family: BSD
   size: 40625
   timestamp: 1715010029254
-- kind: conda
-  name: uriparser
-  version: 0.9.8
-  build: h5a68840_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
   sha256: ed0eed8ed0343d29cdbfaeb1bfd141f090af696547d69f91c18f46350299f00d
   md5: 28b4cf9065681f43cc567410edf8243d
   depends:
@@ -23899,28 +18389,7 @@ packages:
   license_family: BSD
   size: 49181
   timestamp: 1715010467661
-- kind: conda
-  name: uriparser
-  version: 0.9.8
-  build: hac33072_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
-  sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
-  md5: d71d3a66528853c0a1ac2c02d79a0284
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 48270
-  timestamp: 1715010035325
-- kind: conda
-  name: urllib3
-  version: 2.2.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
   sha256: b6bb34ce41cd93956ad6eeee275ed52390fb3788d6c75e753172ea7ac60b66e5
   md5: 6b55867f385dd762ed99ea687af32a69
   depends:
@@ -23933,13 +18402,7 @@ packages:
   license_family: MIT
   size: 98076
   timestamp: 1726496531769
-- kind: conda
-  name: vc
-  version: '14.3'
-  build: ha32ba9b_23
-  build_number: 23
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
   sha256: 986ddaf8feec2904eac9535a7ddb7acda1a1dfb9482088fdb8129f1595181663
   md5: 7c10ec3158d1eb4ddff7007c9101adb0
   depends:
@@ -23950,13 +18413,7 @@ packages:
   license_family: BSD
   size: 17479
   timestamp: 1731710827215
-- kind: conda
-  name: vc14_runtime
-  version: 14.42.34433
-  build: he29a5d6_23
-  build_number: 23
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
   sha256: c483b090c4251a260aba6ff3e83a307bcfb5fb24ad7ced872ab5d02971bd3a49
   md5: 32b37d0cfa80da34548501cdc913a832
   depends:
@@ -23967,13 +18424,7 @@ packages:
   license_family: Proprietary
   size: 754247
   timestamp: 1731710681163
-- kind: conda
-  name: virtualenv
-  version: 20.28.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.0-pyhd8ed1ab_0.conda
   sha256: 82776f74e90a296b79415361faa6b10f360755c1fb8e6d59ca68509e6fe7e115
   md5: 1d601bc1d28b5ce6d112b90f4b9b8ede
   depends:
@@ -23985,13 +18436,7 @@ packages:
   license_family: MIT
   size: 3350255
   timestamp: 1732609542072
-- kind: conda
-  name: vs2015_runtime
-  version: 14.42.34433
-  build: hdffcdeb_23
-  build_number: 23
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
   sha256: 568ce8151eaae256f1cef752fc78651ad7a86ff05153cc7a4740b52ae6536118
   md5: 5c176975ca2b8366abad3c97b3cd1e83
   depends:
@@ -24000,13 +18445,7 @@ packages:
   license_family: BSD
   size: 17572
   timestamp: 1731710685291
-- kind: conda
-  name: vs2019_win-64
-  version: 19.29.30139
-  build: he1865b1_23
-  build_number: 23
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_23.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_23.conda
   sha256: c41039f7f19a6570ad2af6ef7a8534111fe1e6157b187505fb81265d755bb825
   md5: 245e19dde23580d186b11a29bfd3b99e
   depends:
@@ -24019,25 +18458,14 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1731710669471
-- kind: conda
-  name: vswhere
-  version: 3.1.7
-  build: h57928b3_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
   sha256: 8caeda9c0898cb8ee2cf4f45640dbbbdf772ddc01345cfb0f7b352c58b4d8025
   md5: ba83df93b48acfc528f5464c9a882baa
   license: MIT
   license_family: MIT
   size: 219013
   timestamp: 1719460515960
-- kind: conda
-  name: wcwidth
-  version: 0.2.13
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
   sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
   md5: 68f0738df502a14213624b288c60c9ad
   depends:
@@ -24046,13 +18474,7 @@ packages:
   license_family: MIT
   size: 32709
   timestamp: 1704731373922
-- kind: conda
-  name: webcolors
-  version: 24.8.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
   sha256: ec71f97c332a7d328ae038990b8090cbfa772f82845b5d2233defd167b7cc5ac
   md5: eb48b812eb4fbb9ff238a6651fdbbcae
   depends:
@@ -24061,14 +18483,7 @@ packages:
   license_family: BSD
   size: 18378
   timestamp: 1723294800217
-- kind: conda
-  name: webencodings
-  version: 0.5.1
-  build: pyhd8ed1ab_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
   sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
   md5: daf5160ff9cde3a468556965329085b9
   depends:
@@ -24077,13 +18492,7 @@ packages:
   license_family: BSD
   size: 15600
   timestamp: 1694681458271
-- kind: conda
-  name: websocket-client
-  version: 1.8.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
   sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
   md5: f372c576b8774922da83cda2b12f9d29
   depends:
@@ -24092,13 +18501,7 @@ packages:
   license_family: APACHE
   size: 47066
   timestamp: 1713923494501
-- kind: conda
-  name: wheel
-  version: 0.45.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_0.conda
   sha256: 24f6851a336a50c53d6b50b142c1654872494a62528d57c3ff40240cbd8b13be
   md5: bdb2f437ce62fd2f1fef9119a37a12d9
   depends:
@@ -24107,14 +18510,16 @@ packages:
   license_family: MIT
   size: 62998
   timestamp: 1732339880578
-- kind: conda
-  name: win_inet_pton
-  version: 1.1.0
-  build: pyh7428d3b_7
-  build_number: 7
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
   sha256: c5297692ab34aade5e21107abaf623d6f93847662e25f655320038d2bfa1a812
   md5: c998c13b2f998af57c3b88c7a47979e0
   depends:
@@ -24123,43 +18528,13 @@ packages:
   license: LicenseRef-Public-Domain
   size: 9602
   timestamp: 1727796413384
-- kind: conda
-  name: winpty
-  version: 0.4.3
-  build: '4'
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
   sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
   md5: 1cee351bf20b830d991dbe0bc8cd7dfe
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 1176306
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py310h078409c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py310h078409c_0.conda
-  sha256: 69d06687c4082a9abd17e8e18e12f35e85aa54b825b6e6d221f558051d24b40e
-  md5: 478eb95bd48ed09a4697365e117752c0
-  depends:
-  - __osx >=11.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 53892
-  timestamp: 1732523862802
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py310ha75aee5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.0-py310ha75aee5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.0-py310ha75aee5_0.conda
   sha256: ee4a65c7142ab00c8e131c4f418c2d2ab09d9300f4d79114fac78358b63d9e68
   md5: fe2c2c96634281cabf3fcdadaa611722
   depends:
@@ -24171,12 +18546,103 @@ packages:
   license_family: BSD
   size: 56736
   timestamp: 1732523712410
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py310ha8f682b_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py310ha8f682b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.0-py311h9ecbd09_0.conda
+  sha256: 8e9a7a1a69d0d59b3cb0066fbdbf16dc7a0d9554ffc2a365e67eca72230ca3e8
+  md5: 452e39fb544b1ec9cc6c5b2ac9c47efa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 65396
+  timestamp: 1732523677157
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.0-py312h66e93f0_0.conda
+  sha256: a6fc0f4e90643d0c1fd4aab669b6a79f44a305a5474256f6f2da3354d2310fb4
+  md5: ddbe3bb0e1356cb9074dd848570694f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 63807
+  timestamp: 1732523690292
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.0-py39h8cd3c5a_0.conda
+  sha256: 0ebe7d1a5d79133672b79ee9ad53edfd1f133a65b4c9c1a68b080fac654c27c6
+  md5: 643d5c89943f147459d27ec86f6a050e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 56180
+  timestamp: 1732523738395
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py310h078409c_0.conda
+  sha256: 69d06687c4082a9abd17e8e18e12f35e85aa54b825b6e6d221f558051d24b40e
+  md5: 478eb95bd48ed09a4697365e117752c0
+  depends:
+  - __osx >=11.0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 53892
+  timestamp: 1732523862802
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py311h917b07b_0.conda
+  sha256: fff7f86570f0a3fd90878b75b552bafddb854e8f4d68a171cd427a13e9eb160c
+  md5: a56950191b7efa9406bbaff925173d20
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 62309
+  timestamp: 1732524074190
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py312hea69d52_0.conda
+  sha256: 0fb35c3d1642f9f47db87bdb33148f88ef19a3af1eb0ee99b5491551c57269c7
+  md5: 73414acdb779a8694a14527865b4357a
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 61043
+  timestamp: 1732523852129
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py313h90d716c_0.conda
+  sha256: 30534d176f73da945a58b5427e9db9cfe570720880f5d5a0dac7a88a543f36fd
+  md5: c156cc400c728917be658f8069429dfd
+  depends:
+  - __osx >=11.0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 61433
+  timestamp: 1732523906794
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py39hf3bc14e_0.conda
+  sha256: 2710edaa54bdf9face470ecc80542330bb352b073b4cf99cf6a2300ef4419750
+  md5: 267feb90eff089879ef180c1edc1db29
+  depends:
+  - __osx >=11.0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 53776
+  timestamp: 1732523933851
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py310ha8f682b_0.conda
   sha256: ce7343fc99d7ef342570c49017a0f36ea98faf289e346b656d6270b357516c40
   md5: bcb2e1ea36b522a21bdc2cb993b98d63
   depends:
@@ -24189,46 +18655,7 @@ packages:
   license_family: BSD
   size: 55315
   timestamp: 1732524108474
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py311h917b07b_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py311h917b07b_0.conda
-  sha256: fff7f86570f0a3fd90878b75b552bafddb854e8f4d68a171cd427a13e9eb160c
-  md5: a56950191b7efa9406bbaff925173d20
-  depends:
-  - __osx >=11.0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 62309
-  timestamp: 1732524074190
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py311h9ecbd09_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.0-py311h9ecbd09_0.conda
-  sha256: 8e9a7a1a69d0d59b3cb0066fbdbf16dc7a0d9554ffc2a365e67eca72230ca3e8
-  md5: 452e39fb544b1ec9cc6c5b2ac9c47efa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 65396
-  timestamp: 1732523677157
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py311he736701_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py311he736701_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py311he736701_0.conda
   sha256: 32ce0de2941b73106bcbf4cf3216db7475726f1ca7cdff71b614fd929290b39a
   md5: 5adaabe1422ef103e6c6a3f59876d205
   depends:
@@ -24241,12 +18668,7 @@ packages:
   license_family: BSD
   size: 63549
   timestamp: 1732523983327
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py312h4389bb4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py312h4389bb4_0.conda
   sha256: cfbb160f83cbc5ef7bd325edc76737ebe632a99b50592715d36caeb3707e73f2
   md5: ecfc88976499a44de0ee6b0cb04e1ba8
   depends:
@@ -24259,63 +18681,7 @@ packages:
   license_family: BSD
   size: 62371
   timestamp: 1732524043342
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.0-py312h66e93f0_0.conda
-  sha256: a6fc0f4e90643d0c1fd4aab669b6a79f44a305a5474256f6f2da3354d2310fb4
-  md5: ddbe3bb0e1356cb9074dd848570694f9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 63807
-  timestamp: 1732523690292
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py312hea69d52_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py312hea69d52_0.conda
-  sha256: 0fb35c3d1642f9f47db87bdb33148f88ef19a3af1eb0ee99b5491551c57269c7
-  md5: 73414acdb779a8694a14527865b4357a
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 61043
-  timestamp: 1732523852129
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py313h90d716c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py313h90d716c_0.conda
-  sha256: 30534d176f73da945a58b5427e9db9cfe570720880f5d5a0dac7a88a543f36fd
-  md5: c156cc400c728917be658f8069429dfd
-  depends:
-  - __osx >=11.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 61433
-  timestamp: 1732523906794
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py313ha7868ed_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py313ha7868ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py313ha7868ed_0.conda
   sha256: 72e996fcf39ea4841ccadbb2956fba6ebdd8e1ea8afeac28197eebd29738785a
   md5: 339641e56f25984050b43ee659a7c476
   depends:
@@ -24328,29 +18694,7 @@ packages:
   license_family: BSD
   size: 62568
   timestamp: 1732524027983
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py39h8cd3c5a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.0-py39h8cd3c5a_0.conda
-  sha256: 0ebe7d1a5d79133672b79ee9ad53edfd1f133a65b4c9c1a68b080fac654c27c6
-  md5: 643d5c89943f147459d27ec86f6a050e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 56180
-  timestamp: 1732523738395
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py39ha55e580_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py39ha55e580_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.0-py39ha55e580_0.conda
   sha256: 419926ef3080be4cfa392655d3340845ed3cd8323cbdd873a7b3117d258ebb1b
   md5: b68d9f341984faa423c5ab1c5a197aa7
   depends:
@@ -24363,46 +18707,7 @@ packages:
   license_family: BSD
   size: 54867
   timestamp: 1732524102801
-- kind: conda
-  name: wrapt
-  version: 1.17.0
-  build: py39hf3bc14e_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.0-py39hf3bc14e_0.conda
-  sha256: 2710edaa54bdf9face470ecc80542330bb352b073b4cf99cf6a2300ef4419750
-  md5: 267feb90eff089879ef180c1edc1db29
-  depends:
-  - __osx >=11.0
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 53776
-  timestamp: 1732523933851
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: h2d74725_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
-  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
-  md5: ca7129a334198f08347fb19ac98a2de9
-  depends:
-  - vc >=14.1,<15
-  - vs2015_runtime >=14.16.27033
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 5517425
-  timestamp: 1646611941216
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: h924138e_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
   sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
   md5: e7f6ed84d4623d52ee581325c1587a6b
   depends:
@@ -24412,13 +18717,7 @@ packages:
   license_family: GPL
   size: 3357188
   timestamp: 1646609687141
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: hbc6ce65_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
   sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
   md5: b1f7f2780feffe310b068c021e8ff9b2
   depends:
@@ -24427,30 +18726,17 @@ packages:
   license_family: GPL
   size: 1832744
   timestamp: 1646609481185
-- kind: conda
-  name: xerces-c
-  version: 3.2.5
-  build: h92fc2f4_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
-  sha256: 863a7c2a991a4399d362d42c285ebc20748a4ea417647ebd3a171e2220c7457d
-  md5: 50b7325437ef0901fe25dc5c9e743b88
+- conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
+  md5: ca7129a334198f08347fb19ac98a2de9
   depends:
-  - __osx >=11.0
-  - icu >=75.1,<76.0a0
-  - libcxx >=17
-  license: Apache-2.0
-  license_family: Apache
-  size: 1277884
-  timestamp: 1727733870250
-- kind: conda
-  name: xerces-c
-  version: 3.2.5
-  build: h988505b_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 5517425
+  timestamp: 1646611941216
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
   sha256: 339ab0ff05170a295e59133cd0fa9a9c4ba32b6941c8a2a73484cc13f81e248a
   md5: 9dda9667feba914e0e80b95b82f7402b
   depends:
@@ -24463,13 +18749,18 @@ packages:
   license_family: Apache
   size: 1648243
   timestamp: 1727733890754
-- kind: conda
-  name: xerces-c
-  version: 3.2.5
-  build: he0c23c2_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
+  sha256: 863a7c2a991a4399d362d42c285ebc20748a4ea417647ebd3a171e2220c7457d
+  md5: 50b7325437ef0901fe25dc5c9e743b88
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 1277884
+  timestamp: 1727733870250
+- conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
   sha256: 759ae22a0a221dc1c0ba39684b0dcf696aab4132478e17e56a0366ded519e54e
   md5: 82b6eac3c198271e98b48d52d79726d8
   depends:
@@ -24480,14 +18771,7 @@ packages:
   license_family: Apache
   size: 3574017
   timestamp: 1727734520239
-- kind: conda
-  name: xmltodict
-  version: 0.14.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/xmltodict-0.14.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/xmltodict-0.14.2-pyhd8ed1ab_1.conda
   sha256: 7f6f4551da59ec3612783905c67ce825f2f067481bf79cb161ab2665ae2068a1
   md5: 96ef17b8734b174d35346da0762f0137
   depends:
@@ -24495,13 +18779,7 @@ packages:
   license: MIT
   size: 15575
   timestamp: 1732988300912
-- kind: conda
-  name: xorg-libice
-  version: 1.1.1
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
   sha256: ec276da68d1c4a3d34a63195b35ca5b248d4aff0812464dcd843d74649b5cec4
   md5: 19608a9656912805b2b9a2f6bd257b04
   depends:
@@ -24511,13 +18789,7 @@ packages:
   license_family: MIT
   size: 58159
   timestamp: 1727531850109
-- kind: conda
-  name: xorg-libsm
-  version: 1.2.4
-  build: he73a12e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
   sha256: 70e903370977d44c9120a5641ab563887bd48446e9ef6fc2a3f5f60531c2cd6c
   md5: 05a8ea5f446de33006171a7afe6ae857
   depends:
@@ -24529,12 +18801,7 @@ packages:
   license_family: MIT
   size: 27516
   timestamp: 1727634669421
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.10
-  build: h4f16b4b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
   sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
   md5: 0b666058a179b744a622d0a4a0c56353
   depends:
@@ -24546,13 +18813,26 @@ packages:
   license_family: MIT
   size: 838308
   timestamp: 1727356837875
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: h0e40799_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14679
+  timestamp: 1727034741045
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13515
+  timestamp: 1727034783560
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
   sha256: f44bc6f568a9697b7e1eadc2d00ef5de0fe62efcf5e27e5ecc46f81046082faf
   md5: ca66d6f8fe86dd53664e8de5087ef6b1
   depends:
@@ -24563,43 +18843,26 @@ packages:
   license_family: MIT
   size: 107925
   timestamp: 1727035280560
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
-  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
-  md5: 77cbc488235ebbaab2b6e912d3934bae
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 14679
-  timestamp: 1727034741045
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: hd74edd7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
-  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
-  md5: 7e0125f8fb619620a0011dc9297e2493
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 13515
-  timestamp: 1727034783560
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: h0e40799_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
   sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
   md5: 8393c0f7e7870b4eb45553326f81f0ff
   depends:
@@ -24610,41 +18873,7 @@ packages:
   license_family: MIT
   size: 69920
   timestamp: 1727795651979
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
-  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
-  md5: 8035c64cb77ed555e3f150b7b3972480
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 19901
-  timestamp: 1727794976192
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: hd74edd7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
-  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
-  md5: 77c447f48cab5d3a15ac224edb86a968
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 18487
-  timestamp: 1727795205022
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
   sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
   md5: febbab7d15033c913d53c7a2c102309d
   depends:
@@ -24655,12 +18884,7 @@ packages:
   license_family: MIT
   size: 50060
   timestamp: 1727752228921
-- kind: conda
-  name: xorg-libxfixes
-  version: 6.0.1
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
   sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
   md5: 4bdb303603e9821baf5fe5fdff1dc8f8
   depends:
@@ -24671,12 +18895,7 @@ packages:
   license_family: MIT
   size: 19575
   timestamp: 1727794961233
-- kind: conda
-  name: xorg-libxi
-  version: 1.8.2
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
   sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
   md5: 17dcc85db3c7886650b8908b183d6876
   depends:
@@ -24689,12 +18908,7 @@ packages:
   license_family: MIT
   size: 47179
   timestamp: 1727799254088
-- kind: conda
-  name: xorg-libxrandr
-  version: 1.5.4
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
   sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
   md5: 2de7f99d6581a4a7adbff607b5c278ca
   depends:
@@ -24707,13 +18921,7 @@ packages:
   license_family: MIT
   size: 29599
   timestamp: 1727794874300
-- kind: conda
-  name: xorg-libxrender
-  version: 0.9.11
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
   sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
   md5: a7a49a8b85122b49214798321e2e96b4
   depends:
@@ -24725,12 +18933,7 @@ packages:
   license_family: MIT
   size: 37780
   timestamp: 1727529943015
-- kind: conda
-  name: xorg-libxt
-  version: 1.3.1
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
   sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
   md5: 279b0de5f6ba95457190a1c459a64e31
   depends:
@@ -24743,13 +18946,7 @@ packages:
   license_family: MIT
   size: 379686
   timestamp: 1731860547604
-- kind: conda
-  name: xorg-libxtst
-  version: 1.2.5
-  build: hb9d3cd8_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
   sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
   md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
   depends:
@@ -24762,13 +18959,7 @@ packages:
   license_family: MIT
   size: 32808
   timestamp: 1727964811275
-- kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
   sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
   md5: 7c21106b851ec72c037b162c216d8f05
   depends:
@@ -24778,12 +18969,7 @@ packages:
   license_family: MIT
   size: 565425
   timestamp: 1726846388217
-- kind: conda
-  name: xsimd
-  version: 13.0.0
-  build: h297d8ca_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xsimd-13.0.0-h297d8ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xsimd-13.0.0-h297d8ca_0.conda
   sha256: 14ebc7129caee22ff5d6eb16e402f32cb5cf0bb62792346cf1d75193bfc3015b
   md5: ee0693ab2ab0cec9095e52e291357c4f
   depends:
@@ -24793,12 +18979,7 @@ packages:
   license_family: BSD
   size: 133694
   timestamp: 1714980813395
-- kind: conda
-  name: xsimd
-  version: 13.0.0
-  build: h420ef59_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xsimd-13.0.0-h420ef59_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xsimd-13.0.0-h420ef59_0.conda
   sha256: e1fddeb43cf2c173f77337ba661a82e18b38177ee7ab43baa2b86f2899b1ab35
   md5: d8ac5fa63a3bdbe468b8cf61b85d0061
   depends:
@@ -24808,12 +18989,7 @@ packages:
   license_family: BSD
   size: 133777
   timestamp: 1714980950892
-- kind: conda
-  name: xsimd
-  version: 13.0.0
-  build: hc790b64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xsimd-13.0.0-hc790b64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/xsimd-13.0.0-hc790b64_0.conda
   sha256: 3ab68efb13cf4aab2b4997e9c72068fbce780ed59697741ab6eaba2e1521d1e2
   md5: fcca313bb659ec9d9e89bb02d70b5849
   depends:
@@ -24824,13 +19000,7 @@ packages:
   license_family: BSD
   size: 134447
   timestamp: 1714981035240
-- kind: conda
-  name: xyzservices
-  version: 2024.9.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
   sha256: 2dd2825b5a246461a95a0affaf7e1d459f7cc0ae68ad2dd8aab360c2e5859488
   md5: 156c91e778c1d4d57b709f8c5333fd06
   depends:
@@ -24839,12 +19009,7 @@ packages:
   license_family: BSD
   size: 46887
   timestamp: 1725366457240
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
   sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   md5: 2161070d867d1b1204ea749c8eec4ef0
   depends:
@@ -24852,23 +19017,13 @@ packages:
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h57fd34a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
   sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
   md5: 39c6b54e94014701dd157f4f576ed211
   license: LGPL-2.1 and GPL-2.0
   size: 235693
   timestamp: 1660346961024
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h8d14728_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
   sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
   md5: 515d77642eaa3639413c6b1bc3f94219
   depends:
@@ -24877,26 +19032,7 @@ packages:
   license: LGPL-2.1 and GPL-2.0
   size: 217804
   timestamp: 1660346976440
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h3422bc3_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
-  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
-  md5: 4bb3f014845110883a3c5ee811fd84b4
-  license: MIT
-  license_family: MIT
-  size: 88016
-  timestamp: 1641347076660
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h7f98852_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
   sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
   md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
   depends:
@@ -24905,13 +19041,14 @@ packages:
   license_family: MIT
   size: 89141
   timestamp: 1641346969816
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h8ffe710_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
   sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
   md5: adbfb9f45d1004a26763652246a33764
   depends:
@@ -24921,13 +19058,7 @@ packages:
   license_family: MIT
   size: 63274
   timestamp: 1641347623319
-- kind: conda
-  name: zeromq
-  version: 4.3.5
-  build: h3b0a872_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
   sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
   md5: 3947a35e916fcc6b9825449affbf4214
   depends:
@@ -24940,13 +19071,19 @@ packages:
   license_family: MOZILLA
   size: 335400
   timestamp: 1731585026517
-- kind: conda
-  name: zeromq
-  version: 4.3.5
-  build: ha9f60a1_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
+  md5: f7e6b65943cb73bce0143737fded08f1
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 281565
+  timestamp: 1731585108039
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
   sha256: 15cc8e2162d0a33ffeb3f7b7c7883fd830c54a4b1be6a4b8c7ee1f4fef0088fb
   md5: e03f2c245a5ee6055752465519363b1c
   depends:
@@ -24959,31 +19096,7 @@ packages:
   license_family: MOZILLA
   size: 2527503
   timestamp: 1731585151036
-- kind: conda
-  name: zeromq
-  version: 4.3.5
-  build: hc1bb282_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
-  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
-  md5: f7e6b65943cb73bce0143737fded08f1
-  depends:
-  - __osx >=11.0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libcxx >=18
-  - libsodium >=1.0.20,<1.0.21.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 281565
-  timestamp: 1731585108039
-- kind: conda
-  name: zict
-  version: 3.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
   sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
   md5: cf30c2c15b82aacb07f9c09e28ff2275
   depends:
@@ -24992,14 +19105,7 @@ packages:
   license_family: BSD
   size: 36325
   timestamp: 1681770298596
-- kind: conda
-  name: zipp
-  version: 3.21.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
   sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
   md5: 0c3cc595284c5e8f0f9900a9b228a332
   depends:
@@ -25008,13 +19114,28 @@ packages:
   license_family: MIT
   size: 21809
   timestamp: 1732827613585
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
   sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
   md5: be60c4e8efa55fddc17b4131aa47acbd
   depends:
@@ -25026,46 +19147,22 @@ packages:
   license_family: Other
   size: 107439
   timestamp: 1727963788936
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: h8359307_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
-  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
-  md5: e3170d898ca6cb48f1bb567afb92f775
-  depends:
-  - __osx >=11.0
-  - libzlib 1.3.1 h8359307_2
-  license: Zlib
-  license_family: Other
-  size: 77606
-  timestamp: 1727963209370
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
-  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
-  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
+  sha256: b97015e146437283f2213ff0e95abdc8e2480150634d81fbae6b96ee09f5e50b
+  md5: 8b7069e9792ee4e5b4919a7a306d2e67
   depends:
   - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
   - libgcc >=13
-  - libzlib 1.3.1 hb9d3cd8_2
-  license: Zlib
-  license_family: Other
-  size: 92286
-  timestamp: 1727963153079
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py312h15fbf35_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312h15fbf35_1.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 419552
+  timestamp: 1725305670210
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312h15fbf35_1.conda
   sha256: d00ca25c1e28fd31199b26a94f8c96574475704a825d244d7a6351ad3745eeeb
   md5: a4cde595509a7ad9c13b1a3809bcfe51
   depends:
@@ -25080,13 +19177,22 @@ packages:
   license_family: BSD
   size: 330788
   timestamp: 1725305806565
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py312h7606c53_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h7606c53_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py313hf2da073_1.conda
+  sha256: 12b4e34acff24d291e2626c6610dfd819b8d99a461025ae59affcb6e84bc1d57
+  md5: deebca66926691fadaaf16da05ecb5f9
+  depends:
+  - __osx >=11.0
+  - cffi >=1.11
+  - python >=3.13.0rc1,<3.14.0a0
+  - python >=3.13.0rc1,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 336496
+  timestamp: 1725305912716
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h7606c53_1.conda
   sha256: 3e0c718aa18dcac7f080844dbe0aea41a9cea75083019ce02e8a784926239826
   md5: a92cc3435b2fd6f51463f5a4db5c50b1
   depends:
@@ -25102,34 +19208,7 @@ packages:
   license_family: BSD
   size: 320624
   timestamp: 1725305934189
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py312hef9b889_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
-  sha256: b97015e146437283f2213ff0e95abdc8e2480150634d81fbae6b96ee09f5e50b
-  md5: 8b7069e9792ee4e5b4919a7a306d2e67
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cffi >=1.11
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - zstd >=1.5.6,<1.5.7.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 419552
-  timestamp: 1725305670210
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py313h574b89f_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py313h574b89f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py313h574b89f_1.conda
   sha256: 1d2744ec0e91da267ce749e19142081472539cb140a7dad0646cd249246691fe
   md5: 8e017aca933f4dd25491151edd3e7820
   depends:
@@ -25145,33 +19224,28 @@ packages:
   license_family: BSD
   size: 325703
   timestamp: 1725305947138
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py313hf2da073_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py313hf2da073_1.conda
-  sha256: 12b4e34acff24d291e2626c6610dfd819b8d99a461025ae59affcb6e84bc1d57
-  md5: deebca66926691fadaaf16da05ecb5f9
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
   depends:
-  - __osx >=11.0
-  - cffi >=1.11
-  - python >=3.13.0rc1,<3.14.0a0
-  - python >=3.13.0rc1,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.6,<1.5.7.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 336496
-  timestamp: 1725305912716
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: h0ea2cb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
   sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
   md5: 9a17230f95733c04dc40a2b1e5491d74
   depends:
@@ -25183,34 +19257,3 @@ packages:
   license_family: BSD
   size: 349143
   timestamp: 1714723445995
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: ha6fb4c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
-  md5: 4d056880988120e29d75bfff282e0f45
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 554846
-  timestamp: 1714722996770
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: hb46c0d2_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
-  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
-  md5: d96942c06c3e84bfcc5efb038724a7fd
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 405089
-  timestamp: 1714723101397

--- a/pixi.toml
+++ b/pixi.toml
@@ -48,6 +48,8 @@ setuptools-scm = ">=8.1"
 [host-dependencies]
 python = ">=3.9"
 pip = "*"
+setuptools = "*"
+wheel = "*"
 
 [dependencies]
 formulaic = "*"


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

From python 3.13, the conda-forge version of `pip` won't list `setuptools` and `wheel` as its dependencies. We need those because we are installing `glum` with the `--no-use-pep517`. This PR adds those two dependencies to `pixi.toml`.

Same thing as [tabmat #417](https://github.com/Quantco/tabmat/pull/417).

<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
