### PR TITLE
fix: Bypass deprecated feature_dtypes_ setter in fit()

### DIFF
--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -237,7 +237,6 @@ class GeneralizedLinearRegressorBase(skl.base.RegressorMixin, skl.base.BaseEstim
         raise AttributeError("No categorical levels stored.")
 
     @property
-    @deprecated("Use `categorical_levels_` instead.")
     def feature_dtypes_(self) -> dict[str, Any]:
         return self._feature_dtypes_
 

--- a/src/glum/_glm.py
+++ b/src/glum/_glm.py
@@ -2045,11 +2045,10 @@ class GeneralizedLinearRegressorBase(skl.base.RegressorMixin, skl.base.BaseEstim
                         "or pass a contiguous matrix."
                     )
 
-                # Backwards compatibility
+                # Backwards compatibility: write to private backing attr to avoid
+                # triggering the deprecated feature_dtypes_ setter.
                 if isinstance(X, pd.DataFrame):
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore")
-                        self.feature_dtypes_ = X.dtypes.to_dict()
+                    self._feature_dtypes_ = X.dtypes.to_dict()
 
                 X = cast(nw.DataFrame, nw.from_native(X))  # avoid inferring `Never`
 


### PR DESCRIPTION
Two changes:

- Instead of catching the warning, I'm assigning directly to `_feature_dtypes_` instead of going through the deprecated `feature_dtypes_` setter, eliminating the `DeprecationWarning` emitted on every `fit()` call when `X` is a DataFrame.
- I'm removing the deprecation warning from the `feature_dtypes_` getter, because that's also firing for things such as `dir(...)` and other introspection calls.


```python
import warnings
import pandas as pd
from glum import GeneralizedLinearRegressor
warnings.filterwarnings("error", message="Use `categorical_levels_` instead.")

X = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
y = [1.0, 2.0, 3.0]
model = GeneralizedLinearRegressor().fit(X, y)

dir(model)
```

```
/tmp via py v3.12.13 ❯ pixi exec --spec glum python reproducer.py
Traceback (most recent call last):
  File "/private/tmp/reproducer.py", line 10, in <module>
    dir(model)
    ~~~^^^^^^^
  File "/tmp/rattler/cache/cached-envs-v0/glum-12c16ede7e8029a1/lib/python3.14/site-packages/sklearn/base.py", line 214, in __dir__
    return [attr for attr in super().__dir__() if hasattr(self, attr)]
                                                  ~~~~~~~^^^^^^^^^^^^
  File "/tmp/rattler/cache/cached-envs-v0/glum-12c16ede7e8029a1/lib/python3.14/_py_warnings.py", line 799, in wrapper
    _wm.warn(msg, category=category, stacklevel=stacklevel + 1)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
DeprecationWarning: Use `categorical_levels_` instead.
```