### PR TITLE
Keep windows-2022 runners for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - { os: ubuntu-latest, environment: 'py311' }
           - { os: ubuntu-latest, environment: 'py312' }
           - { os: ubuntu-latest, environment: 'py313' }
-          - { os: windows-latest, environment: 'py313' }
+          - { os: windows-2022, environment: 'py313' }
           - { os: macos-latest, environment: 'py313' }
           - { os: ubuntu-latest, environment: 'oldies' }
           - { os: ubuntu-latest, environment: 'nightly' }

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,8 +25,8 @@ jobs:
           - { variant-file: osx_64_numpy2.0python3.10.____cpython,    target-platform: osx-64,    os: macos-15-intel, rattler-build-args: '' }
           - { variant-file: osx_arm64_numpy2.0python3.10.____cpython, target-platform: osx-arm64, os: macos-latest,   rattler-build-args: '' }
           - { variant-file: osx_arm64_numpy2python3.13.____cp313,     target-platform: osx-arm64, os: macos-latest,   rattler-build-args: '' }
-          - { variant-file: win_64_numpy2.0python3.10.____cpython,    target-platform: win-64,    os: windows-latest, rattler-build-args: '' }
-          - { variant-file: win_64_numpy2python3.13.____cp313,        target-platform: win-64,    os: windows-latest, rattler-build-args: '' }
+          - { variant-file: win_64_numpy2.0python3.10.____cpython,    target-platform: win-64,    os: windows-2022, rattler-build-args: '' }
+          - { variant-file: win_64_numpy2python3.13.____cp313,        target-platform: win-64,    os: windows-2022, rattler-build-args: '' }
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

The updated windows-latest runners have made changes to MSVC that are not yet supported by the cxx-compiler package. Let's keep the runners on windows 2022 for now. 

Checklist
* [ ] Added a `CHANGELOG.rst` entry
