### PR TITLE
Fix cibuildwheels setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ skip = [
   "cp36*",
   "cp37*",
   "cp38*",
+  "cp314t*"
 ]
 test-requires = ["pytest", "pytest-xdist"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ skip = [
   "*-manylinux_i686",
   "*-musllinux_*",
   "cp38*",
-  "cp314t*"
+  "cp314t-win*"
 ]
 test-requires = ["pytest", "pytest-xdist"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,7 @@ ignore_missing_imports = true
 skip = [
   "*-win32",
   "*-manylinux_i686",
-  "pp*",
   "*-musllinux_*",
-  "cp36*",
-  "cp37*",
   "cp38*",
   "cp314t*"
 ]


### PR DESCRIPTION
Follow up to #948.

- I'm explicitly skipping free threading builds on Windows (because they're broken)
- Removed cp36, cp37 and pp, because cibuildwheels warns that they don't need to be skipped anymore (see https://github.com/Quantco/glum/actions/runs/17578618735/job/49929562743#step:4:179)

CI will be red until #944 is merged.