### PR TITLE
Fix formula test by using categoricals

### DIFF
--- a/tests/glm/test_formula.py
+++ b/tests/glm/test_formula.py
@@ -108,7 +108,7 @@ def test_formula(get_mixed_data, formula, drop_first, fit_intercept):
         # full rank check must consider presence of intercept
         y_ext, X_ext = formulaic.model_matrix(
             formula,
-            data,
+            data.astype({"c1": "category", "c2": "category"}),
             ensure_full_rank=drop_first,
             materializer=formulaic.materializers.PandasMaterializer,
         )
@@ -116,7 +116,7 @@ def test_formula(get_mixed_data, formula, drop_first, fit_intercept):
     else:
         y_ext, X_ext = formulaic.model_matrix(
             formula + "-1",
-            data,
+            data.astype({"c1": "category", "c2": "category"}),
             ensure_full_rank=drop_first,
             materializer=formulaic.materializers.PandasMaterializer,
         )


### PR DESCRIPTION
The test `test_formula` compares a model that is fitted using a formula with one that "manually" gets a model matrix from formulaic. As formulaic doesn't know yet what to do with pandas' new `str` dtype, I changed the formulaic part of the test to use categoricals instead of `str` dtype columns. `glum` and `tabmat` are fine with the `str` dtype, so this is not a user-facing change. 