### PR TITLE
Switch to `libc.math` import for infinity

### DIFF
--- a/src/glum/_cd_fast.pyx
+++ b/src/glum/_cd_fast.pyx
@@ -10,7 +10,7 @@
 from libc.math cimport fabs
 cimport numpy as np
 import numpy as np
-from numpy.math cimport INFINITY
+from libc.math cimport INFINITY
 
 from cython cimport floating
 from cython.parallel import prange


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

There was a nightly daily failure related to the `numpy.math.INFINITY` import. It seems like switching to the [recommended](https://github.com/cython/cython/blob/6f03859fdeeac88a33f6b1e96cef58c09fd339ad/Cython/Includes/numpy/math.pxd#L21-L23) way to import infinity solves the issue. Closes #930.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
