### PR TITLE
Lower absolute tolerance in _find_alpha_index

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Changelog
 
 - Fixed a bug where :meth:`glum.GeneralizedLinearRegressor.fit` would raise a ``dtype`` mismatch error if fit with ``alpha_search=True``.
 
+**Other changes:
+
+- Lower absolute tolerance when matching the ``alpha`` argument in :meth:`glum.GeneralizedLinearRegressor.predict` to the ``alphas`` used in training when ``alpha_search=True``.
+
 3.0.2 - 2024-06-25
 ------------------
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -1279,7 +1279,8 @@ class GeneralizedLinearRegressorBase(BaseEstimator, RegressorMixin):
         if not self.alpha_search:
             raise ValueError
         # `np.isclose` because comparing floats is difficult
-        isclose = np.isclose(self._alphas, alpha)
+        atol = 100.0 * np.finfo(alpha.dtype).eps
+        isclose = np.isclose(self._alphas, alpha, atol=atol)
         if np.sum(isclose) == 1:
             return np.argmax(isclose)  # cf. stackoverflow.com/a/61117770
         raise IndexError(

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -1599,12 +1599,18 @@ def test_alpha_search(regression_data):
     assert_allclose(mdl_path.intercept_, mdl_no_path.intercept_)
 
 
-@pytest.mark.parametrize("alpha, alpha_index", [(0.5, 0), (0.75, 1), (None, 1)])
+@pytest.mark.parametrize(
+    "alpha, alpha_index",
+    [(0.5, 0), (0.75, 1), (None, 1), (2e-9, 2), (1e-9, 3)]
+)
 def test_predict_scalar(regression_data, alpha, alpha_index):
     X, y = regression_data
     offset = np.ones_like(y)
 
-    estimator = GeneralizedLinearRegressor(alpha=[0.5, 0.75], alpha_search=True)
+    estimator = GeneralizedLinearRegressor(
+        alpha=[0.5, 0.75, 2e-9, 1e-9],
+        alpha_search=True
+    )
     estimator.fit(X, y)
 
     target = estimator.predict(X, alpha_index=alpha_index)


### PR DESCRIPTION
Sometimes I use really small values for `alpha`. The new `atol` is arbitrary. Is should be <= 1e-10 for `float64`.

```python
In [2]: np.finfo(np.float32).eps
Out[2]: 1.1920929e-07

In [3]: np.finfo(np.float64).eps
Out[3]: 2.220446049250313e-16
```

Checklist
* [x] Added a `CHANGELOG.rst` entry

![image](https://github.com/user-attachments/assets/ac73d2a3-3e40-4bd2-b751-e329f12052f2)
