### PR TITLE
Add `TermLayout` -- term-to-coefficient slice registry

### DIFF
--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -48,6 +48,7 @@ from ._solvers import (
     _tikhonov_solver,
     _trust_constr_solver,
 )
+from ._term_layout import TermLayout
 from ._typing import (
     ArrayLike,
     ShapedArrayLike,
@@ -2162,6 +2163,9 @@ class GeneralizedLinearRegressorBase(skl.base.RegressorMixin, skl.base.BaseEstim
 
         self.feature_names_ = X.get_names(type="column", missing_prefix="_col_")  # type: ignore
         self.term_names_ = X.get_names(type="term", missing_prefix="_col_")
+        self.term_layout_ = TermLayout.from_term_names(
+            self.term_names_, self.fit_intercept
+        )
 
         return X, y, sample_weight, offset, weights_sum, P1, P2  # type: ignore
 

--- a/src/glum/_term_layout.py
+++ b/src/glum/_term_layout.py
@@ -1,0 +1,118 @@
+"""Term-to-coefficient layout for fitted GLM models.
+
+A :class:`TermLayout` is a lightweight, immutable view that records which
+contiguous slice of the coefficient vector each model term occupies. It is
+populated alongside ``term_names_`` after fitting and is intended to be the
+single source of truth for code that needs to reason about *terms* rather than
+individual coefficients (penalty assembly, term-level diagnostics, smooth
+construction, etc.).
+
+This module is intentionally small. It contains no formula logic and no
+reference to ``formulaic`` or ``tabmat``; it builds the layout from the
+per-coefficient term-name list that ``GeneralizedLinearRegressorBase`` already
+constructs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class TermSlice:
+    """One term and the coefficient indices it owns.
+
+    ``start`` / ``stop`` are half-open and index the full coefficient vector,
+    i.e. with the intercept at position 0 when ``fit_intercept`` is true.
+    """
+
+    name: str
+    start: int
+    stop: int
+    kind: str
+
+    @property
+    def n_coefs(self) -> int:
+        return self.stop - self.start
+
+
+@dataclass(frozen=True, slots=True)
+class TermLayout:
+    """Ordered view of terms and the coefficient slice each one owns.
+
+    The layout is derived from the per-coefficient term-name list produced
+    during fit and the intercept flag. Construction is O(n_features); after
+    that all lookups are O(n_terms).
+    """
+
+    terms: tuple[TermSlice, ...]
+    has_intercept: bool
+    _by_name: dict[str, TermSlice]
+
+    @classmethod
+    def from_term_names(
+        cls,
+        term_names: Sequence[str],
+        fit_intercept: bool,
+    ) -> TermLayout:
+        """Build a layout from a per-coefficient term-name list.
+
+        ``term_names`` must have one entry per non-intercept coefficient, in
+        coefficient order. Adjacent equal entries are collapsed into a single
+        term slice. If ``fit_intercept`` is true, an ``"intercept"`` slice is
+        prepended at index 0.
+        """
+        slices: list[TermSlice] = []
+        offset = 1 if fit_intercept else 0
+        if fit_intercept:
+            slices.append(TermSlice("intercept", 0, 1, "intercept"))
+
+        i = 0
+        n = len(term_names)
+        while i < n:
+            j = i + 1
+            current = term_names[i]
+            while j < n and term_names[j] == current:
+                j += 1
+            slices.append(
+                TermSlice(
+                    name=str(current) if current is not None else f"_term_{i}",
+                    start=offset + i,
+                    stop=offset + j,
+                    kind="term",
+                )
+            )
+            i = j
+
+        return cls(
+            terms=tuple(slices),
+            has_intercept=fit_intercept,
+            _by_name={s.name: s for s in slices},
+        )
+
+    def __iter__(self) -> Iterator[TermSlice]:
+        return iter(self.terms)
+
+    def __len__(self) -> int:
+        return len(self.terms)
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            return self._by_name[key]
+        return self.terms[key]
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        return key in self._by_name
+
+    @property
+    def n_coefs(self) -> int:
+        """Total number of coefficients spanned by the layout."""
+        return self.terms[-1].stop if self.terms else 0
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Term names in coefficient order."""
+        return tuple(term.name for term in self.terms)

--- a/tests/glm/test_term_layout.py
+++ b/tests/glm/test_term_layout.py
@@ -1,0 +1,280 @@
+import time
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from glum._glm import GeneralizedLinearRegressor
+from glum._term_layout import TermLayout
+
+
+def _slices_partition(layout: TermLayout) -> bool:
+    """True iff layout slices form a contiguous, ordered partition of [0, n_coefs)."""
+    expected_start = 0
+    for term in layout:
+        if term.start != expected_start or term.stop <= term.start:
+            return False
+        expected_start = term.stop
+    return expected_start == layout.n_coefs
+
+
+def test_consecutive_duplicate_term_names_collapse_into_one_slice():
+    # Arrange
+    term_names = ["x1", "c1", "c1", "c1", "x2"]
+
+    # Act
+    layout = TermLayout.from_term_names(term_names, fit_intercept=False)
+
+    # Assert
+    assert [t.name for t in layout] == ["x1", "c1", "x2"]
+    assert layout["c1"].n_coefs == 3
+
+
+def test_intercept_owns_first_coefficient_when_fit_intercept_true():
+    # Arrange
+    term_names = ["x1", "x2"]
+
+    # Act
+    layout = TermLayout.from_term_names(term_names, fit_intercept=True)
+
+    # Assert
+    assert layout.has_intercept is True
+    assert "intercept" in layout
+    assert layout["intercept"].start == 0
+    assert layout["intercept"].stop == 1
+    assert layout["x1"].start == 1
+
+
+def test_layout_without_intercept_starts_at_index_zero():
+    # Arrange
+    term_names = ["x1", "x2"]
+
+    # Act
+    layout = TermLayout.from_term_names(term_names, fit_intercept=False)
+
+    # Assert
+    assert layout.has_intercept is False
+    assert "intercept" not in layout
+    assert layout["x1"].start == 0
+
+
+def test_empty_term_names_with_intercept_yields_intercept_only_layout():
+    # Arrange / Act
+    layout = TermLayout.from_term_names([], fit_intercept=True)
+
+    # Assert
+    assert layout.n_coefs == 1
+    assert [t.name for t in layout] == ["intercept"]
+
+
+def test_empty_term_names_without_intercept_yields_empty_layout():
+    # Arrange / Act
+    layout = TermLayout.from_term_names([], fit_intercept=False)
+
+    # Assert
+    assert layout.n_coefs == 0
+    assert list(layout) == []
+
+
+@pytest.mark.parametrize(
+    "term_names,fit_intercept,expected_n_coefs",
+    [
+        (["x1", "x2", "x3"], False, 3),
+        (["x1", "x2", "x3"], True, 4),
+        (["c1", "c1", "c1"], True, 4),
+        (["a", "b", "b", "c", "c", "c"], False, 6),
+    ],
+)
+def test_slices_partition_the_full_coefficient_vector(
+    term_names, fit_intercept, expected_n_coefs
+):
+    # Arrange / Act
+    layout = TermLayout.from_term_names(term_names, fit_intercept=fit_intercept)
+
+    # Assert
+    assert layout.n_coefs == expected_n_coefs
+    assert _slices_partition(layout)
+
+
+def test_lookup_by_name_returns_slice_covering_that_terms_coefficients():
+    # Arrange
+    term_names = ["x1", "c1", "c1", "c1", "x2"]
+    layout = TermLayout.from_term_names(term_names, fit_intercept=True)
+
+    # Act
+    c1_slice = layout["c1"]
+
+    # Assert: slice covers exactly the c1 entries in term_names (intercept offset 1)
+    coef_indices = range(c1_slice.start, c1_slice.stop)
+    assert [term_names[i - 1] for i in coef_indices] == ["c1", "c1", "c1"]
+
+
+def test_lookup_by_unknown_name_raises_key_error():
+    # Arrange
+    layout = TermLayout.from_term_names(["x1"], fit_intercept=False)
+
+    # Act / Assert
+    with pytest.raises(KeyError):
+        layout["does_not_exist"]
+
+
+def test_membership_check_distinguishes_known_from_unknown_terms():
+    # Arrange
+    layout = TermLayout.from_term_names(["x1", "x2"], fit_intercept=True)
+
+    # Assert (no separate Act; membership is the operation under test)
+    assert "x1" in layout
+    assert "intercept" in layout
+    assert "x3" not in layout
+    assert 42 not in layout  # non-string membership returns False
+
+
+def test_iteration_yields_terms_in_coefficient_order():
+    # Arrange
+    term_names = ["a", "b", "b", "c"]
+    layout = TermLayout.from_term_names(term_names, fit_intercept=True)
+
+    # Act
+    iterated = [(t.name, t.start) for t in layout]
+
+    # Assert: each successive term starts at or after the previous one
+    starts = [start for _, start in iterated]
+    assert starts == sorted(starts)
+    assert [name for name, _ in iterated] == ["intercept", "a", "b", "c"]
+
+
+def test_term_slice_n_coefs_equals_stop_minus_start():
+    # Arrange
+    layout = TermLayout.from_term_names(["c1", "c1", "c1"], fit_intercept=False)
+
+    # Act
+    term = layout["c1"]
+
+    # Assert
+    assert term.n_coefs == term.stop - term.start
+
+
+# --- Integration: end-to-end after .fit() ---------------------------------
+
+
+def test_fit_layout_n_coefs_matches_total_coefficients():
+    # Arrange
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((50, 3))
+    y = rng.standard_normal(50)
+
+    # Act
+    model = GeneralizedLinearRegressor(family="normal", alpha=0.1).fit(X, y)
+
+    # Assert
+    expected_total = (1 if model.fit_intercept else 0) + len(model.coef_)
+    assert model.term_layout_.n_coefs == expected_total
+
+
+def test_fit_without_intercept_layout_excludes_intercept_slice():
+    # Arrange
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((40, 2))
+    y = rng.standard_normal(40)
+
+    # Act
+    model = GeneralizedLinearRegressor(
+        family="normal", alpha=0.1, fit_intercept=False
+    ).fit(X, y)
+
+    # Assert
+    assert "intercept" not in model.term_layout_
+    assert model.term_layout_.has_intercept is False
+
+
+def test_fit_layout_slices_partition_the_coefficient_vector():
+    # Arrange
+    rng = np.random.default_rng(1)
+    df = pd.DataFrame(
+        {
+            "y": rng.standard_normal(60),
+            "x1": rng.standard_normal(60),
+            "c1": pd.Categorical(rng.choice(["a", "b", "c"], 60)),
+        }
+    )
+
+    # Act
+    model = GeneralizedLinearRegressor(
+        family="normal", formula="y ~ x1 + c1", alpha=0.1, drop_first=False
+    ).fit(df)
+
+    # Assert
+    assert _slices_partition(model.term_layout_)
+
+
+def test_fit_layout_term_lookup_yields_correct_design_matrix_columns():
+    """The strongest behavioral test: layout slices must point at the right
+    columns of the design matrix that produced ``coef_``.
+    """
+    # Arrange
+    rng = np.random.default_rng(2)
+    df = pd.DataFrame(
+        {
+            "y": rng.standard_normal(80),
+            "x1": rng.standard_normal(80),
+            "c1": pd.Categorical(rng.choice(["a", "b", "c"], 80)),
+        }
+    )
+    model = GeneralizedLinearRegressor(
+        family="normal", formula="y ~ x1 + c1", alpha=0.1, drop_first=False
+    ).fit(df)
+    intercept_offset = 1 if model.fit_intercept else 0
+
+    # Act: pick the categorical term and read back the column names it spans
+    c1_slice = model.term_layout_["c1"]
+    coef_indices = range(c1_slice.start, c1_slice.stop)
+    feature_indices = [i - intercept_offset for i in coef_indices]
+    spanned_features = [model.feature_names_[i] for i in feature_indices]
+
+    # Assert: every spanned feature name carries the c1 prefix
+    assert len(spanned_features) >= 2  # at least two levels remain
+    assert all(name.startswith("c1") for name in spanned_features)
+
+
+def test_fit_layout_is_deterministic_for_identical_fits():
+    # Arrange
+    rng = np.random.default_rng(3)
+    X = rng.standard_normal((30, 4))
+    y = rng.standard_normal(30)
+
+    # Act
+    layout_a = (
+        GeneralizedLinearRegressor(family="normal", alpha=0.1).fit(X, y).term_layout_
+    )
+    layout_b = (
+        GeneralizedLinearRegressor(family="normal", alpha=0.1).fit(X, y).term_layout_
+    )
+
+    # Assert
+    assert [t.name for t in layout_a] == [t.name for t in layout_b]
+    assert [(t.start, t.stop) for t in layout_a] == [
+        (t.start, t.stop) for t in layout_b
+    ]
+
+
+# --- Performance regression guard -----------------------------------------
+
+
+def test_layout_construction_overhead_is_bounded():
+    """Construction is O(n_terms) and runs once per .fit(). Lock in a generous
+    upper bound so an accidental quadratic regression would fail loudly.
+    """
+    # Arrange
+    n = 1000
+    term_names = [f"x{i}" for i in range(n)]
+
+    # Act
+    start = time.perf_counter()
+    for _ in range(100):
+        TermLayout.from_term_names(term_names, fit_intercept=True)
+    elapsed_per_build_ms = (time.perf_counter() - start) / 100 * 1000
+
+    # Assert: 1000 single-coef terms should build in well under 5 ms
+    assert elapsed_per_build_ms < 5.0, (
+        f"TermLayout build regressed: {elapsed_per_build_ms:.2f} ms/build"
+    )


### PR DESCRIPTION

## Why

Splines (mgcv-style `s(...)` / `te(...)` smooths) need to map each smooth term to a contiguous block of coefficients so a single lambda can penalize a whole block. glum currently exposes only a flat per-coefficient `term_names_` list, with no way to ask "which coefficients does term X own?" without re-scanning that list. This PR adds the registry; later PRs migrate consumers (penalty assembly, Wald-test name lookup, categorical penalty expansion) onto it.
This is the first PR in the splines roadmap -- purely additive, no behavior change.

## What

- New module `src/glum/_term_layout.py` with two frozen, slotted dataclasses:
  - `TermSlice(name, start, stop, kind)` -- one term, half-open coef range over the full coefficient vector (intercept-aware).
  - `TermLayout` -- ordered tuple of `TermSlice` + `has_intercept`, with O(1) name lookup, iteration, and membership.
- `GeneralizedLinearRegressorBase._set_up_for_fit` populates `model.term_layout_` next to the existing `term_names_` assignment. Both fit branches (formula and array/DataFrame) flow through the same point.
- New test file `tests/glm/test_term_layout.py` -- 20 tests, all AAA-structured and strictly behavioral (partition property, slice -> column round-trip after `.fit()`, determinism, lookup contracts, edge cases).

## Consumers

There are exactly two non-test references to `TermLayout` after this PR: the import at `src/glum/_glm.py:51` and the construction at `src/glum/_glm.py:2166`. The execution graph during `.fit()` is:

```text
GeneralizedLinearRegressor.fit(X, y)
  -> _set_up_for_fit(X, y, ...)
       ...
       self.feature_names_ = X.get_names("column")
       self.term_names_    = X.get_names("term")
       self.term_layout_   = TermLayout.from_term_names(...)   # WRITE (this PR)
  -> _solve(...)
       # IRLS / CD inner loops
       # Reads X, y, weights, offset, P1, P2, alpha
       # Does NOT read self.term_layout_
  -> self.coef_, self.intercept_ = ...
```

The layout is constructed once at the end of fit setup and then sits unread for the entire IRLS/CD inner loop. Zero hot-path cost.

Planned consumers, all outside the IRLS inner loop:

| Future consumer | Hot path? | Lookup pattern |
| --- | --- | --- |
| `expand_categorical_penalties` migration (closes the `_glm.py:2039` TODO) | No -- once during fit setup | `layout[term_name]` for each user-supplied per-term penalty |
| Wald-test name lookup at `_glm.py:1349` | No -- once at `model.wald_test(...)` time | `layout[term_name].start:.stop` to slice `coef_` and the covariance |
| `Penalty` / `PenaltyTerm` assembly (next PR) | No -- once per outer lambda update | iterate `layout.terms`, write each `S_m` block into the global penalty matrix |
| Smooth construction (`s(...)` / `te(...)`) | No -- once at fit setup | iterate `layout.terms`, build basis + penalty per smooth term |
| Smooth-term partial-effect prediction | No -- once at `predict_smooth(...)` time | `layout[term_name]` to slice `coef_` for one smooth |

`TermLayout` is metadata that lives at the boundary between user-facing API (term names, formulas) and the numerical solver (column indices), not inside the solver. The hot path (`build_hessian_delta`, the Cython CD sweep, distribution gradient/hessian calls) keeps operating on assembled `numpy` / sparse arrays of length `n_features`, exactly as it does today.

## Performance

### How to read these numbers

Two things are being measured, and they sit in different places:

- **Build cost** (`TermLayout.from_term_names`) is paid **exactly once per `.fit()`**, in fit setup, before the solver runs. It is the only cost this PR adds to a fit.
- **Lookup cost** is paid **zero times during `.fit()`** because no consumer in this PR reads the layout. It will be paid by future consumers listed in the section above, all of which run outside the IRLS inner loop. The lookup number is reported as a forward-looking budget for those consumers.

So the "Build / fit ratio" rows below are the worst-case overhead this PR introduces -- a closed bound on the fit-time cost.

### Source of the numbers

The script that produced these numbers is reproduced verbatim at the bottom of this section. It uses `time.perf_counter_ns`, runs on Python 3.14 / M-series Mac, with GC disabled inside each timed loop, plus a 1 000-call warm-up before measurement. Each row is `n=200` independent repeats; each repeat times an inner loop of `inner` calls and reports the inner-loop-averaged seconds-per-call. `n=80` for `.fit()` (slower, fewer repeats). 95% CIs are normal-approximation on the mean; the empirical 2.5 / 97.5% columns are direct percentiles of the 200 per-repeat means.

### `TermLayout.from_term_names` build cost

| Workload | Mean | 95% CI on mean | Median | Std | Min / Max | Empirical 2.5 / 97.5% |
| --- | --- | --- | --- | --- | --- | --- |
| 50 single-coef terms (w/ intercept) | 32.07 us | [32.00, 32.13] | 31.99 us | 0.48 us | 31.43 / 36.69 | [31.63, 32.59] |
| 500 cols / 5 cat terms | 15.56 us | [15.54, 15.58] | 15.54 us | 0.18 us | 15.18 / 16.10 | [15.26, 15.90] |
| 500 single-coef terms | 314.54 us | [313.93, 315.15] | 313.63 us | 4.41 us | 308.07 / 335.57 | [309.07, 325.49] |
| 1 000 single-coef terms | 639.55 us | [637.61, 641.49] | 636.60 us | 13.97 us | 627.48 / 781.24 | [628.24, 667.79] |
| 10 000 single-coef terms | 6.50 ms | [6.48, 6.52] | 6.47 ms | 0.13 ms | 6.35 / 7.24 | [6.37, 6.82] |

Linear scaling in `n_terms` confirmed: ~0.65 us per term across all scales. Categorical case is sub-linear because the inner-loop count is `n_terms`, not `n_features`.

### Lookup by name (forward-looking budget for future consumers)

| Workload | Mean | 95% CI | Median | Std |
| --- | --- | --- | --- | --- |
| 50-term layout, name -> slice | 0.06 us | [0.06, 0.06] | 0.06 us | <0.01 us |

~60 ns. Constant in `n_terms` (dict lookup).

### Reference cost it competes with

| Workload | Mean | 95% CI | Median | Std |
| --- | --- | --- | --- | --- |
| `.fit()` 1000 x 50, normal | 1.04 ms | [1.03, 1.05] | 1.04 ms | 0.06 ms |

### Overhead in context

| Workload | Build / fit ratio |
| --- | --- |
| 50 features (typical small fit) | 32 us / 1 040 us = ~3.1% |
| 500 cols / 5 cat terms | 16 us / 1 040 us = ~1.5% |
| 10 000 features | 6.5 ms / ~3.8 s = <0.2% |

The 3% on the small case is the floor and is dominated by `n_terms` `TermSlice` dataclass allocations -- intrinsic given the public API. A perf-regression guard test (5 ms ceiling at 1 000 terms vs measured 0.64 ms) fails loudly on accidental quadratic regressions.

### Benchmark script

```python
import gc, statistics, time
import numpy as np
from glum._glm import GeneralizedLinearRegressor
from glum._term_layout import TermLayout


def measure(fn, *, inner, repeats):
    times = []
    for _ in range(repeats):
        gc.collect(); gc.disable()
        try:
            t0 = time.perf_counter_ns()
            for _ in range(inner):
                fn()
            t1 = time.perf_counter_ns()
        finally:
            gc.enable()
        times.append((t1 - t0) / inner / 1e9)
    return times

# Warm up
for _ in range(1000):
    TermLayout.from_term_names(["x"], False)

# Build cost
small = [f"x{i}" for i in range(50)]
times = measure(lambda: TermLayout.from_term_names(small, True),
                inner=2000, repeats=200)
# ... see PR for full set of workloads ...

# Lookup cost
layout = TermLayout.from_term_names(small, True)
times = measure(lambda: layout["x42"], inner=20000, repeats=200)

# Reference .fit()
rng = np.random.default_rng(0)
X = rng.standard_normal((1000, 50)); y = rng.standard_normal(1000)
times = measure(lambda: GeneralizedLinearRegressor(family="normal", alpha=0.1).fit(X, y),
                inner=2, repeats=80)
```

## Compatibility

- Public API: additive only. New attribute `term_layout_` after fit; no existing attribute removed or changed.
- 284-test formula + base regression suite: unchanged, all green.
- Pickle: `TermLayout` is a stdlib dataclass, pickles cleanly. Older pickles that predate this PR will still load -- `term_layout_` is just absent.

## Follow-ups (not in this PR)

- Migrate `expand_categorical_penalties` to use `TermLayout`, closing the formula+categorical TODO at `_glm.py:2039`.
- Migrate Wald-test name lookup at `_glm.py:1349` onto `TermLayout`.
- Introduce `PenaltyTerm` / `Penalty` (per-term lambda vectors, block S matrices) on top of this registry -- the actual prerequisite for splines.
