### PR TITLE
Install statsmodels nightlies

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -35,6 +35,7 @@ cmd = """
     PRE_WHEELS="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS pandas
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS scikit-learn
+    && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS statsmodels
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i https://pypi.fury.io/arrow-nightlies/ pyarrow
     && pip install --no-use-pep517 --no-deps git+https://github.com/Quantco/tabmat
 """


### PR DESCRIPTION
`statsmodels` isn't compatible with `pandas>=3` yet, see https://github.com/statsmodels/statsmodels/issues/9614. The PR got merged, but there's no release yet. I'm addressing this by installing statsmodels nightlies.

CI will be red for the nightlies until #944 is merged.