### PR TITLE
Set `object_as_cat` to `True` when constructing the `tabmat` matrix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@
 Changelog
 =========
 
+3.1.3 - 2025-09-09
+------------------
+
+**Bug fix**
+
+- To support the new ``str`` dtype in Pandas (which will become the default in Pandas 3.0), we now set ``object_as_cat`` to ``True`` when constructing the ``tabmat`` matrix.
+
+
+
 3.1.2 - 2025-01-30
 ------------------
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -281,6 +281,9 @@ class GeneralizedLinearRegressorBase(skl.base.RegressorMixin, skl.base.BaseEstim
                 self, "categorical_format", "{name}__{category}"
             ),
             cat_missing_method=cat_missing_method_after_alignment,
+            # setting object_as_cat to True allows us to bypass issues with the
+            # new str dtype in pandas 3
+            object_as_cat=True,
         )
 
         return X
@@ -1827,6 +1830,9 @@ class GeneralizedLinearRegressorBase(skl.base.RegressorMixin, skl.base.BaseEstim
                     ),
                     cat_missing_method=getattr(self, "cat_missing_method", "fail"),
                     cat_missing_name=getattr(self, "cat_missing_name", "(MISSING)"),
+                    # setting object_as_cat to True allows us to bypass issues with the
+                    # new str dtype in pandas 3
+                    object_as_cat=True,
                 )
 
         if y is None:

--- a/tests/glm/test_formula.py
+++ b/tests/glm/test_formula.py
@@ -108,7 +108,8 @@ def test_formula(get_mixed_data, formula, drop_first, fit_intercept):
         # full rank check must consider presence of intercept
         y_ext, X_ext = formulaic.model_matrix(
             formula,
-            data,
+            # casting to category until formulaic supports pandas 3 str dtype
+            data.astype({"c1": "category", "c2": "category"}),
             ensure_full_rank=drop_first,
             materializer=formulaic.materializers.PandasMaterializer,
         )
@@ -116,7 +117,8 @@ def test_formula(get_mixed_data, formula, drop_first, fit_intercept):
     else:
         y_ext, X_ext = formulaic.model_matrix(
             formula + "-1",
-            data,
+            # casting to category until formulaic supports pandas 3 str dtype
+            data.astype({"c1": "category", "c2": "category"}),
             ensure_full_rank=drop_first,
             materializer=formulaic.materializers.PandasMaterializer,
         )


### PR DESCRIPTION
Fixes #939.

`formulaic` isn't compatible with the `str` dtype that becomes the default in `pandas>=3`. There's an open PR https://github.com/matthewwardrop/formulaic/pull/258, but not much work. My quick fix for this is to use categorical dtypes whenever we're encountering `objects` or `str` dtypes. Happy to entertain a different fix for this.

The relevant code snippet in tabmat is based on narwhals:
https://github.com/Quantco/tabmat/blob/fe2f30dd4c0b697b7bdfa9bf3c97065393d7d36a/src/tabmat/constructor.py#L96-L104