### PR TITLE
Fix/monotonic drop first

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@
 Changelog
 =========
 
+3.4.1 - unreleased
+------------------
+
+**Bug fix:**
+
+- Fixed ``ValueError: Factor 'C(x)-' not found in feature_names`` when using ``monotonic_constraints`` with ``drop_first=True`` (the default) on categorical factors encoded via ``C()``.
+
+**Other changes:**
+
+- Added ``monotonic_constraints`` to ``__setstate__`` defaults for pickle compatibility with models saved before 3.4.0.
+
+
 3.4.0 - 2026-04-27
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changelog
 
 **Bug fix:**
 
-- Fixed ``monotonic_constraints`` raising ``ValueError: Factor 'C(x)-' not found`` with ``drop_first=True`` on categorical factors. The internal constraint resolution read factor names from formulaic's ``ScopedFactor.__str__()``, which appends a ``-`` suffix when the factor is rank-reduced, but feature names never carry this suffix.
+- Fixed ``monotonic_constraints`` raising ``ValueError`` with ``drop_first=True`` on categorical factors.
 - Fixed pickle compatibility for models saved before ``monotonic_constraints`` was added.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,12 @@
 Changelog
 =========
 
-3.4.1 - unreleased
+3.4.1 - 2026-05-06
 ------------------
 
 **Bug fix:**
 
-- Fixed ``monotonic_constraints`` failing with ``drop_first=True`` on categorical factors.
+- Fixed ``monotonic_constraints`` raising ``ValueError: Factor 'C(x)-' not found`` with ``drop_first=True`` on categorical factors. The internal constraint resolution read factor names from formulaic's ``ScopedFactor.__str__()``, which appends a ``-`` suffix when the factor is rank-reduced, but feature names never carry this suffix.
 - Fixed pickle compatibility for models saved before ``monotonic_constraints`` was added.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,8 @@ Changelog
 
 **Bug fix:**
 
-- Fixed ``ValueError: Factor 'C(x)-' not found in feature_names`` when using ``monotonic_constraints`` with ``drop_first=True`` (the default) on categorical factors encoded via ``C()``.
-
-**Other changes:**
-
-- Added ``monotonic_constraints`` to ``__setstate__`` defaults for pickle compatibility with models saved before 3.4.0.
+- Fixed ``monotonic_constraints`` failing with ``drop_first=True`` on categorical factors.
+- Fixed pickle compatibility for models saved before ``monotonic_constraints`` was added.
 
 
 3.4.0 - 2026-04-27

--- a/src/glum/_formula.py
+++ b/src/glum/_formula.py
@@ -189,7 +189,7 @@ def _resolve_monotonic_constraints_from_model_spec(
     for _term, scoped_terms, column_names in model_spec.structure:
         for st in scoped_terms:
             for f in st.factors:
-                factor_name = str(f)
+                factor_name = str(f).rstrip("-+")
                 data_vars = {
                     str(v)
                     for v in f.factor.variables

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -200,6 +200,7 @@ class GeneralizedLinearRegressorBase(skl.base.RegressorMixin, skl.base.BaseEstim
         # This handles models pickled with older versions of glum 3.x
         attribute_defaults = {
             "max_inner_iter": 100000,
+            "monotonic_constraints": None,
         }
 
         for attr, default_value in attribute_defaults.items():

--- a/tests/glm/test_formula.py
+++ b/tests/glm/test_formula.py
@@ -408,22 +408,22 @@ def test_monotonic_constraints_categorical_drop_first():
     """Monotonic constraints work with C() and drop_first=True."""
     rng = np.random.default_rng(0)
     n = 120
-    age = np.tile(np.arange(6), n // 6).astype(float)
-    y = 1.0 / (1.0 + 0.3 * age) + rng.normal(0, 0.02, n)
+    education = np.tile(np.arange(4), n // 4).astype(float)
+    y = 0.5 + 0.2 * education + rng.normal(0, 0.02, n)
     y = np.clip(y, 1e-3, None)
-    df = pd.DataFrame({"age": age, "y": y})
+    df = pd.DataFrame({"education": education, "y": y})
 
     model = GeneralizedLinearRegressor(
-        formula="y ~ C(age)",
+        formula="y ~ C(education)",
         family="gamma",
         drop_first=True,
         alpha=1e-6,
-        monotonic_constraints={"age": "decreasing"},
+        monotonic_constraints={"education": "increasing"},
     )
     model.fit(df)
 
     diffs = np.diff(model.coef_)
-    assert all(diffs <= 1e-8)
+    assert all(diffs >= -1e-8)
 
 
 @pytest.mark.parametrize("direction", ["increasing", "decreasing"])

--- a/tests/glm/test_formula.py
+++ b/tests/glm/test_formula.py
@@ -404,6 +404,28 @@ def test_monotonic_constraints_spline(direction, estimator_cls):
     assert all(sign * diffs >= -1e-8)
 
 
+def test_monotonic_constraints_categorical_drop_first():
+    """Monotonic constraints work with C() and drop_first=True."""
+    rng = np.random.default_rng(0)
+    n = 120
+    age = np.tile(np.arange(6), n // 6).astype(float)
+    y = 1.0 / (1.0 + 0.3 * age) + rng.normal(0, 0.02, n)
+    y = np.clip(y, 1e-3, None)
+    df = pd.DataFrame({"age": age, "y": y})
+
+    model = GeneralizedLinearRegressor(
+        formula="y ~ C(age)",
+        family="gamma",
+        drop_first=True,
+        alpha=1e-6,
+        monotonic_constraints={"age": "decreasing"},
+    )
+    model.fit(df)
+
+    diffs = np.diff(model.coef_)
+    assert all(diffs <= 1e-8)
+
+
 @pytest.mark.parametrize("direction", ["increasing", "decreasing"])
 def test_monotonic_constraints_spline_interaction(direction):
     """Spline x categorical: coefficients ordered within each group level."""


### PR DESCRIPTION
## Summary

## Summary

- Fix `ValueError: Factor 'C(x)-' not found in feature_names` when using `monotonic_constraints` with `drop_first=True` on categorical factors.
- Add pickle backward compatibility for `monotonic_constraints`.

## Root cause

`_resolve_monotonic_constraints_from_model_spec` reads factor names via `str(ScopedFactor)`, which appends a `-` suffix when the factor is rank-reduced (`drop_first=True`). Feature names never carry this suffix (e.g. `"C(education)[1.0]"` not `"C(education)-[1.0]"`), so the downstream lookup in `_build_monotonic_constraints` fails.

Fix: strip trailing `-`/`+` from the factor name before passing it on.

## Test plan

- [x] `test_monotonic_constraints_categorical_drop_first`
- [x] Full formula test suite (87 tests)


Checklist
* [x] Added a `CHANGELOG.rst` entry
