### PR TITLE
Remove `iprint`

### DIFF
--- a/src/glum/_solvers.py
+++ b/src/glum/_solvers.py
@@ -899,7 +899,6 @@ def _lbfgs_solver(
         func,
         coef,
         fprime=None,
-        iprint=(verbose > 0) - 1,
         pgtol=tol,
         maxiter=max_iter,
         factr=1e2,


### PR DESCRIPTION
The `iprint` argument of `fmin_l_bfgs_b` has been deprecated and ineffectual since [SciPy 1.15](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.optimize.fmin_l_bfgs_b.html). With the advent of SciPy 1.17, it's finally been removed, causing CI to break.

Fixes #1010.